### PR TITLE
Fix Mermaid diagram in file-sharing design doc

### DIFF
--- a/docs/file-sharing-design.md
+++ b/docs/file-sharing-design.md
@@ -49,38 +49,38 @@ erDiagram
     User {
         int id
         string username
-        bitmask global_access  // global privilege bits
-        // ... other fields ...
+        bitmask global_access "global privilege bits"
+        %% ... other fields ...
     }
     Group {
         int id
         string name
     }
     UserGroup {
-        int user_id FK -> User.id
-        int group_id FK -> Group.id
+        int user_id FK "-> User.id"
+        int group_id FK "-> Group.id"
     }
     FileNode {
         int id
-        enum type         // 'file', 'folder', 'alias'
+        enum type "file | folder | alias"
         varchar name
-        int parent_id FK -> FileNode.id  // null for root
-        int alias_target_id FK -> FileNode.id  // if type='alias'
-        varchar object_key   // storage key (for files only)
-        bigint size          // file size in bytes (0 for folders)
-        text comment         // file/folder comment/description
-        bool is_dropbox      // flag if this folder is a dropbox
+        int parent_id FK "-> FileNode.id (null for root)"
+        int alias_target_id FK "-> FileNode.id if type='alias'"
+        varchar object_key "storage key (for files only)"
+        bigint size "file size in bytes (0 for folders)"
+        text comment "file/folder comment/description"
+        bool is_dropbox "flag if this folder is a dropbox"
         timestamp created_at
         timestamp updated_at
-        int created_by FK -> User.id
+        int created_by FK "-> User.id"
     }
     Permission {
         int id
-        varchar resource_type  // e.g. 'file' or 'folder'
-        int resource_id FK -> FileNode.id
-        varchar principal_type // 'user' or 'group'
-        int principal_id       // FK -> User.id or Group.id
-        bitmask privileges     // permission bits allowed
+        varchar resource_type "e.g. 'file' or 'folder'"
+        int resource_id FK "-> FileNode.id"
+        varchar principal_type "'user' or 'group'"
+        int principal_id "FK -> User.id or Group.id"
+        bitmask privileges "permission bits allowed"
     }
 ```
 

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -12,8 +12,11 @@ import typing
 from contextlib import contextmanager
 from pathlib import Path
 
-if typing.TYPE_CHECKING:
-    import collections.abc as cabc
+# Typing helpers from collections.abc are needed at runtime, not just for type
+# checking. The previous version imported them only under TYPE_CHECKING,
+# resulting in a NameError when the validator ran. Import unconditionally so the
+# ``cabc`` alias is always available.
+import collections.abc as cabc
 
 BLOCK_RE = re.compile(
     r"^```\s*mermaid\s*\n(.*?)\n```[ \t]*$",


### PR DESCRIPTION
## Summary
- quote FK details in the file-sharing ERD so mermaid syntax parses
- import `collections.abc` unconditionally in `validate_mermaid.py`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --manifest-path validator/Cargo.toml`
- `python3 scripts/validate_mermaid.py docs/file-sharing-design.md`


------
https://chatgpt.com/codex/tasks/task_e_68448d6d32f883228b9251b8350d7a15