### PR TITLE
Fix chat schema diagram parse error

### DIFF
--- a/docs/chat-schema.md
+++ b/docs/chat-schema.md
@@ -21,10 +21,9 @@ erDiagram
     }
 
     chat_participants {
-        INTEGER chat_room_id FK
-        INTEGER user_id FK
+        INTEGER chat_room_id PK FK
+        INTEGER user_id      PK FK
         DATETIME joined_at
-        PRIMARY KEY (chat_room_id, user_id)
     }
 
     chat_messages {


### PR DESCRIPTION
## Summary
- update the `chat_participants` section in the mermaid diagram
  to mark each composite key column individually

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test` in `validator` crate

------
https://chatgpt.com/codex/tasks/task_e_684321d0f57c83229070e1879f53413b

## Summary by Sourcery

Bug Fixes:
- Annotate chat_room_id and user_id as individual primary keys in the chat_participants section of the ER diagram