### PR TITLE
Add mermaid diagram validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This repository is written in Rust and uses Cargo for building and dependency ma
 8. **Keep functions small and focused**; if a function grows too large, consider splitting it into helpers.
 9. **Commit messages should be descriptive**, explaining what was changed and why.
 10. **Check for `TODO` comments** and convert them into issues if more work is required.
+11. **Validate Markdown Mermaid diagrams** with `./scripts/validate_mermaid.py` before submitting documentation changes.
 
 These practices will help maintain a high-quality codebase and make collaboration easier.
 

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -20,6 +20,9 @@ From the repository root run:
 ```
 
 If no file arguments are given the script scans all `*.md` files under `docs/`.
-It extracts each ```mermaid` block and attempts to render it using `mmdc`. Any syntax errors will cause the script to exit with a non-zero status and print which diagram failed.
+It extracts each ```mermaid` block and attempts to render it using `mmdc`.
+Any syntax errors will cause the script to exit with a non-zero status and print which diagram failed along with the CLI error output.
+
+If `npx` or `mmdc` cannot be found the validator will print a message prompting you to install Node.js and `@mermaid-js/mermaid-cli`.
 
 Include this step in your workflow whenever you edit Markdown documentation containing Mermaid diagrams.

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -1,0 +1,25 @@
+# Mermaid Diagram Validation
+
+Mermaid diagrams are rendered client-side, so a small syntax error can leave a broken image in the documentation. To prevent this, every Markdown document that includes a `mermaid` code block must be checked before merging.
+
+## Requirements
+
+- **Node.js** must be available in your PATH.
+- The Mermaid CLI package:
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+## Running the validator
+
+From the repository root run:
+
+```bash
+./scripts/validate_mermaid.py path/to/file.md
+```
+
+If no file arguments are given the script scans all `*.md` files under `docs/`.
+It extracts each ```mermaid` block and attempts to render it using `mmdc`. Any syntax errors will cause the script to exit with a non-zero status and print which diagram failed.
+
+Include this step in your workflow whenever you edit Markdown documentation containing Mermaid diagrams.

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -4,8 +4,8 @@ Mermaid diagrams are rendered client-side, so a small syntax error can leave a b
 
 ## Requirements
 
-- **Node.js** must be available in your PATH.
-- The Mermaid CLI package:
+- **Node.js** must be available in your `PATH`.
+- The validator uses `npx` to run the [`@mermaid-js/mermaid-cli`](https://github.com/mermaid-js/mermaid-cli) package. Installing it globally speeds things up:
 
 ```bash
 npm install -g @mermaid-js/mermaid-cli
@@ -23,6 +23,6 @@ If no file arguments are given the script scans all `*.md` files under `docs/`.
 It extracts each ```mermaid` block and attempts to render it using `mmdc`.
 Any syntax errors will cause the script to exit with a non-zero status and print which diagram failed along with the CLI error output.
 
-If `npx` or `mmdc` cannot be found the validator will print a message prompting you to install Node.js and `@mermaid-js/mermaid-cli`.
+If the required tools are missing the validator explains that Node.js and `@mermaid-js/mermaid-cli` must be installed.
 
 Include this step in your workflow whenever you edit Markdown documentation containing Mermaid diagrams.

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -8,7 +8,7 @@ import os
 import json
 from typing import List
 
-RE = re.compile(r"```mermaid\n(.*?)\n```", re.DOTALL)
+RE = re.compile(r"```mermaid\s*\n(.*?)```", re.DOTALL)
 
 
 def parse_blocks(text: str) -> List[str]:

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -8,26 +8,27 @@ import os
 import json
 from typing import List
 
-RE = re.compile(r"```mermaid\s*\n(.*?)```", re.DOTALL)
+def render_block(block: str, tmpdir: Path, cfg_path: Path, path: Path, idx: int) -> bool:
+    mmd = tmpdir / f"{path.stem}_{idx}.mmd"
+    svg = mmd.with_suffix(".svg")
+
+    mmd.write_text(block)
+                str(mmd),
+                str(svg),
 
 
-def parse_blocks(text: str) -> List[str]:
-    """Return all mermaid code blocks found in the text."""
-    return RE.findall(text)
 
-
-def create_puppeteer_config() -> Path:
-    """Write a minimal Puppeteer config disabling sandboxing."""
-    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
-        json.dump({"args": ["--no-sandbox"]}, fh)
-        fh.flush()
-        return Path(fh.name)
-
-
-def render_block(block: str, cfg_path: Path, path: Path, idx: int) -> bool:
-    """Render a single mermaid block using the CLI."""
-    with tempfile.NamedTemporaryFile("w", suffix=".mmd", delete=False) as fh:
-        fh.write(block)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        for idx, block in enumerate(blocks, 1):
+            if not render_block(block, tmp_path, cfg_path, path, idx):
+                ok = False
+    args = sys.argv[1:]
+    doc_paths = (
+        [Path(p) for p in args]
+        if args
+        else list(Path("docs").glob("*.md"))
+    )
         fh.flush()
         temp = Path(fh.name)
 

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import re
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+import os
+
+RE = re.compile(r"```mermaid\n(.*?)\n```", re.DOTALL)
+
+
+def check_file(path: Path) -> bool:
+    text = path.read_text()
+    blocks = RE.findall(text)
+    if not blocks:
+        return True
+    ok = True
+    for idx, block in enumerate(blocks, 1):
+        with tempfile.NamedTemporaryFile("w", suffix=".mmd", delete=False) as fh:
+            fh.write(block)
+            temp = fh.name
+        try:
+            subprocess.run(
+                ["npx", "-y", "mmdc", "-i", temp, "-o", temp + ".svg"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            print(f"{path}: diagram {idx} failed to render", file=sys.stderr)
+            ok = False
+        finally:
+            for ext in ("", ".svg"):
+                try:
+                    os.remove(temp + ext)
+                except OSError:
+                    pass
+    return ok
+
+
+def main(paths):
+    ok = True
+    for p in paths:
+        if not check_file(p):
+            ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    doc_paths = [Path(p) for p in sys.argv[1:]] or list(Path("docs").glob("*.md"))
+    sys.exit(main(doc_paths))

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -58,8 +58,8 @@ def render_block(block: str, cfg_path: Path, path: Path, idx: int) -> bool:
     success = proc.returncode == 0
     if not success:
         print(f"{path}: diagram {idx} failed to render", file=sys.stderr)
-        if proc.stderr:
-            print(proc.stderr, file=sys.stderr)
+        # Surface the CLI error output to help diagnose syntax problems
+        print(proc.stderr, file=sys.stderr)
 
     for ext in ("", ".svg"):
         try:

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import tempfile
 import os
 import json
+import shutil
 from typing import List
 
 def render_block(block: str, tmpdir: Path, cfg_path: Path, path: Path, idx: int) -> bool:
@@ -13,23 +14,24 @@ def render_block(block: str, tmpdir: Path, cfg_path: Path, path: Path, idx: int)
     svg = mmd.with_suffix(".svg")
 
     mmd.write_text(block)
-                str(mmd),
-                str(svg),
+    cmd = [
+        "mmdc"
+        if shutil.which("mmdc")
+        else "npx",
+    ]
+    if cmd[0] == "npx":
+        cmd += ["--yes", "@mermaid-js/mermaid-cli", "mmdc"]
+    cmd += [
+        "-p",
+        str(cfg_path),
+        "-i",
+        str(mmd),
+        "-o",
+        str(svg),
+    ]
 
-
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
-        for idx, block in enumerate(blocks, 1):
-            if not render_block(block, tmp_path, cfg_path, path, idx):
-                ok = False
-    args = sys.argv[1:]
-    doc_paths = (
-        [Path(p) for p in args]
-        if args
-        else list(Path("docs").glob("*.md"))
-    )
-        fh.flush()
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+            "Error: Node.js with 'npx' is required to validate Mermaid diagrams.",
         temp = Path(fh.name)
 
     try:

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -14,12 +14,9 @@ def render_block(block: str, tmpdir: Path, cfg_path: Path, path: Path, idx: int)
     svg = mmd.with_suffix(".svg")
 
     mmd.write_text(block)
-    cmd = [
-        "mmdc"
-        if shutil.which("mmdc")
-        else "npx",
-    ]
-    if cmd[0] == "npx":
+    cli = "mmdc" if shutil.which("mmdc") else "npx"
+    cmd = [cli]
+    if cli == "npx":
         cmd += ["--yes", "@mermaid-js/mermaid-cli", "mmdc"]
     cmd += [
         "-p",
@@ -31,7 +28,7 @@ def render_block(block: str, tmpdir: Path, cfg_path: Path, path: Path, idx: int)
     ]
 
         proc = subprocess.run(cmd, capture_output=True, text=True)
-            "Error: Node.js with 'npx' is required to validate Mermaid diagrams.",
+            f"Error: '{cli}' not found. Node.js with npx and @mermaid-js/mermaid-cli is required.",
         temp = Path(fh.name)
 
     try:


### PR DESCRIPTION
## Summary
- script that validates mermaidjs diagrams using mermaid-cli
- document how to run the validator
- update AGENTS guidelines to require diagram validation

## Testing
- `cargo clippy`
- `cargo test`
- `cargo test` in validator crate
- `python3 scripts/validate_mermaid.py docs/chat-schema.md` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'npx')*

------
https://chatgpt.com/codex/tasks/task_e_684322d068bc8322a9ab5b4fe532cf80

## Summary by Sourcery

Implement Mermaid diagram validation for documentation by adding a CLI validator script, usage docs, and updating contribution guidelines.

New Features:
- Add `scripts/validate_mermaid.py` to extract and render Mermaid code blocks using `mmdc` or `npx` for syntax checking.
- Introduce `docs/mermaid-validation.md` with installation requirements and instructions for running the Mermaid validator.

Enhancements:
- Require Mermaid diagram validation in AGENTS guidelines before submitting documentation changes.