### PR TITLE
Fix mermaid syntax in chat schema

### DIFF
--- a/docs/chat-schema.md
+++ b/docs/chat-schema.md
@@ -21,8 +21,8 @@ erDiagram
     }
 
     chat_participants {
-        INTEGER chat_room_id PK FK
-        INTEGER user_id      PK FK
+        INTEGER chat_room_id PK "FK"
+        INTEGER user_id      PK "FK"
         DATETIME joined_at
     }
 


### PR DESCRIPTION
## Summary
- fix `chat_participants` table in `docs/chat-schema.md` so Mermaid renders correctly

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo test --manifest-path validator/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6843a04a966c8322a528581162539b4e

## Summary by Sourcery

Documentation:
- Enclose foreign key markers in quotes for the chat_participants table in docs/chat-schema.md to ensure correct rendering