### PR TITLE
Improve invalid payload handling

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,6 +13,8 @@ use futures_util::future::BoxFuture;
 
 /// Error code used when the requested news path is unsupported.
 pub const NEWS_ERR_PATH_UNSUPPORTED: u32 = 1;
+/// Error code used when a request includes an unexpected payload.
+pub const ERR_INVALID_PAYLOAD: u32 = 2;
 
 pub enum Command {
     Login {
@@ -37,7 +39,8 @@ pub enum Command {
         article_id: i32,
         header: FrameHeader,
     },
-    /// Request contained a payload when none was expected.
+    /// Request contained a payload when none was expected. The server
+    /// responds with [`ERR_INVALID_PAYLOAD`].
     InvalidPayload {
         header: FrameHeader,
     },
@@ -154,7 +157,7 @@ impl Command {
                 article_id,
             } => handle_article_data(pool, header, path, article_id).await,
             Command::InvalidPayload { header } => Ok(Transaction {
-                header: reply_header(&header, 1, 0),
+                header: reply_header(&header, ERR_INVALID_PAYLOAD, 0),
                 payload: Vec::new(),
             }),
             Command::Unknown { header } => Ok(handle_unknown(peer, header)),

--- a/tests/file_list.rs
+++ b/tests/file_list.rs
@@ -173,7 +173,7 @@ fn list_files_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = [0u8; 20];
     stream.read_exact(&mut buf)?;
     let hdr = FrameHeader::from_bytes(&buf);
-    assert_eq!(hdr.error, 1);
+    assert_eq!(hdr.error, mxd::commands::ERR_INVALID_PAYLOAD);
     assert_eq!(hdr.data_size, 0);
     Ok(())
 }

--- a/tests/payload_reject.rs
+++ b/tests/payload_reject.rs
@@ -43,7 +43,7 @@ fn download_banner_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = [0u8; 20];
     stream.read_exact(&mut buf)?;
     let hdr = FrameHeader::from_bytes(&buf);
-    assert_eq!(hdr.error, 1);
+    assert_eq!(hdr.error, mxd::commands::ERR_INVALID_PAYLOAD);
     assert_eq!(hdr.data_size, 0);
     Ok(())
 }
@@ -73,7 +73,7 @@ fn user_name_list_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = [0u8; 20];
     stream.read_exact(&mut buf)?;
     let hdr = FrameHeader::from_bytes(&buf);
-    assert_eq!(hdr.error, 1);
+    assert_eq!(hdr.error, mxd::commands::ERR_INVALID_PAYLOAD);
     assert_eq!(hdr.data_size, 0);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `ERR_INVALID_PAYLOAD` constant
- return that error code when rejecting requests with unexpected payloads
- update tests to expect the new error

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test` in `validator` crate

------
https://chatgpt.com/codex/tasks/task_e_6845e835fc5083228c304c0c250350e2