### PR TITLE
Support news bundles hierarchy

### DIFF
--- a/migrations/00000000000002_add_bundles/down.sql
+++ b/migrations/00000000000002_add_bundles/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_categories_bundle;
+DROP INDEX IF EXISTS idx_bundles_parent;
+ALTER TABLE news_categories DROP COLUMN bundle_id;
+DROP TABLE news_bundles;

--- a/migrations/00000000000002_add_bundles/up.sql
+++ b/migrations/00000000000002_add_bundles/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE news_bundles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_bundle_id INTEGER REFERENCES news_bundles(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    UNIQUE(name, parent_bundle_id)
+);
+
+ALTER TABLE news_categories
+    ADD COLUMN bundle_id INTEGER REFERENCES news_bundles(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_bundles_parent ON news_bundles(parent_bundle_id);
+CREATE INDEX idx_categories_bundle ON news_categories(bundle_id);

--- a/src/models.rs
+++ b/src/models.rs
@@ -19,10 +19,26 @@ pub struct NewUser<'a> {
 pub struct Category {
     pub id: i32,
     pub name: String,
+    pub bundle_id: Option<i32>,
 }
 
 #[derive(Insertable, Deserialize)]
 #[diesel(table_name = crate::schema::news_categories)]
 pub struct NewCategory<'a> {
+    pub name: &'a str,
+    pub bundle_id: Option<i32>,
+}
+
+#[derive(Queryable, Serialize, Deserialize, Debug)]
+pub struct Bundle {
+    pub id: i32,
+    pub parent_bundle_id: Option<i32>,
+    pub name: String,
+}
+
+#[derive(Insertable, Deserialize)]
+#[diesel(table_name = crate::schema::news_bundles)]
+pub struct NewBundle<'a> {
+    pub parent_bundle_id: Option<i32>,
     pub name: &'a str,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,8 +6,16 @@ diesel::table! {
     }
 }
 diesel::table! {
+    news_bundles (id) {
+        id -> Integer,
+        parent_bundle_id -> Nullable<Integer>,
+        name -> Text,
+    }
+}
+diesel::table! {
     news_categories (id) {
         id -> Integer,
         name -> Text,
+        bundle_id -> Nullable<Integer>,
     }
 }

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -3,7 +3,7 @@ use std::net::TcpStream;
 
 use diesel_async::AsyncConnection;
 use mxd::commands::NEWS_ERR_PATH_UNSUPPORTED;
-use mxd::db::{DbConnection, create_category, run_migrations};
+use mxd::db::{DbConnection, create_bundle, create_category, run_migrations};
 use mxd::field_id::FieldId;
 use mxd::models::NewCategory;
 use mxd::transaction::encode_params;
@@ -18,8 +18,30 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
         rt.block_on(async {
             let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
             run_migrations(&mut conn).await?;
-            create_category(&mut conn, &NewCategory { name: "General" }).await?;
-            create_category(&mut conn, &NewCategory { name: "Updates" }).await?;
+            create_bundle(
+                &mut conn,
+                &mxd::models::NewBundle {
+                    parent_bundle_id: None,
+                    name: "Bundle",
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "Updates",
+                    bundle_id: None,
+                },
+            )
+            .await?;
             Ok(())
         })
     })?;
@@ -73,7 +95,7 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
             }
         })
         .collect::<Vec<_>>();
-    assert_eq!(names, vec!["General", "Updates"]);
+    assert_eq!(names, vec!["Bundle", "General", "Updates"]);
     Ok(())
 }
 
@@ -84,8 +106,30 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
         rt.block_on(async {
             let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
             run_migrations(&mut conn).await?;
-            create_category(&mut conn, &NewCategory { name: "General" }).await?;
-            create_category(&mut conn, &NewCategory { name: "Updates" }).await?;
+            create_bundle(
+                &mut conn,
+                &mxd::models::NewBundle {
+                    parent_bundle_id: None,
+                    name: "Bundle",
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "Updates",
+                    bundle_id: None,
+                },
+            )
+            .await?;
             Ok(())
         })
     })?;
@@ -138,7 +182,7 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
             }
         })
         .collect::<Vec<_>>();
-    assert_eq!(names, vec!["General", "Updates"]);
+    assert_eq!(names, vec!["Bundle", "General", "Updates"]);
     Ok(())
 }
 
@@ -149,7 +193,14 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
         rt.block_on(async {
             let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
             run_migrations(&mut conn).await?;
-            create_category(&mut conn, &NewCategory { name: "General" }).await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
             Ok(())
         })
     })?;


### PR DESCRIPTION
## Summary
- add migration for `news_bundles` table and bundle_id column
- support bundles in models and database layer
- implement path-aware listing with bundles first
- update news categories tests for bundles

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684419976e5c83228c3d92a3e5877327