### PR TITLE
Introduce reusable test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,11 +679,10 @@ dependencies = [
  "diesel",
  "diesel-async",
  "diesel_migrations",
- "nix",
  "rand",
  "serde",
  "serde_json",
- "tempfile",
+ "test-util",
  "thiserror",
  "tokio",
 ]
@@ -1026,6 +1025,14 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test-util"
+version = "0.1.0"
+dependencies = [
+ "nix",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"
 
 [dev-dependencies]
-tempfile = "3"
-nix = { version = "0.27", features = ["signal"] }
+test-util = { path = "test-util" }

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-util"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tempfile = "3"
+nix = { version = "0.27", features = ["signal"] }

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -1,0 +1,115 @@
+use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+#[cfg(unix)]
+use nix::sys::signal::{Signal, kill};
+#[cfg(unix)]
+use nix::unistd::Pid;
+
+/// Helper struct to start the mxd server for integration tests.
+///
+/// The server process is terminated when this struct is dropped.
+pub struct TestServer {
+    child: Child,
+    port: u16,
+    db_path: PathBuf,
+    _temp: TempDir,
+}
+
+impl TestServer {
+    /// Start the server using the given Cargo manifest path.
+    pub fn start(manifest_path: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::start_with_setup(manifest_path, |_| Ok(()))
+    }
+
+    /// Start the server and run a setup function before launching.
+    pub fn start_with_setup<F>(
+        manifest_path: &str,
+        setup: F,
+    ) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        F: FnOnce(&Path) -> Result<(), Box<dyn std::error::Error>>,
+    {
+        let temp = TempDir::new()?;
+        let db_path = temp.path().join("mxd.db");
+
+        setup(&db_path)?;
+
+        let socket = TcpListener::bind("127.0.0.1:0")?;
+        let port = socket.local_addr()?.port();
+        drop(socket);
+
+        let mut child = Command::new("cargo")
+            .args([
+                "run",
+                "--manifest-path",
+                manifest_path,
+                "--quiet",
+                "--",
+                "--bind",
+                &format!("127.0.0.1:{}", port),
+                "--database",
+                db_path.to_str().expect("database path utf8"),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        if let Some(out) = &mut child.stdout {
+            let mut reader = BufReader::new(out);
+            let mut line = String::new();
+            let timeout = Duration::from_secs(10);
+            let start = Instant::now();
+            loop {
+                line.clear();
+                if reader.read_line(&mut line)? == 0 {
+                    return Err("server exited before signaling readiness".into());
+                }
+                if line.contains("listening on") {
+                    break;
+                }
+                if start.elapsed() > timeout {
+                    return Err("timeout waiting for server to signal readiness".into());
+                }
+            }
+        } else {
+            return Err("missing stdout from server".into());
+        }
+
+        Ok(Self {
+            child,
+            port,
+            db_path,
+            _temp: temp,
+        })
+    }
+
+    /// Return the port the server is bound to.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Path to the SQLite database used by this server.
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            let _ = kill(Pid::from_raw(self.child.id() as i32), Signal::SIGTERM);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}

--- a/tests/handshake.rs
+++ b/tests/handshake.rs
@@ -1,82 +1,13 @@
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
+use std::net::TcpStream;
 
-#[cfg(unix)]
-use nix::sys::signal::{Signal, kill};
-#[cfg(unix)]
-use nix::unistd::Pid;
-use tempfile::TempDir;
-
-/// Kill the child process when dropped to avoid orphans if the test panics.
-struct ChildGuard(Child);
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            let _ = kill(Pid::from_raw(self.0.id() as i32), Signal::SIGTERM);
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = self.0.kill();
-        }
-        let _ = self.0.wait();
-    }
-}
+use test_util::TestServer;
 
 #[test]
 fn handshake() -> Result<(), Box<dyn std::error::Error>> {
-    let temp = TempDir::new()?;
-    let db_path = temp.path().join("mxd.db");
+    let server = TestServer::start("./Cargo.toml")?;
+    let port = server.port();
 
-    // pick a free port for the server
-    let socket = TcpListener::bind("127.0.0.1:0")?;
-    let port = socket.local_addr()?.port();
-    drop(socket);
-
-    // start server
-    let child = Command::new("cargo")
-        .args([
-            "run",
-            "--manifest-path",
-            "./Cargo.toml",
-            "--quiet",
-            "--",
-            "--bind",
-            &format!("127.0.0.1:{}", port),
-            "--database",
-            db_path.to_str().expect("Database path is not valid UTF-8"),
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-    let mut child = ChildGuard(child);
-
-    // wait for server to start
-    if let Some(out) = &mut child.0.stdout {
-        let mut reader = BufReader::new(out);
-        let mut line = String::new();
-        let timeout = Duration::from_secs(10);
-        let start = Instant::now();
-        loop {
-            line.clear();
-            if reader.read_line(&mut line)? == 0 {
-                panic!("server exited before signaling readiness");
-            }
-            if line.contains("listening on") {
-                break;
-            }
-            if start.elapsed() > timeout {
-                panic!("timeout waiting for server to signal readiness");
-            }
-        }
-    } else {
-        panic!("missing stdout from server");
-    }
-
-    // connect to server directly
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
     let mut handshake = Vec::new();
     handshake.extend_from_slice(b"TRTP");
@@ -94,10 +25,5 @@ fn handshake() -> Result<(), Box<dyn std::error::Error>> {
     let mut line = String::new();
     reader.read_line(&mut line)?;
     assert_eq!(line.trim_end(), "MXD");
-
-    #[cfg(unix)]
-    kill(Pid::from_raw(child.0.id() as i32), Signal::SIGTERM)?;
-    #[cfg(not(unix))]
-    child.0.kill()?;
     Ok(())
 }

--- a/tests/handshake_invalid.rs
+++ b/tests/handshake_invalid.rs
@@ -1,76 +1,12 @@
-use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
+use std::io::{Read, Write};
+use std::net::TcpStream;
 
-#[cfg(unix)]
-use nix::sys::signal::{Signal, kill};
-#[cfg(unix)]
-use nix::unistd::Pid;
-use tempfile::TempDir;
-
-struct ChildGuard(Child);
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            let _ = kill(Pid::from_raw(self.0.id() as i32), Signal::SIGTERM);
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = self.0.kill();
-        }
-        let _ = self.0.wait();
-    }
-}
+use test_util::TestServer;
 
 #[test]
 fn handshake_invalid_protocol() -> Result<(), Box<dyn std::error::Error>> {
-    let temp = TempDir::new()?;
-    let db_path = temp.path().join("mxd.db");
-
-    let socket = TcpListener::bind("127.0.0.1:0")?;
-    let port = socket.local_addr()?.port();
-    drop(socket);
-
-    let child = Command::new("cargo")
-        .args([
-            "run",
-            "--manifest-path",
-            "./Cargo.toml",
-            "--quiet",
-            "--",
-            "--bind",
-            &format!("127.0.0.1:{}", port),
-            "--database",
-            db_path.to_str().expect("db path invalid"),
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-    let mut child = ChildGuard(child);
-
-    if let Some(out) = &mut child.0.stdout {
-        let mut reader = BufReader::new(out);
-        let mut line = String::new();
-        let timeout = Duration::from_secs(10);
-        let start = Instant::now();
-        loop {
-            line.clear();
-            if reader.read_line(&mut line)? == 0 {
-                panic!("server exited before signaling readiness");
-            }
-            if line.contains("listening on") {
-                break;
-            }
-            if start.elapsed() > timeout {
-                panic!("timeout waiting for server");
-            }
-        }
-    } else {
-        panic!("missing stdout from server");
-    }
+    let server = TestServer::start("./Cargo.toml")?;
+    let port = server.port();
 
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
     let mut handshake = Vec::new();
@@ -84,10 +20,5 @@ fn handshake_invalid_protocol() -> Result<(), Box<dyn std::error::Error>> {
     stream.read_exact(&mut reply)?;
     assert_eq!(&reply[0..4], b"TRTP");
     assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 1);
-
-    #[cfg(unix)]
-    kill(Pid::from_raw(child.0.id() as i32), Signal::SIGTERM)?;
-    #[cfg(not(unix))]
-    child.0.kill()?;
     Ok(())
 }

--- a/tests/handshake_unsupported_version.rs
+++ b/tests/handshake_unsupported_version.rs
@@ -1,76 +1,12 @@
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
+use std::net::TcpStream;
 
-#[cfg(unix)]
-use nix::sys::signal::{Signal, kill};
-#[cfg(unix)]
-use nix::unistd::Pid;
-use tempfile::TempDir;
-
-struct ChildGuard(Child);
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            let _ = kill(Pid::from_raw(self.0.id() as i32), Signal::SIGTERM);
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = self.0.kill();
-        }
-        let _ = self.0.wait();
-    }
-}
+use test_util::TestServer;
 
 #[test]
 fn handshake_unsupported_version() -> Result<(), Box<dyn std::error::Error>> {
-    let temp = TempDir::new()?;
-    let db_path = temp.path().join("mxd.db");
-
-    let socket = TcpListener::bind("127.0.0.1:0")?;
-    let port = socket.local_addr()?.port();
-    drop(socket);
-
-    let child = Command::new("cargo")
-        .args([
-            "run",
-            "--manifest-path",
-            "./Cargo.toml",
-            "--quiet",
-            "--",
-            "--bind",
-            &format!("127.0.0.1:{}", port),
-            "--database",
-            db_path.to_str().expect("db path invalid"),
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-    let mut child = ChildGuard(child);
-
-    if let Some(out) = &mut child.0.stdout {
-        let mut reader = BufReader::new(out);
-        let mut line = String::new();
-        let timeout = Duration::from_secs(10);
-        let start = Instant::now();
-        loop {
-            line.clear();
-            if reader.read_line(&mut line)? == 0 {
-                panic!("server exited before signaling readiness");
-            }
-            if line.contains("listening on") {
-                break;
-            }
-            if start.elapsed() > timeout {
-                panic!("timeout waiting for server");
-            }
-        }
-    } else {
-        panic!("missing stdout from server");
-    }
+    let server = TestServer::start("./Cargo.toml")?;
+    let port = server.port();
 
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
     let mut handshake = Vec::new();
@@ -89,10 +25,5 @@ fn handshake_unsupported_version() -> Result<(), Box<dyn std::error::Error>> {
     let mut line = String::new();
     let bytes = reader.read_line(&mut line)?;
     assert_eq!(bytes, 0, "unexpected server data: {}", line);
-
-    #[cfg(unix)]
-    kill(Pid::from_raw(child.0.id() as i32), Signal::SIGTERM)?;
-    #[cfg(not(unix))]
-    child.0.kill()?;
     Ok(())
 }

--- a/validator/Cargo.lock
+++ b/validator/Cargo.lock
@@ -252,12 +252,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-util"
+version = "0.1.0"
+dependencies = [
+ "nix 0.27.1",
+ "tempfile",
+]
+
+[[package]]
 name = "validator"
 version = "0.1.0"
 dependencies = [
  "expectrl",
  "nix 0.27.1",
  "tempfile",
+ "test-util",
  "which",
 ]
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -8,3 +8,6 @@ expectrl = "0.7"
 tempfile = "3"
 which = "4"
 nix = { version = "0.27", optional = false, features = ["signal"] }
+
+[dev-dependencies]
+test-util = { path = "../test-util" }

--- a/validator/tests/login.rs
+++ b/validator/tests/login.rs
@@ -1,31 +1,6 @@
 use expectrl::{spawn, Regex};
-use std::io::{BufRead, BufReader};
-use std::time::{Duration, Instant};
-use std::net::TcpListener;
-use std::process::{Child, Command, Stdio};
-#[cfg(unix)]
-use nix::sys::signal::{kill, Signal};
-#[cfg(unix)]
-use nix::unistd::Pid;
-use tempfile::TempDir;
+use test_util::TestServer;
 use which::which;
-
-/// Kill the child process when dropped to avoid orphans if the test panics.
-struct ChildGuard(Child);
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            let _ = kill(Pid::from_raw(self.0.id() as i32), Signal::SIGTERM);
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = self.0.kill();
-        }
-        let _ = self.0.wait();
-    }
-}
 
 #[test]
 fn login_validation() -> Result<(), Box<dyn std::error::Error>> {
@@ -33,86 +8,35 @@ fn login_validation() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("shx not installed; skipping test");
         return Ok(());
     }
-    let temp = TempDir::new()?;
-    let db_path = temp.path().join("mxd.db");
 
-    // create user
-    let status = Command::new("cargo")
-        .args([
-            "run",
-            "--manifest-path",
-            "../Cargo.toml",
-            "--quiet",
-            "--",
-            "--database",
-            db_path
-                .to_str()
-                .expect("Database path is not valid UTF-8"),
-            "create-user",
-            "test",
-            "secret",
-        ])
-        .status()?;
-    assert!(status.success());
-
-    // pick a free port for the server
-    let socket = TcpListener::bind("127.0.0.1:0")?;
-    let port = socket.local_addr()?.port();
-    drop(socket);
-
-    // start server
-    let child = Command::new("cargo")
-        .args([
-            "run",
-            "--manifest-path",
-            "../Cargo.toml",
-            "--quiet",
-            "--",
-            "--bind",
-            &format!("127.0.0.1:{}", port),
-            "--database",
-            db_path
-                .to_str()
-                .expect("Database path is not valid UTF-8"),
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-    let mut child = ChildGuard(child);
-
-    // wait for server to start by reading stdout with a timeout
-    if let Some(out) = &mut child.0.stdout {
-        let mut reader = BufReader::new(out);
-        let mut line = String::new();
-        let timeout = Duration::from_secs(10);
-        let start = Instant::now();
-        loop {
-            line.clear();
-            if reader.read_line(&mut line)? == 0 {
-                panic!("server exited before signaling readiness");
-            }
-            if line.contains("listening on") {
-                break;
-            }
-            if start.elapsed() > timeout {
-                panic!("timeout waiting for server to signal readiness");
-            }
+    let server = TestServer::start_with_setup("../Cargo.toml", |db| {
+        let status = std::process::Command::new("cargo")
+            .args([
+                "run",
+                "--manifest-path",
+                "../Cargo.toml",
+                "--quiet",
+                "--",
+                "--database",
+                db.to_str().expect("db path utf8"),
+                "create-user",
+                "test",
+                "secret",
+            ])
+            .status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err("failed to create user".into())
         }
-    } else {
-        panic!("missing stdout from server");
-    }
+    })?;
 
-    // spawn shx client using expect
+    let port = server.port();
     let mut p = spawn(&format!("shx 127.0.0.1 {}", port))?;
     p.expect(Regex("MXD"))?;
     p.send_line("LOGIN test secret")?;
     p.expect(Regex("OK"))?;
     p.send_line("/quit")?;
     p.expect(Regex("OK"))?;
-
-    #[cfg(unix)]
-    kill(Pid::from_raw(child.0.id() as i32), Signal::SIGTERM)?;
-    #[cfg(not(unix))]
-    child.0.kill()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `test-util` crate containing `TestServer` helper
- use `TestServer` in integration tests and login validator
- update `Cargo.toml` files to depend on new crate

## Testing
- `cargo clippy --all-targets --all-features -q`
- `cargo test --quiet`
- `cd validator && cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841803055bc8322aaa9b008cbce2390

## Summary by Sourcery

Introduce a reusable test harness crate and refactor existing integration tests to use TestServer for streamlined server setup and teardown

New Features:
- Introduce test-util crate offering TestServer API (start and start_with_setup) for integration tests

Enhancements:
- Refactor login and handshake tests to leverage TestServer for process management, removing manual port binding, child process guards, and database setup

Build:
- Add test-util as a dev-dependency in root and validator Cargo.toml files

Tests:
- Simplify test code across multiple test modules by consolidating server startup and teardown logic