### PR TITLE
Add AFL fuzzing harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,23 @@ The `validator` crate provides a compatibility check using the `shx` client and 
 cd validator
 cargo test
 ```
+
+## Fuzzing
+
+A simple AFL++ harness lives in the `fuzz/` directory. To build it you need the AFL clang wrappers and sanitizers enabled:
+
+```bash
+# install afl++ and make sure afl-clang-fast is on your PATH
+export CC=afl-clang-fast
+export CXX=afl-clang-fast++
+export RUSTFLAGS="-Zsanitizer=address"
+
+# compile the instrumented binary
+cargo afl build -p fuzz
+
+# run the fuzzer
+cargo afl fuzz -i corpus -o findings target/debug/fuzz
+```
+
+The harness uses `__AFL_LOOP` to process test cases in persistent mode.
+

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fuzz"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+afl = "0.15"
+mxd = { path = ".." }

--- a/fuzz/src/main.rs
+++ b/fuzz/src/main.rs
@@ -1,0 +1,12 @@
+extern "C" { fn __AFL_LOOP(cnt: u32) -> i32; }
+use std::io::{self, Read};
+
+fn main() {
+    let mut data = Vec::new();
+    loop {
+        if unsafe { __AFL_LOOP(1000) } == 0 { break; }
+        data.clear();
+        if io::stdin().read_to_end(&mut data).is_err() { return; }
+        let _ = mxd::transaction::parse_transaction(&data);
+    }
+}


### PR DESCRIPTION
## Summary
- add `fuzz` crate using the afl crate and `__AFL_LOOP`
- document build steps for fuzzing in README

## Testing
- `cargo test`
- `cargo test` in `validator` crate

------
https://chatgpt.com/codex/tasks/task_e_6842345103808322b72bc63912eab063