### PR TITLE
Improve Mermaid validator with asyncio

### DIFF
--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -25,6 +25,14 @@ Shell expansion lets you validate everything in `docs/` at once:
 ./scripts/validate_mermaid.py docs/*.md
 ```
 
+For machines with many cores, increasing the concurrency can speed up
+validation. Use the `--concurrency` flag to set the number of diagrams
+rendered in parallel:
+
+```bash
+./scripts/validate_mermaid.py --concurrency 8 docs/*.md
+```
+
 The script extracts each ```mermaid` block and attempts to render it using
 `mmdc`.
 Any syntax errors will cause the script to exit with a non-zero status. The

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -19,14 +19,16 @@ From the repository root run the script with one or more Markdown paths:
 ./scripts/validate_mermaid.py docs/chat-schema.md docs/news-schema.md
 ```
 
-Shell expansion lets you validate everything in `docs/` at once:
+You can pass directories and the validator will search for Markdown files
+recursively. Shell expansion lets you validate everything in `docs/` at once:
 
 ```bash
 ./scripts/validate_mermaid.py docs/*.md
 ```
 
 For machines with many cores, increasing the concurrency can speed up
-validation. Use the `--concurrency` flag to set the number of diagrams
+validation. By default the script uses the number of CPU cores detected on
+your system. Use the `--concurrency` flag to override the number of diagrams
 rendered in parallel:
 
 ```bash

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -124,8 +124,8 @@ async def check_file(path: Path, cfg_path: Path, semaphore: asyncio.Semaphore) -
             render_block(block, tmp_path, cfg_path, path, idx, semaphore)
             for idx, block in enumerate(blocks, 1)
         ]
-        results = await asyncio.gather(*tasks)
-    return all(results)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+    return all(result is True for result in results)
 
 
 async def main(paths, max_concurrent: int = 4):

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -108,7 +108,7 @@ async def render_block(
     success = proc.returncode == 0
     if not success:
         print(f"{path}: diagram {idx} failed to render", file=sys.stderr)
-        print(format_cli_error(stderr.decode()), file=sys.stderr)
+        print(format_cli_error(stderr.decode('utf-8', errors='replace')), file=sys.stderr)
 
     return success
 

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -142,15 +142,20 @@ def default_concurrency() -> int:
     return os.cpu_count() or 4
 
 
-async def main(paths, max_concurrent: int = default_concurrency()):
+
+async def run_validator(paths, max_concurrent: int) -> int:
     files = collect_markdown_files(paths)
         tasks = [check_file(p, cfg_path, semaphore) for p in files]
-        help="Markdown files or directories to validate",
-        default=default_concurrency(),
+async def main(argv=None) -> int:
+        description="Validate Mermaid diagrams in Markdown files",
         help="Maximum number of concurrent mmdc processes",
     )
-    sys.exit(asyncio.run(main(parsed.paths, parsed.concurrency)))
+    args = parser.parse_args(argv)
+    return await run_validator(args.paths, args.concurrency)
 
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))
 
 async def check_file(path: Path, cfg_path: Path, semaphore: asyncio.Semaphore) -> bool:
     blocks = parse_blocks(path.read_text(encoding="utf-8"))

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -87,7 +87,7 @@ async def wait_for_proc(
         proc.kill()
         await proc.wait()
         print(f"{path}: diagram {idx} timed out", file=sys.stderr)
-        return False
+        return (False, b"")
     success = proc.returncode == 0
     return success, stderr
 

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -167,8 +167,15 @@ async def main(paths, max_concurrent):
     with create_puppeteer_config() as cfg_path:
         collected_files = collect_markdown_files(paths)
         tasks = [check_file(p, cfg_path, semaphore) for p in collected_files]
-        results = await asyncio.gather(*tasks)
-    return 0 if all(results) else 1
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        all_success = True
+        for result in results:
+            if isinstance(result, Exception):
+                print(f"Validation task raised an exception: {result}")
+                all_success = False
+            elif not result:
+                all_success = False
+        return 0 if all_success else 1
 
 
 def positive_int(value: str) -> int:

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -79,7 +79,7 @@ def format_cli_error(stderr: str) -> str:
 
 async def wait_for_proc(
     proc: asyncio.subprocess.Process, path: Path, idx: int, timeout: float = 30.0
-) -> tuple[bool, str]:
+) -> tuple[bool, bytes]:
     """Wait for a process to complete and return its success status and stderr."""
     try:
         _, stderr = await asyncio.wait_for(proc.communicate(), timeout)


### PR DESCRIPTION
## Summary
- speed up scripts/validate_mermaid.py by running mmdc in parallel
- reuse puppeteer config between checks

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo test`
- `cargo test --manifest-path validator/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6843a5a66a1c8322b7e69ca7ea16a349

## Summary by Sourcery

Parallelize Mermaid diagram validation by leveraging asyncio for concurrent rendering, reuse Puppeteer configuration across checks, and support recursive Markdown discovery with adjustable concurrency.

New Features:
- Add asynchronous diagram rendering with a configurable --concurrency flag
- Support passing directories for recursive Markdown file discovery

Enhancements:
- Reuse a single Puppeteer config file across all checks
- Implement timeouts and improved error reporting for rendering failures
- Utilize CPU-based default concurrency and parallel mmdc invocations to speed up validation

Documentation:
- Update documentation to describe recursive file scanning and the --concurrency option