### PR TITLE
Refactor param decoding helpers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,13 +95,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         create_user(&mut conn, &new_user)
             .await
             .expect("failed to create user");
-        println!("User {} created", username);
+        println!("User {username} created");
         return Ok(());
     }
 
     let addr = cli.bind;
     let listener = TcpListener::bind(&addr).await?;
-    println!("mxd listening on {}", addr);
+    println!("mxd listening on {addr}");
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let mut join_set = JoinSet::new();
@@ -121,12 +121,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         let mut rx = shutdown_rx.clone();
                         join_set.spawn(async move {
                             if let Err(e) = handle_client(socket, peer, pool, &mut rx).await {
-                                eprintln!("connection error from {}: {}", peer, e);
+                                eprintln!("connection error from {peer}: {e}");
                             }
                         });
                     }
                     Err(e) => {
-                        eprintln!("accept error: {}", e);
+                        eprintln!("accept error: {e}");
                     }
                 }
             }
@@ -138,7 +138,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     while let Some(res) = join_set.join_next().await {
         if let Err(e) = res {
-            eprintln!("task error: {}", e);
+            eprintln!("task error: {e}");
         }
     }
     Ok(())

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,5 @@
-use chrono::NaiveDateTime;
 use crate::schema::{file_acl, files};
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 

--- a/tests/handshake_unsupported_version.rs
+++ b/tests/handshake_unsupported_version.rs
@@ -24,6 +24,6 @@ fn handshake_unsupported_version() -> Result<(), Box<dyn std::error::Error>> {
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
     let bytes = reader.read_line(&mut line)?;
-    assert_eq!(bytes, 0, "unexpected server data: {}", line);
+    assert_eq!(bytes, 0, "unexpected server data: {line}");
     Ok(())
 }

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -96,8 +96,8 @@ fn list_news_articles_valid_path() -> Result<(), Box<dyn std::error::Error>> {
                     poster: None,
                     posted_at: posted,
                     flags: 0,
-                    data_flavor: "text/plain",
-                    data: "a",
+                    data_flavor: Some("text/plain"),
+                    data: Some("a"),
                 })
                 .execute(&mut conn)
                 .await?;
@@ -113,8 +113,8 @@ fn list_news_articles_valid_path() -> Result<(), Box<dyn std::error::Error>> {
                     poster: None,
                     posted_at: posted2,
                     flags: 0,
-                    data_flavor: "text/plain",
-                    data: "b",
+                    data_flavor: Some("text/plain"),
+                    data: Some("b"),
                 })
                 .execute(&mut conn)
                 .await?;
@@ -205,8 +205,8 @@ fn get_news_article_data() -> Result<(), Box<dyn std::error::Error>> {
                     poster: Some("alice"),
                     posted_at: posted,
                     flags: 0,
-                    data_flavor: "text/plain",
-                    data: "hello",
+                    data_flavor: Some("text/plain"),
+                    data: Some("hello"),
                 })
                 .execute(&mut conn)
                 .await?;


### PR DESCRIPTION
## Summary
- add helper functions to parse parameter maps
- refactor commands to use helpers
- silence new clippy warnings with inline format strings
- adjust tests for updated API

## Testing
- `cargo clippy`
- `cargo test` *(failed: tests hung for over 60 seconds)*
- `cargo test --manifest-path validator/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6845b03508cc8322bc60d1bb4ccdbbeb

## Summary by Sourcery

Introduce reusable helpers for decoding parameter maps and refactor command handlers to use them, update print macros to use inline formatting for Clippy compliance, and adjust tests for the new API.

New Features:
- Add first_param_string, required_param_string, and required_param_i32 helper functions for parameter map parsing

Enhancements:
- Refactor command implementations to replace manual parameter decoding with the new helpers
- Update println! and eprintln! calls to use inline "{var}" formatting to silence Clippy warnings

Tests:
- Adapt news_articles tests to wrap data_flavor and data fields in Some(...)
- Modify handshake_unsupported_version assertion message to use inline formatting for the line variable