### PR TITLE
Switch to Argon2 password hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bb8"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +149,15 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -362,6 +389,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -436,6 +464,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -601,13 +640,14 @@ dependencies = [
 name = "mxd"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "clap",
  "diesel",
  "diesel-async",
  "diesel_migrations",
+ "rand",
  "serde",
  "serde_json",
- "sha2",
  "thiserror",
  "tokio",
 ]
@@ -672,6 +712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +771,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -797,17 +887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +931,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1227,4 +1312,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
-argon2 = "0.5"
+argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
-sha2 = "0.10"
+argon2 = "0.5"
+rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Marrakesh Express Daemon
 mxd is a minimal implementation of a [Hotline](https://hotline.fandom.com/wiki/Virtual1%27s_Hotline_Server_Protocol_Guide) server written in Rust.
 It currently implements the bare essentials for accepting TCP connections and
 authenticating users stored in a SQLite database using Diesel with its async
-extension. Passwords are stored as SHA-256 hashes.
+extension. Passwords are stored using Argon2 with a random salt for security.
 Commands are read line by line using Tokio's `BufReader` and a simple `LOGIN`
 command is supported. Invalid `LOGIN` requests result in an `ERR` response.
 Each client session stays open so multiple commands can be processed until the

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ mxd is a minimal implementation of a [Hotline](https://hotline.fandom.com/wiki/V
 It currently implements the bare essentials for accepting TCP connections and
 authenticating users stored in a SQLite database using Diesel with its async
 extension. Passwords are stored using Argon2 with a random salt for security.
+Argon2 parameters can be tuned with the `--argon2-m-cost`, `--argon2-t-cost`,
+and `--argon2-p-cost` command line options.
 Commands are read line by line using Tokio's `BufReader` and a simple `LOGIN`
 command is supported. Invalid `LOGIN` requests result in an `ERR` response.
 Each client session stays open so multiple commands can be processed until the

--- a/src/users.rs
+++ b/src/users.rs
@@ -1,0 +1,30 @@
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
+
+pub(crate) fn hash_password(pw: &str) -> String {
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(pw.as_bytes(), &salt)
+        .expect("Failed to hash password")
+        .to_string()
+}
+
+pub(crate) fn verify_password(hash: &str, pw: &str) -> bool {
+    let parsed_hash = PasswordHash::new(hash).expect("Failed to parse hash");
+    Argon2::default()
+        .verify_password(pw.as_bytes(), &parsed_hash)
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hash_password, verify_password};
+
+    #[test]
+    fn test_hash_password() {
+        let hashed = hash_password("secret");
+        assert!(verify_password(&hashed, "secret"));
+    }
+}


### PR DESCRIPTION
## Summary
- use the Argon2 crate for password hashing
- add random salt and verification helper
- adjust login flow to check Argon2 hashes
- document the stronger password hashing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68408b7d7bd08322bf8a0da80d4635b2

## Summary by Sourcery

Switch password storage from SHA-256 to Argon2 with random salts, update authentication flow and tests accordingly, and revise dependencies and documentation.

New Features:
- Introduce Argon2-based password hashing with random salt generation
- Add a password verification helper function (`verify_password`)

Enhancements:
- Replace SHA-256 hashing with Argon2 in the login authentication flow

Build:
- Remove `sha2` crate and add `argon2` and `rand` dependencies in Cargo.toml

Documentation:
- Update README to document Argon2 password hashing usage

Tests:
- Adjust password hashing test to use `verify_password` for Argon2 hashes