### PR TITLE
Fix shutdown watcher

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -25,10 +25,7 @@ pub async fn run_migrations(conn: &mut DbConnection) -> QueryResult<()> {
         c.run_pending_migrations(MIGRATIONS)
             .map(|_| ())
             .map_err(|e| {
-                DieselError::QueryBuilderError(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    e.to_string(),
-                )))
+                DieselError::QueryBuilderError(Box::new(std::io::Error::other(e.to_string())))
             })
     })
     .await?;


### PR DESCRIPTION
## Summary
- use a boolean with watch channel so shutdown signal triggers `changed()`
- fix migration error mapping

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo clippy -- -D warnings` (validator)
- `cargo test` (validator)


------
https://chatgpt.com/codex/tasks/task_e_6841080642788322947774688fbc960f

## Summary by Sourcery

Use a boolean flag in the shutdown signal watcher for reliable change detection, ensure async writes are awaited, and simplify error mapping in DB migrations.

Bug Fixes:
- Switch shutdown watch channel from unit to bool and send `true` to trigger changes.
- Add missing `.await` when writing error responses to clients.
- Replace manual `std::io::Error::new` with `std::io::Error::other` for migration error mapping.