### PR TITLE
Streamline mermaid validator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This repository is written in Rust and uses Cargo for building and dependency ma
 8. **Keep functions small and focused**; if a function grows too large, consider splitting it into helpers.
 9. **Commit messages should be descriptive**, explaining what was changed and why.
 10. **Check for `TODO` comments** and convert them into issues if more work is required.
+11. **Validate Markdown Mermaid diagrams** with `./scripts/validate_mermaid.py` before submitting documentation changes.
 
 These practices will help maintain a high-quality codebase and make collaboration easier.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repository is written in Rust and uses Cargo for building and dependency ma
 8. **Keep functions small and focused**; if a function grows too large, consider splitting it into helpers.
 9. **Commit messages should be descriptive**, explaining what was changed and why.
 10. **Check for `TODO` comments** and convert them into issues if more work is required.
-11. **Validate Markdown Mermaid diagrams** with `./scripts/validate_mermaid.py` before submitting documentation changes.
+11. **Validate Markdown Mermaid diagrams** with `./scripts/validate_mermaid.py <paths>` before submitting documentation changes.
 
 These practices will help maintain a high-quality codebase and make collaboration easier.
 

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -21,7 +21,9 @@ From the repository root run:
 
 If no file arguments are given the script scans all `*.md` files under `docs/`.
 It extracts each ```mermaid` block and attempts to render it using `mmdc`.
-Any syntax errors will cause the script to exit with a non-zero status and print which diagram failed along with the CLI error output.
+Any syntax errors will cause the script to exit with a non-zero status. The
+failing diagram's line and a pointer to the error location are printed to help
+you fix the issue.
 
 If the required tools are missing the validator explains that Node.js and `@mermaid-js/mermaid-cli` must be installed.
 

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -13,14 +13,20 @@ npm install -g @mermaid-js/mermaid-cli
 
 ## Running the validator
 
-From the repository root run:
+From the repository root run the script with one or more Markdown paths:
 
 ```bash
-./scripts/validate_mermaid.py path/to/file.md
+./scripts/validate_mermaid.py docs/chat-schema.md docs/news-schema.md
 ```
 
-If no file arguments are given the script scans all `*.md` files under `docs/`.
-It extracts each ```mermaid` block and attempts to render it using `mmdc`.
+Shell expansion lets you validate everything in `docs/` at once:
+
+```bash
+./scripts/validate_mermaid.py docs/*.md
+```
+
+The script extracts each ```mermaid` block and attempts to render it using
+`mmdc`.
 Any syntax errors will cause the script to exit with a non-zero status. The
 failing diagram's line and a pointer to the error location are printed to help
 you fix the issue.

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -1,0 +1,28 @@
+# Mermaid Diagram Validation
+
+Mermaid diagrams are rendered client-side, so a small syntax error can leave a broken image in the documentation. To prevent this, every Markdown document that includes a `mermaid` code block must be checked before merging.
+
+## Requirements
+
+- **Node.js** must be available in your `PATH`.
+- The validator uses `npx` to run the [`@mermaid-js/mermaid-cli`](https://github.com/mermaid-js/mermaid-cli) package. Installing it globally speeds things up:
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+## Running the validator
+
+From the repository root run:
+
+```bash
+./scripts/validate_mermaid.py path/to/file.md
+```
+
+If no file arguments are given the script scans all `*.md` files under `docs/`.
+It extracts each ```mermaid` block and attempts to render it using `mmdc`.
+Any syntax errors will cause the script to exit with a non-zero status and print which diagram failed along with the CLI error output.
+
+If the required tools are missing the validator explains that Node.js and `@mermaid-js/mermaid-cli` must be installed.
+
+Include this step in your workflow whenever you edit Markdown documentation containing Mermaid diagrams.

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
+import argparse
+import json
+import os
+from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
-from pathlib import Path
 import tempfile
-import os
-import json
-import shutil
 from typing import List, Optional
 
 RE = re.compile(
@@ -114,10 +115,14 @@ def main(paths):
 
 
 if __name__ == "__main__":
-    args = sys.argv[1:]
-    doc_paths = (
-        [Path(p) for p in args]
-        if args
-        else list(Path("docs").glob("*.md"))
+    parser = argparse.ArgumentParser(
+        description="Validate Mermaid diagrams in Markdown files"
     )
-    sys.exit(main(doc_paths))
+    parser.add_argument(
+        "paths",
+        type=Path,
+        nargs="+",
+        help="Markdown files to validate",
+    )
+    parsed = parser.parse_args()
+    sys.exit(main(parsed.paths))

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import re
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+import os
+import json
+import shutil
+from typing import List
+
+RE = re.compile(r"```mermaid\n(.*?)\n```", re.DOTALL)
+
+
+def parse_blocks(text: str) -> List[str]:
+    """Return all mermaid code blocks found in the text."""
+    return RE.findall(text)
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def create_puppeteer_config() -> Path:
+    """Yield a Puppeteer config path and remove it on exit."""
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump({"args": ["--no-sandbox"]}, fh)
+        name = fh.name
+    path = Path(name)
+    try:
+        yield path
+    finally:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def get_mmdc_cmd(mmd: Path, svg: Path, cfg_path: Path) -> List[str]:
+    """Return the command to run mermaid-cli."""
+    cli = "mmdc" if shutil.which("mmdc") else "npx"
+    cmd = [cli]
+    if cli == "npx":
+        cmd += ["--yes", "@mermaid-js/mermaid-cli", "mmdc"]
+    cmd += ["-p", str(cfg_path), "-i", str(mmd), "-o", str(svg)]
+    return cmd
+
+
+def render_block(block: str, tmpdir: Path, cfg_path: Path, path: Path, idx: int) -> bool:
+    """Render a single mermaid block using the CLI."""
+    mmd = tmpdir / f"{path.stem}_{idx}.mmd"
+    svg = mmd.with_suffix(".svg")
+
+    mmd.write_text(block)
+
+    cmd = get_mmdc_cmd(mmd, svg, cfg_path)
+    cli = cmd[0]
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError:
+        print(
+            f"Error: '{cli}' not found. Node.js with npx and @mermaid-js/mermaid-cli is required.",
+            file=sys.stderr,
+        )
+        return False
+
+    success = proc.returncode == 0
+    if not success:
+        print(f"{path}: diagram {idx} failed to render", file=sys.stderr)
+        # Surface the CLI error output to help diagnose syntax problems
+        print(proc.stderr, file=sys.stderr)
+
+    return success
+
+
+def check_file(path: Path) -> bool:
+    blocks = parse_blocks(path.read_text())
+    if not blocks:
+        return True
+
+    ok = True
+    with create_puppeteer_config() as cfg_path:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            for idx, block in enumerate(blocks, 1):
+                if not render_block(block, tmp_path, cfg_path, path, idx):
+                    ok = False
+    return ok
+
+
+def main(paths):
+    ok = True
+    for p in paths:
+        if not check_file(p):
+            ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    doc_paths = (
+        [Path(p) for p in args]
+        if args
+        else list(Path("docs").glob("*.md"))
+    )
+    sys.exit(main(doc_paths))

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -9,7 +9,10 @@ import json
 import shutil
 from typing import List, Optional
 
-RE = re.compile(r"```mermaid\n(.*?)\n```", re.DOTALL)
+RE = re.compile(
+    r"^```\s*mermaid\s*\n(.*?)\n```[ \t]*$",
+    re.DOTALL | re.MULTILINE,
+)
 
 
 def parse_blocks(text: str) -> List[str]:
@@ -88,7 +91,7 @@ def render_block(block: str, tmpdir: Path, cfg_path: Path, path: Path, idx: int)
 
 
 def check_file(path: Path) -> bool:
-    blocks = parse_blocks(path.read_text())
+    blocks = parse_blocks(path.read_text(encoding="utf-8"))
     if not blocks:
         return True
 


### PR DESCRIPTION
## Summary
- simplify temp file cleanup using `TemporaryDirectory`
- clean up argument parsing for clarity
- fix Mermaid CLI invocation using `npx --yes` fallback
- document that validator auto-installs CLI via `npx`
- improve CLI fallback message
- extract `get_mmdc_cmd` helper and use a finally block for config cleanup
- make puppeteer config helper a context manager

## Testing
- `cargo fmt --all`
- `cargo clippy --all --quiet`
- `cargo test --quiet`
- `cargo test --manifest-path validator/Cargo.toml --quiet`
- `python3 scripts/validate_mermaid.py docs/chat-schema.md` *(fails: mermaid syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_684322d068bc8322a9ab5b4fe532cf80

## Summary by Sourcery

Add automated Mermaid diagram validation for Markdown files, including a new Python script and documentation updates.

New Features:
- Introduce `scripts/validate_mermaid.py` to extract and render Mermaid code blocks from Markdown using the Mermaid CLI.
- Add `docs/mermaid-validation.md` and update AGENTS.md to document and enforce the new validation step.

Enhancements:
- Streamline temporary file and directory management with context managers and extract a `get_mmdc_cmd` helper.
- Improve CLI invocation by falling back to `npx --yes` when `mmdc` is unavailable and enhance error messaging.