### PR TITLE
Refactor request handling into pure function

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,0 +1,39 @@
+use std::net::SocketAddr;
+
+use crate::commands::Command;
+use crate::db::DbPool;
+use crate::transaction::{Transaction, parse_transaction};
+
+/// Per-connection context used by `handle_request`.
+pub struct Context {
+    pub peer: SocketAddr,
+    pub pool: DbPool,
+    pub responses: Vec<Transaction>,
+}
+
+impl Context {
+    pub fn new(peer: SocketAddr, pool: DbPool) -> Self {
+        Self {
+            peer,
+            pool,
+            responses: Vec::new(),
+        }
+    }
+
+    /// Drain all queued responses.
+    pub fn take_responses(&mut self) -> Vec<Transaction> {
+        std::mem::take(&mut self.responses)
+    }
+}
+
+/// Parse and handle a single request frame without performing network I/O.
+pub async fn handle_request(
+    ctx: &mut Context,
+    frame: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tx = parse_transaction(frame)?;
+    let cmd = Command::from_transaction(tx)?;
+    let reply = cmd.process(ctx.peer, ctx.pool.clone()).await?;
+    ctx.responses.push(reply);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- factor command processing into a new `handler` module
- keep replies in memory and send them after calling `handle_request`
- expose utilities to convert transactions to/from bytes
- update main event loop to use the new handler

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test` in `validator` crate

------
https://chatgpt.com/codex/tasks/task_e_684224b44f0083229d0db9490233d9d8