### PR TITLE
Introduce payload policy

### DIFF
--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -14,6 +14,13 @@ pub enum TransactionType {
     Other(u16),
 }
 
+impl TransactionType {
+    /// Return true if this transaction type may include a payload.
+    pub fn allows_payload(self) -> bool {
+        !matches!(self, TransactionType::GetFileNameList)
+    }
+}
+
 impl From<u16> for TransactionType {
     fn from(v: u16) -> Self {
         match v {

--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -1,4 +1,6 @@
 pub const FILE_NAME_LIST_ID: u16 = 200;
+pub const DOWNLOAD_BANNER_ID: u16 = 212;
+pub const USER_NAME_LIST_ID: u16 = 300;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransactionType {
@@ -7,6 +9,10 @@ pub enum TransactionType {
     Agreement,
     Agreed,
     GetFileNameList,
+    /// Request to download the server's banner image.
+    DownloadBanner,
+    /// Request the list of logged-in users.
+    GetUserNameList,
     UserAccess,
     NewsCategoryNameList,
     NewsArticleNameList,
@@ -17,7 +23,12 @@ pub enum TransactionType {
 impl TransactionType {
     /// Return true if this transaction type may include a payload.
     pub fn allows_payload(self) -> bool {
-        !matches!(self, TransactionType::GetFileNameList)
+        !matches!(
+            self,
+            TransactionType::GetFileNameList
+                | TransactionType::DownloadBanner
+                | TransactionType::GetUserNameList
+        )
     }
 }
 
@@ -29,6 +40,8 @@ impl From<u16> for TransactionType {
             109 => Self::Agreement,
             121 => Self::Agreed,
             FILE_NAME_LIST_ID => Self::GetFileNameList,
+            DOWNLOAD_BANNER_ID => Self::DownloadBanner,
+            USER_NAME_LIST_ID => Self::GetUserNameList,
             354 => Self::UserAccess,
             370 => Self::NewsCategoryNameList,
             371 => Self::NewsArticleNameList,
@@ -46,6 +59,8 @@ impl From<TransactionType> for u16 {
             TransactionType::Agreement => 109,
             TransactionType::Agreed => 121,
             TransactionType::GetFileNameList => FILE_NAME_LIST_ID,
+            TransactionType::DownloadBanner => DOWNLOAD_BANNER_ID,
+            TransactionType::GetUserNameList => USER_NAME_LIST_ID,
             TransactionType::UserAccess => 354,
             TransactionType::NewsCategoryNameList => 370,
             TransactionType::NewsArticleNameList => 371,
@@ -63,6 +78,8 @@ impl std::fmt::Display for TransactionType {
             TransactionType::Agreement => f.write_str("Agreement"),
             TransactionType::Agreed => f.write_str("Agreed"),
             TransactionType::GetFileNameList => f.write_str("GetFileNameList"),
+            TransactionType::DownloadBanner => f.write_str("DownloadBanner"),
+            TransactionType::GetUserNameList => f.write_str("GetUserNameList"),
             TransactionType::UserAccess => f.write_str("UserAccess"),
             TransactionType::NewsCategoryNameList => f.write_str("NewsCategoryNameList"),
             TransactionType::NewsArticleNameList => f.write_str("NewsArticleNameList"),

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -47,6 +47,8 @@ impl TestServer {
         let mut child = Command::new("cargo")
             .args([
                 "run",
+                "--bin",
+                "mxd",
                 "--manifest-path",
                 manifest_path,
                 "--quiet",

--- a/tests/payload_reject.rs
+++ b/tests/payload_reject.rs
@@ -1,0 +1,79 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+use mxd::field_id::FieldId;
+use mxd::transaction::{FrameHeader, Transaction, encode_params};
+use mxd::transaction_type::TransactionType;
+use test_util::TestServer;
+
+fn handshake(stream: &mut TcpStream) -> std::io::Result<()> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"TRTP");
+    buf.extend_from_slice(&0u32.to_be_bytes());
+    buf.extend_from_slice(&1u16.to_be_bytes());
+    buf.extend_from_slice(&0u16.to_be_bytes());
+    stream.write_all(&buf)?;
+    let mut reply = [0u8; 8];
+    stream.read_exact(&mut reply)?;
+    Ok(())
+}
+
+#[test]
+fn download_banner_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
+    let server = TestServer::start("./Cargo.toml")?;
+    let port = server.port();
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    handshake(&mut stream)?;
+
+    let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())]);
+    let header = FrameHeader {
+        flags: 0,
+        is_reply: 0,
+        ty: TransactionType::DownloadBanner.into(),
+        id: 10,
+        error: 0,
+        total_size: params.len() as u32,
+        data_size: params.len() as u32,
+    };
+    let tx = Transaction {
+        header,
+        payload: params,
+    };
+    stream.write_all(&tx.to_bytes())?;
+    let mut buf = [0u8; 20];
+    stream.read_exact(&mut buf)?;
+    let hdr = FrameHeader::from_bytes(&buf);
+    assert_eq!(hdr.error, 1);
+    assert_eq!(hdr.data_size, 0);
+    Ok(())
+}
+
+#[test]
+fn user_name_list_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
+    let server = TestServer::start("./Cargo.toml")?;
+    let port = server.port();
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    handshake(&mut stream)?;
+
+    let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())]);
+    let header = FrameHeader {
+        flags: 0,
+        is_reply: 0,
+        ty: TransactionType::GetUserNameList.into(),
+        id: 11,
+        error: 0,
+        total_size: params.len() as u32,
+        data_size: params.len() as u32,
+    };
+    let tx = Transaction {
+        header,
+        payload: params,
+    };
+    stream.write_all(&tx.to_bytes())?;
+    let mut buf = [0u8; 20];
+    stream.read_exact(&mut buf)?;
+    let hdr = FrameHeader::from_bytes(&buf);
+    assert_eq!(hdr.error, 1);
+    assert_eq!(hdr.data_size, 0);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- handle invalid payloads via a new `InvalidPayload` command variant
- reject unexpected payloads declaratively using `TransactionType::allows_payload`
- make `TestServer` choose the mxd binary explicitly

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cd validator && cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845d84a18208322aa7dd56c3bcdf96e

## Summary by Sourcery

Introduce a payload policy mechanism to declaratively reject unexpected payloads via TransactionType::allows_payload and a new InvalidPayload command variant, simplify the GetFileNameList payload check accordingly, and update the TestServer to explicitly specify the mxd binary during testing.

Enhancements:
- Implement a payload policy by adding TransactionType::allows_payload and an InvalidPayload command variant to reject unexpected payloads.
- Simplify the GetFileNameList handler by removing its manual payload validation.

Tests:
- Update TestServer to explicitly select the mxd binary in test runs.