### PR TITLE
Expose mxd as library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "mxd"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 diesel = { version = "2", features = ["sqlite", "chrono"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod commands;
+pub mod db;
+pub mod field_id;
+pub mod handler;
+pub mod models;
+pub mod protocol;
+pub mod schema;
+pub mod transaction;
+pub mod transaction_type;
+pub mod users;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,21 +11,11 @@ use tokio::time::timeout;
 
 use argon2::{Algorithm, Argon2, Params, ParamsBuilder, Version};
 
-mod commands;
-mod db;
-mod field_id;
-mod handler;
-mod models;
-mod protocol;
-mod schema;
-mod transaction;
-mod transaction_type;
-mod users;
-use crate::transaction::{TransactionReader, TransactionWriter};
-use handler::{Context, handle_request};
-
-use db::{DbPool, create_user, establish_pool, run_migrations};
-use users::hash_password;
+use mxd::db::{DbPool, create_user, establish_pool, run_migrations};
+use mxd::handler::{Context, handle_request};
+use mxd::transaction::{TransactionReader, TransactionWriter};
+use mxd::users::hash_password;
+use mxd::{models, protocol};
 
 async fn shutdown_signal() {
     #[cfg(unix)]

--- a/src/users.rs
+++ b/src/users.rs
@@ -4,7 +4,7 @@ use argon2::{
     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
 
-pub(crate) fn hash_password(argon2: &Argon2, pw: &str) -> Result<String, Error> {
+pub fn hash_password(argon2: &Argon2, pw: &str) -> Result<String, Error> {
     let salt = SaltString::generate(&mut OsRng);
     Ok(argon2.hash_password(pw.as_bytes(), &salt)?.to_string())
 }

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -1,11 +1,7 @@
-#[path = "../src/field_id.rs"]
-mod field_id;
-#[path = "../src/transaction.rs"]
-mod transaction;
-#[path = "../src/transaction_type.rs"]
-mod transaction_type;
+use mxd::field_id;
+use mxd::transaction::*;
+use mxd::transaction_type;
 use tokio::io::{AsyncWriteExt, duplex};
-use transaction::*;
 
 fn build_tx() -> Transaction {
     let mut payload = Vec::new();
@@ -168,11 +164,6 @@ async fn roundtrip_empty_payload() {
         data_size: 0,
     };
 
-#[test]
-fn short_header_error() {
-    let err = FrameHeader::new(&[0u8; 10]).unwrap_err();
-    assert!(matches!(err, TransactionError::ShortBuffer));
-}
     let tx = Transaction {
         header,
         payload: Vec::new(),
@@ -201,6 +192,12 @@ async fn oversized_payload() {
         TransactionError::PayloadTooLarge => {}
         e => panic!("unexpected {e:?}"),
     }
+}
+
+#[test]
+fn short_header_error() {
+    let err = FrameHeader::new(&[0u8; 10]).unwrap_err();
+    assert!(matches!(err, TransactionError::ShortBuffer));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add library crate section so other crates can link to mxd
- expose modules via `src/lib.rs`
- update main binary to use the library
- fix compile issues in transaction parser
- make password hashing public
- clean up transaction tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cd validator && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68422cf8da1083229c525e6722f0deed

## Summary by Sourcery

Expose mxd as a library crate by adding a lib.rs and adjusting Cargo.toml, update the main application and tests to use the new library API, fix compile errors in the transaction parser, and make password hashing public.

New Features:
- Add a library crate for mxd to allow external crates to link against it

Bug Fixes:
- Fix transaction parser compilation by correcting FrameHeader parsing, adding write_timeout_all, and propagating errors in decode_params

Enhancements:
- Update main binary to use the mxd library imports instead of local modules
- Make the password hashing function public for external use

Build:
- Add [lib] section to Cargo.toml and create src/lib.rs to expose modules

Tests:
- Refactor transaction tests to import from the mxd library and clean up redundant code