### PR TITLE
Update fuzz Dockerfile

### DIFF
--- a/fuzz/Dockerfile
+++ b/fuzz/Dockerfile
@@ -3,6 +3,9 @@ FROM aflplusplus/aflplusplus:latest AS builder
 WORKDIR /mxd
 COPY . .
 
+# Build the seed corpus included in the repository
+RUN make corpus
+
 ENV CC=afl-clang-fast
 ENV CXX=afl-clang-fast++
 RUN cargo afl build --manifest-path fuzz/Cargo.toml


### PR DESCRIPTION
## Summary
- build the seed corpus when building the fuzzing container

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --manifest-path validator/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6845fc48cf1c8322a86d23f7b96a9bdf

## Summary by Sourcery

Enhancements:
- Add `make corpus` step to generate the seed corpus in the fuzz Dockerfile