### PR TITLE
Add fuzz crash triage

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,6 +25,15 @@ jobs:
             -v ${{ github.workspace }}/artifacts:/out \
             mxd-fuzz
 
+      - name: Triage crashes
+        if: always()
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -w /work \
+            mxd-fuzz \
+            bash scripts/triage_crashes.sh artifacts/main/crashes
+
       - name: Upload crash corpus
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/triage_crashes.sh
+++ b/scripts/triage_crashes.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 <crash_dir> [harness]" >&2
+    exit 1
+fi
+
+CRASH_DIR=$(realpath "$1")
+HARNESS=${2:-/usr/local/bin/fuzz}
+
+if [[ ! -d "$CRASH_DIR" ]]; then
+    echo "Crash directory $CRASH_DIR does not exist" >&2
+    exit 0
+fi
+
+UNIQUE_DIR="$CRASH_DIR/unique"
+mkdir -p "$UNIQUE_DIR"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# afl-cmin reduces crashes to those with unique coverage
+# Use persistent mode harness
+afl-cmin -i "$CRASH_DIR" -o "$WORK_DIR" -- "$HARNESS" @@ || true
+
+# Minimize each crash input with afl-tmin
+for crash in "$WORK_DIR"/*; do
+    [ -e "$crash" ] || continue
+    base=$(basename "$crash")
+    afl-tmin -i "$crash" -o "$UNIQUE_DIR/$base" -- "$HARNESS" @@ || true
+done

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -201,6 +201,15 @@ fn short_header_error() {
 }
 
 #[test]
+fn parse_transaction_short_frame() {
+    let buf = vec![0u8; HEADER_LEN - 2];
+    match parse_transaction(&buf).unwrap_err() {
+        TransactionError::SizeMismatch => {}
+        e => panic!("unexpected {e:?}"),
+    }
+}
+
+#[test]
 fn parse_transaction_rejects_large_frame() {
     let payload = vec![0u8; MAX_PAYLOAD_SIZE + 1];
     let header = FrameHeader {


### PR DESCRIPTION
## Summary
- add `triage_crashes.sh` to deduplicate and minimize crash inputs
- call the script in the fuzz workflow
- test short frame handling in `parse_transaction`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68464608379c8322a52d4b9d6479b019