### PR TITLE
Configure clippy pedantic lints as warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 test-util = { path = "test-util" }
+
+[lints.clippy]
+pedantic = "warn"

--- a/src/db.rs
+++ b/src/db.rs
@@ -260,7 +260,7 @@ pub async fn create_root_article(
                 .optional()?;
 
             let now = Utc::now().naive_utc();
-            let new = crate::models::NewArticle {
+            let article = crate::models::NewArticle {
                 category_id: cat_id,
                 parent_article_id: None,
                 prev_article_id: last_id,
@@ -275,7 +275,7 @@ pub async fn create_root_article(
             };
 
             let inserted_id: i32 = diesel::insert_into(a::news_articles)
-                .values(&new)
+                .values(&article)
                 .returning(a::id)
                 .get_result(conn)
                 .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ struct Cli {
     #[arg(long, default_value = "0.0.0.0:5500")]
     bind: String,
 
-    /// Path to the SQLite database
+    /// Path to the `SQLite` database
     #[arg(long, default_value = "mxd.db")]
     database: String,
 
@@ -110,7 +110,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     loop {
         tokio::select! {
-            _ = &mut shutdown => {
+            () = &mut shutdown => {
                 println!("shutdown signal received");
                 break;
             }

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -115,3 +115,19 @@ impl Drop for TestServer {
         let _ = self.child.wait();
     }
 }
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+/// Send a valid protocol handshake and read the server reply.
+pub fn handshake(stream: &mut TcpStream) -> std::io::Result<()> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"TRTP");
+    buf.extend_from_slice(&0u32.to_be_bytes());
+    buf.extend_from_slice(&1u16.to_be_bytes());
+    buf.extend_from_slice(&0u16.to_be_bytes());
+    stream.write_all(&buf)?;
+    let mut reply = [0u8; 8];
+    stream.read_exact(&mut reply)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- enable clippy `pedantic` lints as warnings
- rename variable in `create_root_article` to address a `similar_names` warning
- shorten lengthy tests using helper functions and new `handshake` helper
- fix doc comment and shutdown select pattern

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6846c9ddae2c832297fdb00b376e7788

## Summary by Sourcery

Enable Clippy pedantic lints as warnings and clean up test code by introducing reusable helpers, while addressing related lints in application code.

New Features:
- Introduce a `handshake` helper in test-util to send and verify the protocol handshake.
- Add `setup_news_db` and `setup_files_db` helpers to centralize database initialization in tests.

Enhancements:
- Enable Clippy pedantic lints as warnings in Cargo.toml.
- Replace inline handshake byte sequences in news and file tests with the new `handshake` helper.
- Rename the `new` variable to `article` in `create_root_article` to address a similar names lint.
- Update the shutdown select pattern to `() = &mut shutdown`.

Build:
- Configure `[lints.clippy] pedantic = "warn"` in Cargo.toml.

Documentation:
- Surround “SQLite” with backticks in the CLI help comment.

Tests:
- Extract and reuse database setup logic in news and file tests through standalone helper functions.
- Remove duplicated handshake setup code across tests in favor of the new `handshake` function.