### PR TITLE
Add date parameter encoding docs

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -66,13 +66,15 @@ Field IDs never repeat within a single transaction. Integers are unsigned; the s
 
 #### 2.2 Date parameters
 
-Several protocol fields store timestamps in an eight‑byte structure. The layout is:
+Several protocol fields store timestamps in an eight‑byte structure, often called *date objects*. The layout is:
 
-* **Year** – 2 bytes (big endian)
-* **Milliseconds** – 2 bytes
-* **Seconds** – 4 bytes
+* **Year** – 2 bytes (big-endian)
+* **Milliseconds** – 2 bytes (big-endian)
+* **Seconds** – 4 bytes (big-endian)
 
-Seconds and milliseconds indicate the elapsed time since **January&nbsp;1** of the given year. For example, a value of 70 seconds and 2,000 milliseconds with year 2010 corresponds to *1&nbsp;January&nbsp;2010&nbsp;00:01:12*. Likewise, 432,000 seconds and 5,000 milliseconds with year 2008 represent *6&nbsp;January&nbsp;2008&nbsp;00:00:05*.
+All three values use network byte order.
+
+Seconds and milliseconds indicate the elapsed time since **January&nbsp;1** of the given year. For example, a value of 70 seconds and 2,000 milliseconds with year 2010 corresponds to *1&nbsp;January&nbsp;2010&nbsp;00:01:12*. Likewise, 432,010 seconds and 5,000 milliseconds with year 2008 represent *6&nbsp;January&nbsp;2008&nbsp;00:00:15*.
 
 To convert a `SYSTEMTIME` structure to this format, compute the seconds field as:
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -64,6 +64,43 @@ Immediately afterwards, *Param-count* **records** follow:
 
 Field IDs never repeat within a single transaction. Integers are unsigned; the sender may use 16-bit encoding if the value ≤ 0xFFFF, otherwise 32-bit.
 
+#### 2.2 Date parameters
+
+Several protocol fields store timestamps in an eight‑byte structure. The layout is:
+
+* **Year** – 2 bytes (big endian)
+* **Milliseconds** – 2 bytes
+* **Seconds** – 4 bytes
+
+Seconds and milliseconds indicate the elapsed time since **January&nbsp;1** of the given year. For example, a value of 70 seconds and 2,000 milliseconds with year 2010 corresponds to *1&nbsp;January&nbsp;2010&nbsp;00:01:12*. Likewise, 432,000 seconds and 5,000 milliseconds with year 2008 represent *6&nbsp;January&nbsp;2008&nbsp;00:00:05*.
+
+To convert a `SYSTEMTIME` structure to this format, compute the seconds field as:
+
+```text
+MONTH_SECS[wMonth - 1] +
+(if (wMonth > 2) and isLeapYear(wYear) { 86400 } else { 0 }) +
+(wSecond + 60 * (wMinute + 60 * (wHour + 24 * (wDay - 1))))
+```
+
+`MONTH_SECS` is a table containing the cumulative seconds at the start of each month:
+
+| Month     | Seconds |
+|-----------|--------:|
+| January   | 0 |
+| February  | 2,678,400 |
+| March     | 5,097,600 |
+| April     | 7,776,000 |
+| May       | 10,368,000 |
+| June      | 13,046,400 |
+| July      | 15,638,400 |
+| August    | 18,316,800 |
+| September | 20,995,200 |
+| October   | 23,587,200 |
+| November  | 26,265,600 |
+| December  | 28,857,600 |
+
+The year and milliseconds fields are copied directly from the original timestamp structure.
+
 ---
 
 ### 3  Fragmentation rules


### PR DESCRIPTION
## Summary
- explain `Date` parameter format and conversion to/from `SYSTEMTIME`
- run unit tests for `mxd` and `validator`

## Testing
- `cargo fmt`
- `cargo clippy -q`
- `cargo test`
- `cargo test` in `validator`
- `./scripts/validate_mermaid.py docs/protocol.md`

------
https://chatgpt.com/codex/tasks/task_e_6846c07b6c80832298d96202019e2435

## Summary by Sourcery

Document the date parameter encoding format and conversion from SYSTEMTIME in the protocol specification

Documentation:
- Add a new "Date parameters" section detailing the 8-byte date field layout and byte ordering
- Describe the calculation of the seconds field using a cumulative monthly seconds table and leap year adjustment
- Include the conversion formula from the SYSTEMTIME structure and the MONTH_SECS table for reference