### PR TITLE
Implement news article listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository is written in Rust and uses Cargo for building and dependency ma
 9. **Commit messages should be descriptive**, explaining what was changed and why.
 10. **Check for `TODO` comments** and convert them into issues if more work is required.
 11. **Validate Markdown Mermaid diagrams** with `./scripts/validate_mermaid.py <paths>` before submitting documentation changes.
+12. **Do not construct SQL by concatenating strings.** Always use Diesel's query builder or parameter binding to avoid injection vulnerabilities.
 
 These practices will help maintain a high-quality codebase and make collaboration easier.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,9 +334,13 @@ version = "2.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff3e1edb1f37b4953dd5176916347289ed43d7119cc2e6c7c3f7849ff44ea506"
 dependencies = [
+ "bitflags",
+ "byteorder",
  "chrono",
  "diesel_derives",
+ "itoa",
  "libsqlite3-sys",
+ "pq-sys",
  "time",
 ]
 
@@ -346,6 +356,13 @@ dependencies = [
  "futures-util",
  "scoped-futures",
  "tokio",
+]
+
+[[package]]
+name = "diesel_cte_ext"
+version = "0.1.0"
+dependencies = [
+ "diesel",
 ]
 
 [[package]]
@@ -679,6 +696,7 @@ dependencies = [
  "clap",
  "diesel",
  "diesel-async",
+ "diesel_cte_ext",
  "diesel_migrations",
  "rand",
  "serde",
@@ -800,6 +818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pq-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41c852911b98f5981956037b2ca976660612e548986c30af075e753107bc3400"
+dependencies = [
+ "libc",
+ "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ name = "mxd"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "chrono",
  "clap",
  "diesel",
  "diesel-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -698,6 +710,7 @@ dependencies = [
  "diesel-async",
  "diesel_cte_ext",
  "diesel_migrations",
+ "futures-util",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4", features = ["derive"] }
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+diesel_cte_ext = { path = "diesel_cte_ext" }
 
 [dev-dependencies]
 test-util = { path = "test-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 test-util = { path = "test-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 diesel_cte_ext = { path = "diesel_cte_ext" }
+futures-util = "0.3"
 
 [dev-dependencies]
 test-util = { path = "test-util" }

--- a/migrations/00000000000003_add_articles/down.sql
+++ b/migrations/00000000000003_add_articles/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_articles_category;
+DROP TABLE news_articles;

--- a/migrations/00000000000003_add_articles/up.sql
+++ b/migrations/00000000000003_add_articles/up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE news_articles (
+    id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+    category_id            INTEGER NOT NULL REFERENCES news_categories(id) ON DELETE CASCADE,
+    parent_article_id      INTEGER REFERENCES news_articles(id),
+    prev_article_id        INTEGER REFERENCES news_articles(id),
+    next_article_id        INTEGER REFERENCES news_articles(id),
+    first_child_article_id INTEGER REFERENCES news_articles(id),
+    title       TEXT    NOT NULL,
+    poster      TEXT,
+    posted_at   DATETIME NOT NULL,
+    flags       INTEGER DEFAULT 0,
+    data_flavor TEXT    DEFAULT 'text/plain',
+    data        TEXT,
+    CHECK (category_id IS NOT NULL)
+);
+
+CREATE INDEX idx_articles_category ON news_articles(category_id);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -241,14 +241,10 @@ async fn handle_article_data(
     if let Some(p) = article.poster {
         params.push((FieldId::NewsPoster, p.into_bytes()));
     }
+    #[allow(deprecated)]
     params.push((
         FieldId::NewsDate,
-        article
-            .posted_at
-            .and_utc()
-            .timestamp()
-            .to_be_bytes()
-            .to_vec(),
+        article.posted_at.timestamp().to_be_bytes().to_vec(),
     ));
     if let Some(prev) = article.prev_article_id {
         params.push((FieldId::NewsPrevId, prev.to_be_bytes().to_vec()));

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -103,164 +103,19 @@ impl Command {
                 username,
                 password,
                 header,
-            } => {
-                let mut conn = pool.get().await?;
-                let user = get_user_by_name(&mut conn, &username).await?;
-                let (error, payload) = if let Some(u) = user {
-                    if verify_password(&u.password, &password) {
-                        let params = encode_params(&[(
-                            FieldId::Version,
-                            &crate::protocol::CLIENT_VERSION.to_be_bytes(),
-                        )]);
-                        (0u32, params)
-                    } else {
-                        (1u32, Vec::new())
-                    }
-                } else {
-                    (1u32, Vec::new())
-                };
-                let reply = Transaction {
-                    header: FrameHeader {
-                        flags: 0,
-                        is_reply: 1,
-                        ty: header.ty,
-                        id: header.id,
-                        error,
-                        total_size: payload.len() as u32,
-                        data_size: payload.len() as u32,
-                    },
-                    payload,
-                };
-                if error == 0 {
-                    println!("{} authenticated as {}", peer, username);
-                }
-                Ok(reply)
-            }
+            } => handle_login(peer, pool, username, password, header).await,
             Command::GetNewsCategoryNameList { header, path } => {
-                let mut conn = pool.get().await?;
-                let names = match list_names_at_path(&mut conn, path.as_deref()).await {
-                    Ok(c) => c,
-                    Err(CategoryError::InvalidPath) => {
-                        return Ok(Transaction {
-                            header: reply_header(&header, NEWS_ERR_PATH_UNSUPPORTED, 0),
-                            payload: Vec::new(),
-                        });
-                    }
-                    Err(CategoryError::Diesel(e)) => return Err(Box::new(e)),
-                };
-                let params: Vec<(FieldId, &[u8])> = names
-                    .iter()
-                    .map(|c| (FieldId::NewsCategory, c.as_bytes()))
-                    .collect();
-                let payload = encode_params(&params);
-                Ok(Transaction {
-                    header: reply_header(&header, 0, payload.len()),
-                    payload,
-                })
+                handle_category_list(pool, header, path).await
             }
             Command::GetNewsArticleNameList { header, path } => {
-                let mut conn = pool.get().await?;
-                let names = match list_article_titles(&mut conn, &path).await {
-                    Ok(c) => c,
-                    Err(CategoryError::InvalidPath) => {
-                        return Ok(Transaction {
-                            header: reply_header(&header, NEWS_ERR_PATH_UNSUPPORTED, 0),
-                            payload: Vec::new(),
-                        });
-                    }
-                    Err(CategoryError::Diesel(e)) => return Err(Box::new(e)),
-                };
-                let params: Vec<(FieldId, &[u8])> = names
-                    .iter()
-                    .map(|t| (FieldId::NewsArticle, t.as_bytes()))
-                    .collect();
-                let payload = encode_params(&params);
-                Ok(Transaction {
-                    header: reply_header(&header, 0, payload.len()),
-                    payload,
-                })
+                handle_article_titles(pool, header, path).await
             }
             Command::GetNewsArticleData {
                 header,
                 path,
                 article_id,
-            } => {
-                use crate::db::get_article;
-                let mut conn = pool.get().await?;
-                let article = match get_article(&mut conn, &path, article_id).await {
-                    Ok(Some(a)) => a,
-                    Ok(None) => {
-                        return Ok(Transaction {
-                            header: reply_header(&header, NEWS_ERR_PATH_UNSUPPORTED, 0),
-                            payload: Vec::new(),
-                        });
-                    }
-                    Err(CategoryError::InvalidPath) => {
-                        return Ok(Transaction {
-                            header: reply_header(&header, NEWS_ERR_PATH_UNSUPPORTED, 0),
-                            payload: Vec::new(),
-                        });
-                    }
-                    Err(CategoryError::Diesel(e)) => return Err(Box::new(e)),
-                };
-                let mut params: Vec<(FieldId, Vec<u8>)> = Vec::new();
-                params.push((FieldId::NewsTitle, article.title.into_bytes()));
-                if let Some(p) = article.poster {
-                    params.push((FieldId::NewsPoster, p.into_bytes()));
-                }
-                params.push((
-                    FieldId::NewsDate,
-                    article
-                        .posted_at
-                        .and_utc()
-                        .timestamp()
-                        .to_be_bytes()
-                        .to_vec(),
-                ));
-                if let Some(prev) = article.prev_article_id {
-                    params.push((FieldId::NewsPrevId, prev.to_be_bytes().to_vec()));
-                }
-                if let Some(next) = article.next_article_id {
-                    params.push((FieldId::NewsNextId, next.to_be_bytes().to_vec()));
-                }
-                if let Some(parent) = article.parent_article_id {
-                    params.push((FieldId::NewsParentId, parent.to_be_bytes().to_vec()));
-                }
-                if let Some(child) = article.first_child_article_id {
-                    params.push((FieldId::NewsFirstChildId, child.to_be_bytes().to_vec()));
-                }
-                params.push((
-                    FieldId::NewsArticleFlags,
-                    (article.flags as i32).to_be_bytes().to_vec(),
-                ));
-                params.push((FieldId::NewsDataFlavor, b"text/plain".to_vec()));
-                if let Some(data) = article.data {
-                    params.push((FieldId::NewsArticleData, data.into_bytes()));
-                }
-                let payload_pairs: Vec<(FieldId, &[u8])> =
-                    params.iter().map(|(id, d)| (*id, d.as_slice())).collect();
-                let payload = encode_params(&payload_pairs);
-                Ok(Transaction {
-                    header: reply_header(&header, 0, payload.len()),
-                    payload,
-                })
-            }
-            Command::Unknown { header } => {
-                let reply = Transaction {
-                    header: FrameHeader {
-                        flags: 0,
-                        is_reply: 1,
-                        ty: header.ty,
-                        id: header.id,
-                        error: 1,
-                        total_size: 0,
-                        data_size: 0,
-                    },
-                    payload: Vec::new(),
-                };
-                println!("{} sent unknown transaction: {}", peer, header.ty);
-                Ok(reply)
-            }
+            } => handle_article_data(pool, header, path, article_id).await,
+            Command::Unknown { header } => Ok(handle_unknown(peer, header)),
         }
     }
 }
@@ -275,4 +130,168 @@ fn reply_header(req: &FrameHeader, payload_error: u32, payload_len: usize) -> Fr
         total_size: payload_len as u32,
         data_size: payload_len as u32,
     }
+}
+
+async fn handle_login(
+    peer: SocketAddr,
+    pool: DbPool,
+    username: String,
+    password: String,
+    header: FrameHeader,
+) -> Result<Transaction, Box<dyn std::error::Error>> {
+    let mut conn = pool.get().await?;
+    let user = get_user_by_name(&mut conn, &username).await?;
+    let (error, payload) = if let Some(u) = user {
+        if verify_password(&u.password, &password) {
+            let params = encode_params(&[(
+                FieldId::Version,
+                &crate::protocol::CLIENT_VERSION.to_be_bytes(),
+            )]);
+            (0u32, params)
+        } else {
+            (1u32, Vec::new())
+        }
+    } else {
+        (1u32, Vec::new())
+    };
+    let reply = Transaction {
+        header: reply_header(&header, error, payload.len()),
+        payload,
+    };
+    if error == 0 {
+        println!("{} authenticated as {}", peer, username);
+    }
+    Ok(reply)
+}
+
+async fn handle_category_list(
+    pool: DbPool,
+    header: FrameHeader,
+    path: Option<String>,
+) -> Result<Transaction, Box<dyn std::error::Error>> {
+    let mut conn = pool.get().await?;
+    let names = match list_names_at_path(&mut conn, path.as_deref()).await {
+        Ok(c) => c,
+        Err(CategoryError::InvalidPath) => {
+            return Ok(Transaction {
+                header: reply_header(&header, NEWS_ERR_PATH_UNSUPPORTED, 0),
+                payload: Vec::new(),
+            });
+        }
+        Err(CategoryError::Diesel(e)) => return Err(Box::new(e)),
+    };
+    let params: Vec<(FieldId, &[u8])> = names
+        .iter()
+        .map(|c| (FieldId::NewsCategory, c.as_bytes()))
+        .collect();
+    let payload = encode_params(&params);
+    Ok(Transaction {
+        header: reply_header(&header, 0, payload.len()),
+        payload,
+    })
+}
+
+async fn handle_article_titles(
+    pool: DbPool,
+    header: FrameHeader,
+    path: String,
+) -> Result<Transaction, Box<dyn std::error::Error>> {
+    let mut conn = pool.get().await?;
+    let names = match list_article_titles(&mut conn, &path).await {
+        Ok(c) => c,
+        Err(CategoryError::InvalidPath) => {
+            return Ok(Transaction {
+                header: reply_header(&header, NEWS_ERR_PATH_UNSUPPORTED, 0),
+                payload: Vec::new(),
+            });
+        }
+        Err(CategoryError::Diesel(e)) => return Err(Box::new(e)),
+    };
+    let params: Vec<(FieldId, &[u8])> = names
+        .iter()
+        .map(|t| (FieldId::NewsArticle, t.as_bytes()))
+        .collect();
+    let payload = encode_params(&params);
+    Ok(Transaction {
+        header: reply_header(&header, 0, payload.len()),
+        payload,
+    })
+}
+
+async fn handle_article_data(
+    pool: DbPool,
+    header: FrameHeader,
+    path: String,
+    article_id: i32,
+) -> Result<Transaction, Box<dyn std::error::Error>> {
+    use crate::db::get_article;
+    let mut conn = pool.get().await?;
+    let article = match get_article(&mut conn, &path, article_id).await {
+        Ok(Some(a)) => a,
+        Ok(None) | Err(CategoryError::InvalidPath) => {
+            return Ok(Transaction {
+                header: reply_header(&header, NEWS_ERR_PATH_UNSUPPORTED, 0),
+                payload: Vec::new(),
+            });
+        }
+        Err(CategoryError::Diesel(e)) => return Err(Box::new(e)),
+    };
+    let mut params: Vec<(FieldId, Vec<u8>)> = Vec::new();
+    params.push((FieldId::NewsTitle, article.title.into_bytes()));
+    if let Some(p) = article.poster {
+        params.push((FieldId::NewsPoster, p.into_bytes()));
+    }
+    params.push((
+        FieldId::NewsDate,
+        article
+            .posted_at
+            .and_utc()
+            .timestamp()
+            .to_be_bytes()
+            .to_vec(),
+    ));
+    if let Some(prev) = article.prev_article_id {
+        params.push((FieldId::NewsPrevId, prev.to_be_bytes().to_vec()));
+    }
+    if let Some(next) = article.next_article_id {
+        params.push((FieldId::NewsNextId, next.to_be_bytes().to_vec()));
+    }
+    if let Some(parent) = article.parent_article_id {
+        params.push((FieldId::NewsParentId, parent.to_be_bytes().to_vec()));
+    }
+    if let Some(child) = article.first_child_article_id {
+        params.push((FieldId::NewsFirstChildId, child.to_be_bytes().to_vec()));
+    }
+    params.push((
+        FieldId::NewsArticleFlags,
+        (article.flags as i32).to_be_bytes().to_vec(),
+    ));
+    params.push((FieldId::NewsDataFlavor, b"text/plain".to_vec()));
+    if let Some(data) = article.data {
+        params.push((FieldId::NewsArticleData, data.into_bytes()));
+    }
+    let payload_pairs: Vec<(FieldId, &[u8])> =
+        params.iter().map(|(id, d)| (*id, d.as_slice())).collect();
+    let payload = encode_params(&payload_pairs);
+    Ok(Transaction {
+        header: reply_header(&header, 0, payload.len()),
+        payload,
+    })
+}
+
+fn handle_unknown(peer: SocketAddr, header: FrameHeader) -> Transaction {
+    let reply = Transaction {
+        header: FrameHeader {
+            flags: 0,
+            is_reply: 1,
+            ty: header.ty,
+            id: header.id,
+            error: 1,
+            total_size: 0,
+            data_size: 0,
+        },
+        payload: Vec::new(),
+    };
+    println!("{} sent unknown transaction: {}", peer, header.ty);
+    reply
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -151,17 +151,6 @@ pub async fn create_bundle(
         .await
 }
 
-pub async fn create_article(
-    conn: &mut DbConnection,
-    art: &crate::models::NewArticle<'_>,
-) -> QueryResult<usize> {
-    use crate::schema::news_articles::dsl::*;
-    diesel::insert_into(news_articles)
-        .values(art)
-        .execute(conn)
-        .await
-}
-
 async fn category_id_from_path(conn: &mut DbConnection, path: &str) -> Result<i32, CategoryError> {
     let trimmed = path.trim_matches('/');
     if trimmed.is_empty() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -151,17 +151,6 @@ pub async fn create_bundle(
         .await
 }
 
-pub async fn create_article(
-    conn: &mut DbConnection,
-    art: &crate::models::NewArticle<'_>,
-) -> QueryResult<usize> {
-    use crate::schema::news_articles::dsl::*;
-    diesel::insert_into(news_articles)
-        .values(art)
-        .execute(conn)
-        .await
-}
-
 pub async fn get_article(
     conn: &mut DbConnection,
     path: &str,
@@ -233,7 +222,8 @@ pub async fn list_article_titles(
         .order(a::posted_at.asc())
         .select(a::title)
         .load::<String>(conn)
-        .await?;
+        .await
+        .map_err(CategoryError::Diesel)?;
     Ok(titles)
 }
 

--- a/src/field_id.rs
+++ b/src/field_id.rs
@@ -8,6 +8,8 @@ pub enum FieldId {
     Version,
     /// News category list entry returned by the server.
     NewsCategory,
+    /// News article list entry returned by the server.
+    NewsArticle,
     /// Path within the news hierarchy.
     NewsPath,
     /// Any other field id not explicitly covered.
@@ -21,6 +23,7 @@ impl From<u16> for FieldId {
             106 => Self::Password,
             160 => Self::Version,
             323 => Self::NewsCategory,
+            321 => Self::NewsArticle,
             325 => Self::NewsPath,
             other => Self::Other(other),
         }
@@ -34,6 +37,7 @@ impl From<FieldId> for u16 {
             FieldId::Password => 106,
             FieldId::Version => 160,
             FieldId::NewsCategory => 323,
+            FieldId::NewsArticle => 321,
             FieldId::NewsPath => 325,
             FieldId::Other(v) => v,
         }
@@ -47,6 +51,7 @@ impl std::fmt::Display for FieldId {
             FieldId::Password => f.write_str("Password"),
             FieldId::Version => f.write_str("Version"),
             FieldId::NewsCategory => f.write_str("NewsCategory"),
+            FieldId::NewsArticle => f.write_str("NewsArticle"),
             FieldId::NewsPath => f.write_str("NewsPath"),
             FieldId::Other(v) => write!(f, "Other({v})"),
         }

--- a/src/field_id.rs
+++ b/src/field_id.rs
@@ -10,6 +10,28 @@ pub enum FieldId {
     NewsCategory,
     /// News article list entry returned by the server.
     NewsArticle,
+    /// Article identifier in requests.
+    NewsArticleId,
+    /// Data flavor for article content.
+    NewsDataFlavor,
+    /// Article title field.
+    NewsTitle,
+    /// Article poster field.
+    NewsPoster,
+    /// Article post date.
+    NewsDate,
+    /// Previous article id for navigation.
+    NewsPrevId,
+    /// Next article id for navigation.
+    NewsNextId,
+    /// Article data payload.
+    NewsArticleData,
+    /// Article flags field.
+    NewsArticleFlags,
+    /// Parent article id field.
+    NewsParentId,
+    /// First child article id field.
+    NewsFirstChildId,
     /// Path within the news hierarchy.
     NewsPath,
     /// Any other field id not explicitly covered.
@@ -24,6 +46,17 @@ impl From<u16> for FieldId {
             160 => Self::Version,
             323 => Self::NewsCategory,
             321 => Self::NewsArticle,
+            326 => Self::NewsArticleId,
+            327 => Self::NewsDataFlavor,
+            328 => Self::NewsTitle,
+            329 => Self::NewsPoster,
+            330 => Self::NewsDate,
+            331 => Self::NewsPrevId,
+            332 => Self::NewsNextId,
+            333 => Self::NewsArticleData,
+            334 => Self::NewsArticleFlags,
+            335 => Self::NewsParentId,
+            336 => Self::NewsFirstChildId,
             325 => Self::NewsPath,
             other => Self::Other(other),
         }
@@ -38,6 +71,17 @@ impl From<FieldId> for u16 {
             FieldId::Version => 160,
             FieldId::NewsCategory => 323,
             FieldId::NewsArticle => 321,
+            FieldId::NewsArticleId => 326,
+            FieldId::NewsDataFlavor => 327,
+            FieldId::NewsTitle => 328,
+            FieldId::NewsPoster => 329,
+            FieldId::NewsDate => 330,
+            FieldId::NewsPrevId => 331,
+            FieldId::NewsNextId => 332,
+            FieldId::NewsArticleData => 333,
+            FieldId::NewsArticleFlags => 334,
+            FieldId::NewsParentId => 335,
+            FieldId::NewsFirstChildId => 336,
             FieldId::NewsPath => 325,
             FieldId::Other(v) => v,
         }
@@ -52,6 +96,17 @@ impl std::fmt::Display for FieldId {
             FieldId::Version => f.write_str("Version"),
             FieldId::NewsCategory => f.write_str("NewsCategory"),
             FieldId::NewsArticle => f.write_str("NewsArticle"),
+            FieldId::NewsArticleId => f.write_str("NewsArticleId"),
+            FieldId::NewsDataFlavor => f.write_str("NewsDataFlavor"),
+            FieldId::NewsTitle => f.write_str("NewsTitle"),
+            FieldId::NewsPoster => f.write_str("NewsPoster"),
+            FieldId::NewsDate => f.write_str("NewsDate"),
+            FieldId::NewsPrevId => f.write_str("NewsPrevId"),
+            FieldId::NewsNextId => f.write_str("NewsNextId"),
+            FieldId::NewsArticleData => f.write_str("NewsArticleData"),
+            FieldId::NewsArticleFlags => f.write_str("NewsArticleFlags"),
+            FieldId::NewsParentId => f.write_str("NewsParentId"),
+            FieldId::NewsFirstChildId => f.write_str("NewsFirstChildId"),
             FieldId::NewsPath => f.write_str("NewsPath"),
             FieldId::Other(v) => write!(f, "Other({v})"),
         }

--- a/src/models.rs
+++ b/src/models.rs
@@ -72,6 +72,6 @@ pub struct NewArticle<'a> {
     pub poster: Option<&'a str>,
     pub posted_at: NaiveDateTime,
     pub flags: i32,
-    pub data_flavor: &'a str,
-    pub data: &'a str,
+    pub data_flavor: Option<&'a str>,
+    pub data: Option<&'a str>,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -41,4 +42,36 @@ pub struct Bundle {
 pub struct NewBundle<'a> {
     pub parent_bundle_id: Option<i32>,
     pub name: &'a str,
+}
+
+#[derive(Queryable, Debug)]
+pub struct Article {
+    pub id: i32,
+    pub category_id: i32,
+    pub parent_article_id: Option<i32>,
+    pub prev_article_id: Option<i32>,
+    pub next_article_id: Option<i32>,
+    pub first_child_article_id: Option<i32>,
+    pub title: String,
+    pub poster: Option<String>,
+    pub posted_at: NaiveDateTime,
+    pub flags: i32,
+    pub data_flavor: Option<String>,
+    pub data: Option<String>,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::news_articles)]
+pub struct NewArticle<'a> {
+    pub category_id: i32,
+    pub parent_article_id: Option<i32>,
+    pub prev_article_id: Option<i32>,
+    pub next_article_id: Option<i32>,
+    pub first_child_article_id: Option<i32>,
+    pub title: &'a str,
+    pub poster: Option<&'a str>,
+    pub posted_at: NaiveDateTime,
+    pub flags: i32,
+    pub data_flavor: &'a str,
+    pub data: &'a str,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,3 +19,20 @@ diesel::table! {
         bundle_id -> Nullable<Integer>,
     }
 }
+
+diesel::table! {
+    news_articles (id) {
+        id -> Integer,
+        category_id -> Integer,
+        parent_article_id -> Nullable<Integer>,
+        prev_article_id -> Nullable<Integer>,
+        next_article_id -> Nullable<Integer>,
+        first_child_article_id -> Nullable<Integer>,
+        title -> Text,
+        poster -> Nullable<Text>,
+        posted_at -> Timestamp,
+        flags -> Integer,
+        data_flavor -> Nullable<Text>,
+        data -> Nullable<Text>,
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -210,7 +210,7 @@ pub enum TransactionError {
 
 /// Determine whether duplicate instances of the given field id are permitted.
 fn duplicate_allowed(fid: &FieldId) -> bool {
-    matches!(*fid, FieldId::NewsCategory)
+    matches!(*fid, FieldId::NewsCategory | FieldId::NewsArticle)
 }
 
 fn check_duplicate(fid: &FieldId, seen: &mut HashSet<u16>) -> Result<(), TransactionError> {
@@ -406,6 +406,14 @@ pub fn decode_params(buf: &[u8]) -> Result<Vec<(FieldId, Vec<u8>)>, TransactionE
         return Err(TransactionError::SizeMismatch);
     }
     Ok(params)
+}
+
+/// Decode the parameter block into a map keyed by `FieldId`.
+pub fn decode_params_map(
+    buf: &[u8],
+) -> Result<std::collections::HashMap<FieldId, Vec<u8>>, TransactionError> {
+    let params = decode_params(buf)?;
+    Ok(params.into_iter().collect())
 }
 
 /// Build a parameter block from field id/data pairs.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -411,9 +411,14 @@ pub fn decode_params(buf: &[u8]) -> Result<Vec<(FieldId, Vec<u8>)>, TransactionE
 /// Decode the parameter block into a map keyed by `FieldId`.
 pub fn decode_params_map(
     buf: &[u8],
-) -> Result<std::collections::HashMap<FieldId, Vec<u8>>, TransactionError> {
+) -> Result<std::collections::HashMap<FieldId, Vec<Vec<u8>>>, TransactionError> {
     let params = decode_params(buf)?;
-    Ok(params.into_iter().collect())
+    let mut map: std::collections::HashMap<FieldId, Vec<Vec<u8>>> =
+        std::collections::HashMap::new();
+    for (fid, value) in params {
+        map.entry(fid).or_default().push(value);
+    }
+    Ok(map)
 }
 
 /// Build a parameter block from field id/data pairs.

--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -7,6 +7,7 @@ pub enum TransactionType {
     UserAccess,
     NewsCategoryNameList,
     NewsArticleNameList,
+    NewsArticleData,
     Other(u16),
 }
 
@@ -20,6 +21,7 @@ impl From<u16> for TransactionType {
             354 => Self::UserAccess,
             370 => Self::NewsCategoryNameList,
             371 => Self::NewsArticleNameList,
+            400 => Self::NewsArticleData,
             other => Self::Other(other),
         }
     }
@@ -35,6 +37,7 @@ impl From<TransactionType> for u16 {
             TransactionType::UserAccess => 354,
             TransactionType::NewsCategoryNameList => 370,
             TransactionType::NewsArticleNameList => 371,
+            TransactionType::NewsArticleData => 400,
             TransactionType::Other(v) => v,
         }
     }
@@ -50,6 +53,7 @@ impl std::fmt::Display for TransactionType {
             TransactionType::UserAccess => f.write_str("UserAccess"),
             TransactionType::NewsCategoryNameList => f.write_str("NewsCategoryNameList"),
             TransactionType::NewsArticleNameList => f.write_str("NewsArticleNameList"),
+            TransactionType::NewsArticleData => f.write_str("NewsArticleData"),
             TransactionType::Other(v) => write!(f, "Other({v})"),
         }
     }

--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -6,6 +6,7 @@ pub enum TransactionType {
     Agreed,
     UserAccess,
     NewsCategoryNameList,
+    NewsArticleNameList,
     Other(u16),
 }
 
@@ -18,6 +19,7 @@ impl From<u16> for TransactionType {
             121 => Self::Agreed,
             354 => Self::UserAccess,
             370 => Self::NewsCategoryNameList,
+            371 => Self::NewsArticleNameList,
             other => Self::Other(other),
         }
     }
@@ -32,6 +34,7 @@ impl From<TransactionType> for u16 {
             TransactionType::Agreed => 121,
             TransactionType::UserAccess => 354,
             TransactionType::NewsCategoryNameList => 370,
+            TransactionType::NewsArticleNameList => 371,
             TransactionType::Other(v) => v,
         }
     }
@@ -46,6 +49,7 @@ impl std::fmt::Display for TransactionType {
             TransactionType::Agreed => f.write_str("Agreed"),
             TransactionType::UserAccess => f.write_str("UserAccess"),
             TransactionType::NewsCategoryNameList => f.write_str("NewsCategoryNameList"),
+            TransactionType::NewsArticleNameList => f.write_str("NewsArticleNameList"),
             TransactionType::Other(v) => write!(f, "Other({v})"),
         }
     }

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -173,3 +173,104 @@ fn list_news_articles_valid_path() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(names, vec!["First", "Second"]);
     Ok(())
 }
+
+#[test]
+fn get_news_article_data() -> Result<(), Box<dyn std::error::Error>> {
+    use chrono::NaiveDateTime;
+    use mxd::models::NewArticle;
+
+    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            run_migrations(&mut conn).await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            use mxd::schema::news_articles::dsl as a;
+            let posted = NaiveDateTime::from_timestamp_opt(1000, 0).unwrap();
+            diesel::insert_into(a::news_articles)
+                .values(&NewArticle {
+                    category_id: 1,
+                    parent_article_id: None,
+                    prev_article_id: None,
+                    next_article_id: None,
+                    first_child_article_id: None,
+                    title: "First",
+                    poster: Some("alice"),
+                    posted_at: posted,
+                    flags: 0,
+                    data_flavor: "text/plain",
+                    data: "hello",
+                })
+                .execute(&mut conn)
+                .await?;
+            Ok(())
+        })
+    })?;
+
+    let port = server.port();
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    let mut handshake = Vec::new();
+    handshake.extend_from_slice(b"TRTP");
+    handshake.extend_from_slice(&0u32.to_be_bytes());
+    handshake.extend_from_slice(&1u16.to_be_bytes());
+    handshake.extend_from_slice(&0u16.to_be_bytes());
+    stream.write_all(&handshake)?;
+
+    let mut reply = [0u8; 8];
+    stream.read_exact(&mut reply)?;
+    assert_eq!(&reply[0..4], b"TRTP");
+    assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
+
+    let mut params = Vec::new();
+    params.push((FieldId::NewsPath, b"General".as_ref()));
+    let id_bytes = 1i32.to_be_bytes();
+    params.push((FieldId::NewsArticleId, id_bytes.as_ref()));
+    params.push((FieldId::NewsDataFlavor, b"text/plain".as_ref()));
+    let payload = encode_params(&params);
+    let header = FrameHeader {
+        flags: 0,
+        is_reply: 0,
+        ty: TransactionType::NewsArticleData.into(),
+        id: 8,
+        error: 0,
+        total_size: payload.len() as u32,
+        data_size: payload.len() as u32,
+    };
+    let tx = Transaction { header, payload };
+    stream.write_all(&tx.to_bytes())?;
+
+    let mut hdr_buf = [0u8; 20];
+    stream.read_exact(&mut hdr_buf)?;
+    let hdr = FrameHeader::from_bytes(&hdr_buf);
+    let mut data = vec![0u8; hdr.data_size as usize];
+    stream.read_exact(&mut data)?;
+    let reply_tx = Transaction {
+        header: hdr,
+        payload: data,
+    };
+    let params = decode_params(&reply_tx.payload)?;
+    let mut found_title = false;
+    let mut found_data = false;
+    for (id, d) in params {
+        match id {
+            FieldId::NewsTitle => {
+                assert_eq!(String::from_utf8(d).unwrap(), "First");
+                found_title = true;
+            }
+            FieldId::NewsArticleData => {
+                assert_eq!(String::from_utf8(d).unwrap(), "hello");
+                found_data = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(found_title && found_data);
+    Ok(())
+}

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -3,10 +3,10 @@ use std::net::TcpStream;
 
 use diesel_async::AsyncConnection;
 use mxd::commands::NEWS_ERR_PATH_UNSUPPORTED;
-use mxd::db::{DbConnection, create_category, run_migrations};
+use mxd::db::{DbConnection, create_article, create_category, run_migrations};
 use mxd::field_id::FieldId;
 use mxd::models::NewCategory;
-use mxd::transaction::{FrameHeader, Transaction, encode_params};
+use mxd::transaction::{FrameHeader, Transaction, decode_params, encode_params};
 use mxd::transaction_type::TransactionType;
 use test_util::TestServer;
 
@@ -61,5 +61,115 @@ fn list_news_articles_invalid_path() -> Result<(), Box<dyn std::error::Error>> {
     stream.read_exact(&mut hdr_buf)?;
     let hdr = FrameHeader::from_bytes(&hdr_buf);
     assert_eq!(hdr.error, NEWS_ERR_PATH_UNSUPPORTED);
+    Ok(())
+}
+
+#[test]
+fn list_news_articles_valid_path() -> Result<(), Box<dyn std::error::Error>> {
+    use chrono::NaiveDateTime;
+    use mxd::models::NewArticle;
+
+    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            run_migrations(&mut conn).await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            let posted = NaiveDateTime::from_timestamp_opt(1000, 0).unwrap();
+            create_article(
+                &mut conn,
+                &NewArticle {
+                    category_id: 1,
+                    parent_article_id: None,
+                    prev_article_id: None,
+                    next_article_id: None,
+                    first_child_article_id: None,
+                    title: "First",
+                    poster: None,
+                    posted_at: posted,
+                    flags: 0,
+                    data_flavor: "text/plain",
+                    data: "a",
+                },
+            )
+            .await?;
+            let posted2 = NaiveDateTime::from_timestamp_opt(2000, 0).unwrap();
+            create_article(
+                &mut conn,
+                &NewArticle {
+                    category_id: 1,
+                    parent_article_id: None,
+                    prev_article_id: Some(1),
+                    next_article_id: None,
+                    first_child_article_id: None,
+                    title: "Second",
+                    poster: None,
+                    posted_at: posted2,
+                    flags: 0,
+                    data_flavor: "text/plain",
+                    data: "b",
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    })?;
+
+    let port = server.port();
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    let mut handshake = Vec::new();
+    handshake.extend_from_slice(b"TRTP");
+    handshake.extend_from_slice(&0u32.to_be_bytes());
+    handshake.extend_from_slice(&1u16.to_be_bytes());
+    handshake.extend_from_slice(&0u16.to_be_bytes());
+    stream.write_all(&handshake)?;
+
+    let mut reply = [0u8; 8];
+    stream.read_exact(&mut reply)?;
+    assert_eq!(&reply[0..4], b"TRTP");
+    assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
+
+    let params = vec![(FieldId::NewsPath, b"General".as_ref())];
+    let payload = encode_params(&params);
+    let header = FrameHeader {
+        flags: 0,
+        is_reply: 0,
+        ty: TransactionType::NewsArticleNameList.into(),
+        id: 7,
+        error: 0,
+        total_size: payload.len() as u32,
+        data_size: payload.len() as u32,
+    };
+    let tx = Transaction { header, payload };
+    stream.write_all(&tx.to_bytes())?;
+
+    let mut hdr_buf = [0u8; 20];
+    stream.read_exact(&mut hdr_buf)?;
+    let hdr = FrameHeader::from_bytes(&hdr_buf);
+    let mut data = vec![0u8; hdr.data_size as usize];
+    stream.read_exact(&mut data)?;
+    let reply_tx = Transaction {
+        header: hdr,
+        payload: data,
+    };
+    let params = decode_params(&reply_tx.payload)?;
+    let names: Vec<String> = params
+        .into_iter()
+        .filter_map(|(id, d)| {
+            if id == FieldId::NewsArticle {
+                Some(String::from_utf8(d).unwrap())
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(names, vec!["First", "Second"]);
     Ok(())
 }

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -1,0 +1,65 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+use diesel_async::AsyncConnection;
+use mxd::commands::NEWS_ERR_PATH_UNSUPPORTED;
+use mxd::db::{DbConnection, create_category, run_migrations};
+use mxd::field_id::FieldId;
+use mxd::models::NewCategory;
+use mxd::transaction::{FrameHeader, Transaction, encode_params};
+use mxd::transaction_type::TransactionType;
+use test_util::TestServer;
+
+#[test]
+fn list_news_articles_invalid_path() -> Result<(), Box<dyn std::error::Error>> {
+    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            run_migrations(&mut conn).await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    })?;
+
+    let port = server.port();
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    let mut handshake = Vec::new();
+    handshake.extend_from_slice(b"TRTP");
+    handshake.extend_from_slice(&0u32.to_be_bytes());
+    handshake.extend_from_slice(&1u16.to_be_bytes());
+    handshake.extend_from_slice(&0u16.to_be_bytes());
+    stream.write_all(&handshake)?;
+
+    let mut reply = [0u8; 8];
+    stream.read_exact(&mut reply)?;
+    assert_eq!(&reply[0..4], b"TRTP");
+    assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
+
+    let params = vec![(FieldId::NewsPath, b"Missing".as_ref())];
+    let payload = encode_params(&params);
+    let header = FrameHeader {
+        flags: 0,
+        is_reply: 0,
+        ty: TransactionType::NewsArticleNameList.into(),
+        id: 6,
+        error: 0,
+        total_size: payload.len() as u32,
+        data_size: payload.len() as u32,
+    };
+    let tx = Transaction { header, payload };
+    stream.write_all(&tx.to_bytes())?;
+
+    let mut hdr_buf = [0u8; 20];
+    stream.read_exact(&mut hdr_buf)?;
+    let hdr = FrameHeader::from_bytes(&hdr_buf);
+    assert_eq!(hdr.error, NEWS_ERR_PATH_UNSUPPORTED);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add migration and schema for `news_articles`
- create article DB helpers
- support `NewsArticleNameList` transaction
- expose article list field id and transaction type
- test invalid article path handling

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68448b16f8b4832292fd6086d6a3c8fa

## Summary by Sourcery

Implement support for listing and retrieving news articles via new transactions backed by a dedicated database table

New Features:
- Create `news_articles` table with migrations, schema, and models to store article metadata and content
- Add `get_article` and `list_article_titles` DB helpers to fetch article details by category path
- Introduce `NewsArticleNameList` and `NewsArticleData` transaction types with corresponding `FieldId` mappings
- Expose commands to list article titles under a given news path and retrieve full article data

Enhancements:
- Refactor command handling into reusable async handler functions and introduce `decode_params_map` for payload parsing
- Add `reply_for_category_op` helper to consolidate response construction logic

Build:
- Add dependencies on `chrono`, `diesel_cte_ext`, and `futures-util` for date handling, recursive CTE support, and async futures

Documentation:
- Update AGENTS.md with a guideline to prefer Diesel’s query builder over manual SQL string concatenation

Tests:
- Add integration tests covering invalid path handling, article listing, and article data retrieval