### PR TITLE
Add dedicated fuzzing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,54 +55,7 @@ cargo test
 ```
 
 ## Fuzzing
-
-A simple AFL++ harness lives in the `fuzz/` directory.
-
-A `fuzz/Dockerfile` builds the debug harness with sanitizers and runs AFL++ in a container.
-
-Crash files appear under `artifacts/main/crashes`.
-
-```bash
-# install afl++ and make sure afl-clang-fast is on your PATH
-export CC=afl-clang-fast
-export CXX=afl-clang-fast++
-export RUSTFLAGS="-Zsanitizer=address"
-
-# compile the instrumented binary
-cargo afl build --manifest-path fuzz/Cargo.toml
-
-# prepare a corpus directory of initial inputs
-mkdir -p fuzz/corpus
-
-# run the fuzzer
-cargo afl fuzz -i fuzz/corpus -o findings fuzz/target/debug/fuzz
-```
-
-### Running in Docker
-
-A `fuzz/Dockerfile` is provided to build the harness and run AFL++ in a container.
-
-```bash
-# build the fuzzing image
-docker build -t mxd-fuzz -f fuzz/Dockerfile .
-
-# run with your corpus and an output directory for results
-mkdir -p fuzz/corpus artifacts
-docker run --rm \
-  -v $(pwd)/fuzz/corpus:/corpus \
-  -v $(pwd)/artifacts:/out \
-  mxd-fuzz
-```
-
-Crash files will appear under `artifacts/main/crashes`.
-
-The `src/bin/gen_corpus.rs` utility rebuilds the seed files placed in
-`fuzz/corpus/` from the transactions crafted in the integration tests.
-Run it whenever you want to refresh or extend the corpus. A simple
-`Makefile` provides a convenience target so you only need to run:
-
-```bash
-make corpus
-```
-
-Add new transactions to the tool to grow the set of starting inputs.
+The repository includes an AFL++ harness under `fuzz/`. See
+[docs/fuzzing.md](docs/fuzzing.md) for build commands, Docker usage and how the
+nightly GitHub Actions job integrates AFL++. Crash files are written to
+`artifacts/main/crashes`.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -45,4 +45,17 @@ docker run --rm \
 
 ## CI Integration
 
-GitHub Actions runs the fuzzer nightly. The workflow defined in `.github/workflows/fuzz.yml` builds the Docker image, executes AFL++ for several hours and uploads any crashes. Review the artifacts after each run to inspect new findings.
+GitHub Actions runs the fuzzer nightly. The workflow defined in `.github/workflows/fuzz.yml` builds the Docker image, executes AFL++ for several hours and uploads any crashes. Review the artifacts after each run to inspect new findings. This process aligns with the overall architecture outlined in [roadmap.md](roadmap.md) and the storage notes in [file-sharing-design.md](file-sharing-design.md).
+
+```mermaid
+flowchart TD
+    subgraph "Nightly CI Fuzzing Process (described in docs/fuzzing.md)"
+        A[GitHub Actions Nightly Trigger] --> B[Build 'mxd-fuzz' Docker Image]
+        B -- "Includes project code, AFL++, and sanitizers" --> B
+        B --> C[Execute AFL++ in Docker Container]
+        C -- "Targets 'parse_transaction' function" --> D[AFL++ Fuzzing Process]
+        D -- "Runs for several hours" --> D
+        D -- "Identifies new crashes" --> E[Upload Crash Artifacts]
+    end
+    F[Developer/Maintainer] -- "Reviews artifacts to inspect new findings" --> E
+```

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -29,7 +29,7 @@ The harness panics on parsing errors so crashes will be detected. Refer to `file
 
 ### Docker
 
-`fuzz/Dockerfile` builds the harness with sanitizers and runs AFL++ inside the official container. Use it when you want a reproducible environment:
+`fuzz/Dockerfile` builds the harness with sanitizers and runs AFL++ inside the official container. Building with sanitizers (for example by setting `RUSTFLAGS="-Zsanitizer=address"`) requires the nightly Rust toolchain, which the Dockerfile installs automatically. Use the container when you want a reproducible environment:
 
 ```bash
 # build the image

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,0 +1,48 @@
+# AFL++ Fuzzing Guide
+
+This document summarizes how to build and run the fuzzing harness for `mxd` and how it integrates with CI.
+
+## Building the Harness
+
+The fuzzing code lives in `fuzz/` and targets the `parse_transaction` function. Seed inputs are generated using `src/bin/gen_corpus.rs`, which constructs transactions defined in [docs/protocol.md](protocol.md).
+
+```bash
+# rebuild the seed corpus from the protocol examples
+make corpus
+
+# instrument the harness with AFL++
+export CC=afl-clang-fast
+export CXX=afl-clang-fast++
+cargo afl build --manifest-path fuzz/Cargo.toml
+```
+
+## Running AFL++
+
+Once compiled, invoke AFL++ with a directory of seed files:
+
+```bash
+mkdir -p fuzz/corpus findings
+cargo afl fuzz -i fuzz/corpus -o findings fuzz/target/debug/fuzz
+```
+
+The harness panics on parsing errors so crashes will be detected. Refer to `file-sharing-design.md` for how file operations interact with the protocol.
+
+### Docker
+
+`fuzz/Dockerfile` builds the harness with sanitizers and runs AFL++ inside the official container. Use it when you want a reproducible environment:
+
+```bash
+# build the image
+docker build -t mxd-fuzz -f fuzz/Dockerfile .
+
+# run with mounted corpus and output directory
+mkdir -p fuzz/corpus artifacts
+docker run --rm \
+  -v $(pwd)/fuzz/corpus:/corpus \
+  -v $(pwd)/artifacts:/out \
+  mxd-fuzz
+```
+
+## CI Integration
+
+GitHub Actions runs the fuzzer nightly. The workflow defined in `.github/workflows/fuzz.yml` builds the Docker image, executes AFL++ for several hours and uploads any crashes. Review the artifacts after each run to inspect new findings.


### PR DESCRIPTION
## Summary
- document the fuzzing process in docs/fuzzing.md
- link to the new fuzzing guide from the README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cd validator && cargo test && cd ..`
- `./scripts/validate_mermaid.py docs/fuzzing.md docs/*.md` *(fails: diagram timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68464623e0688322b3fb056d74a91c5b

## Summary by Sourcery

Document the project’s AFL++ fuzzing workflow in a new dedicated guide and update the README to reference it

Documentation:
- Add docs/fuzzing.md with instructions for building, running, Dockerizing, and CI integration of the fuzzing harness
- Link the new fuzzing guide from README and condense the inline fuzzing instructions