### PR TITLE
Fix diesel_cte_ext build

### DIFF
--- a/diesel_cte_ext/Cargo.toml
+++ b/diesel_cte_ext/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 diesel = { version = "2", default-features = false }
 
 [features]
-default = []
+default = ["sqlite", "postgres"]
 sqlite = ["diesel/sqlite"]
 postgres = ["diesel/postgres"]
 

--- a/diesel_cte_ext/src/builders.rs
+++ b/diesel_cte_ext/src/builders.rs
@@ -2,10 +2,6 @@ use crate::cte::{RecursiveBackend, WithRecursive};
 use diesel::query_builder::QueryFragment;
 
 /// Build a recursive CTE query.
-    Seed: QueryFragment<DB>,
-    Step: QueryFragment<DB>,
-    Body: QueryFragment<DB>,
-use diesel::query_builder::QueryFragment;
 
 pub fn with_recursive<DB, Seed, Step, Body>(
     cte_name: &'static str,


### PR DESCRIPTION
## Summary
- clean up `with_recursive` builder function
- enable `sqlite` and `postgres` features by default for `diesel_cte_ext`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test` in `validator`
- `cargo test` in `diesel_cte_ext`


------
https://chatgpt.com/codex/tasks/task_e_68425080597c8322855e21a4c25c87f7

## Summary by Sourcery

Simplify the recursive CTE builder and enable Diesel sqlite/postgres by default

Enhancements:
- Clean up the `with_recursive` builder function by removing redundant type parameters and duplicate imports
- Set the default Cargo.toml features to include `sqlite` and `postgres` for `diesel_cte_ext`