### PR TITLE
Extract shared reply header builder

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 
 use crate::db::{CategoryError, DbConnection, DbPool, list_article_titles, list_names_at_path};
 use crate::field_id::FieldId;
+use crate::header_util::reply_header;
 use crate::login::handle_login;
 use crate::transaction::{
     FrameHeader, Transaction, decode_params, decode_params_map, encode_params, first_param_string,
@@ -152,18 +153,6 @@ impl Command {
             } => handle_article_data(pool, header, path, article_id).await,
             Command::Unknown { header } => Ok(handle_unknown(peer, header)),
         }
-    }
-}
-
-fn reply_header(req: &FrameHeader, payload_error: u32, payload_len: usize) -> FrameHeader {
-    FrameHeader {
-        flags: 0,
-        is_reply: 1,
-        ty: req.ty,
-        id: req.id,
-        error: payload_error,
-        total_size: payload_len as u32,
-        data_size: payload_len as u32,
     }
 }
 

--- a/src/header_util.rs
+++ b/src/header_util.rs
@@ -1,0 +1,17 @@
+/// Build a reply `FrameHeader` mirroring the request and specifying
+/// the payload size and error code.
+pub fn reply_header(
+    req: &crate::transaction::FrameHeader,
+    payload_error: u32,
+    payload_len: usize,
+) -> crate::transaction::FrameHeader {
+    crate::transaction::FrameHeader {
+        flags: 0,
+        is_reply: 1,
+        ty: req.ty,
+        id: req.id,
+        error: payload_error,
+        total_size: payload_len as u32,
+        data_size: payload_len as u32,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod db;
 pub mod field_id;
 pub mod handler;
+pub mod header_util;
 pub mod login;
 pub mod models;
 pub mod protocol;

--- a/src/login.rs
+++ b/src/login.rs
@@ -2,22 +2,9 @@ use std::net::SocketAddr;
 
 use crate::db::{DbPool, get_user_by_name};
 use crate::field_id::FieldId;
+use crate::header_util::reply_header;
 use crate::transaction::{FrameHeader, Transaction, encode_params};
 use crate::users::verify_password;
-
-/// Construct a reply header mirroring the request header fields and setting the
-/// payload size and error code.
-fn reply_header(req: &FrameHeader, payload_error: u32, payload_len: usize) -> FrameHeader {
-    FrameHeader {
-        flags: 0,
-        is_reply: 1,
-        ty: req.ty,
-        id: req.id,
-        error: payload_error,
-        total_size: payload_len as u32,
-        data_size: payload_len as u32,
-    }
-}
 
 /// Handle a user login request.
 pub async fn handle_login(


### PR DESCRIPTION
## Summary
- create `header_util` module with `reply_header`
- use `reply_header` in login and command handlers

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test` in `validator` crate

------
https://chatgpt.com/codex/tasks/task_e_6845cfd75f1c8322afe681057b277349

## Summary by Sourcery

Enhancements:
- Extract the duplicated reply_header function into a new header_util module and update login and command handlers to use the shared builder.