### PR TITLE
Add markdownlint config and fix docs

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "MD013": {
+      "line_length": 80,
+      "code_block_line_length": 120,
+      "tables": false
+    }
+  }
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,4 +1,6 @@
 {
+  // Ignore MD013 (line length) inside tables since reflowing
+  // Markdown tables often breaks formatting and readability.
   "config": {
     "MD013": {
       "line_length": 80,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mxd
+
 Marrakesh Express Daemon
 
 Hop aboard the Marrakesh Express — a compact but spirited
@@ -19,9 +20,10 @@ into the protocol and how we juggle SQLite and PostgreSQL migrations.
 
 ## Running
 
-Build the project and run the daemon. Specify a bind address and database path if the defaults don't tickle your fancy:
+Build the project and run the daemon. Specify a bind address and
+database path if the defaults don't tickle your fancy:
 
-```
+```bash
 cargo build
 
 # Run server listening on the default address
@@ -32,22 +34,23 @@ cargo run -- --bind 0.0.0.0:5500 --database mxd.db
 
 Use the `create-user` subcommand to add accounts:
 
-```
+```bash
 cargo run -- create-user alice secret
 ```
 
 ### Running tests
 
-```
+```bash
 cargo test
 ```
 
 Integration tests live in the repository's `tests/` directory.
 
-
 ## Validation harness
 
-The `validator` crate provides a compatibility check using the `shx` client and `expectrl` to ensure mxd speaks the Hotline protocol correctly. Install `shx` version 0.2.4 and make sure it's on your `PATH` before running:
+The `validator` crate provides a compatibility check using the `shx` client and
+`expectrl` to ensure mxd speaks the Hotline protocol correctly. Install `shx`
+version 0.2.4 and make sure it's on your `PATH` before running:
 
 ```bash
 cd validator
@@ -55,6 +58,7 @@ cargo test
 ```
 
 ## Fuzzing
+
 The repository includes an AFL++ harness under `fuzz/`. See
 [docs/fuzzing.md](docs/fuzzing.md) for build commands, Docker usage and how the
 nightly GitHub Actions job integrates AFL++. Crash files are written to

--- a/docs/file-sharing-design.md
+++ b/docs/file-sharing-design.md
@@ -204,7 +204,7 @@ async fn list_directory(path: &str, user: &User) -> Result<Vec<ListEntry>, Error
 }
 ```
 
-*(The above is illustrative; actual code would need to join with alias target to get size if alias, etc.)*
+Note: The above is illustrative; actual code would need to join with alias target to get size if alias, etc.
 
 ### File Download – *DownloadFile (202)*
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -6,7 +6,6 @@ Hotline is a client/server system providing chat, private messaging, file sharin
 
 All multi-byte integers are transmitted **big-endian (“network byte order”)**. No padding or alignment bytes are used: the fields follow one another exactly as listed.
 
-
 ### 1  Session-initialisation handshake
 
 | Offset | Size (bytes) | Field               | Meaning                                                                          |
@@ -852,7 +851,7 @@ These let an admin manage the server’s user database (the list of login accoun
 
 **Server behavior:** When the server is about to disconnect a user (either via admin action, or maybe due to inactivity timeout or other reasons), it sends DisconnectMsg with a reason text (for example, “You have been kicked by Admin” or “Server shutting down”). Immediately after sending this, the server closes the connection from its side as well. The user ID of the target is implicit (since it’s sent on that user’s connection).
 
-**End-user experience:** The user sees a message popup or in the status: whatever text the server sent. Commonly if an admin kicked them, they might see “Disconnected by Server: <message>”. Then the connection is lost – the client returns to the server list or login screen. This is more graceful than a silent drop; the user at least knows the cause. If the server simply dropped without sending 111, the user would just see “Connection lost.”
+**End-user experience:** The user sees a message popup or in the status: whatever text the server sent. Commonly if an admin kicked them, they might see “Disconnected by Server: `<message>`”. Then the connection is lost – the client returns to the server list or login screen. This is more graceful than a silent drop; the user at least knows the cause. If the server simply dropped without sending 111, the user would just see “Connection lost.”
 
 ### Broadcasting a Message (Transaction 355) – Admin/Server Initiated
 
@@ -868,7 +867,7 @@ These let an admin manage the server’s user database (the list of login accoun
 
 Privilege required to send a broadcast via 355 is *Broadcast* priv (32), which typically only admin or moderators have.
 
-**End-user experience:** All users will see a message appear, usually in a separate system message window or as a highlighted text, often prefixed by something like “Broadcast from Admin: <text>”. For example, an admin might announce “Server will restart in 5 minutes.” Users see that in real-time. It’s not part of public chat; it’s a distinct message, often modal or clearly different (Hotline client had a floating window or a different color for admin broadcasts). They cannot reply to it (except via PM or such privately). It’s essentially like a server announcement PA system.
+**End-user experience:** All users will see a message appear, usually in a separate system message window or as a highlighted text, often prefixed by something like “Broadcast from Admin: `<text>`”. For example, an admin might announce “Server will restart in 5 minutes.” Users see that in real-time. It’s not part of public chat; it’s a distinct message, often modal or clearly different (Hotline client had a floating window or a different color for admin broadcasts). They cannot reply to it (except via PM or such privately). It’s essentially like a server announcement PA system.
 
 ### Additional Admin Privileges Note
 

--- a/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
+++ b/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
@@ -57,7 +57,7 @@ Things that **do *not* port** and therefore need conditional SQL:
 
 ## 3  Putting it together: a minimal dual-backend migration
 
-```
+```text
 migrations/
 └─ 20250605142700_create_users/
    ├─ up.postgres.sql


### PR DESCRIPTION
## Summary
- configure markdownlint to ignore table line length
- tidy README formatting
- tweak SQL migration docs example
- escape inline HTML in protocol docs
- clarify note in file sharing design doc

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `cd validator && cargo test --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6846d8f2eca48322a187ba32cab536e7

## Summary by Sourcery

Add markdownlint config and refine documentation formatting, examples, and notes across the project

Build:
- Add markdownlint configuration and ignore table line length

Documentation:
- Tidy README formatting and add language identifiers to code fences
- Update SQL migration guide example with proper code block syntax
- Escape inline HTML in protocol documentation examples
- Clarify explanatory note in file sharing design document