### PR TITLE
Introduce encode_vec_params helper

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,8 +5,8 @@ use crate::field_id::FieldId;
 use crate::header_util::reply_header;
 use crate::login::handle_login;
 use crate::transaction::{
-    FrameHeader, Transaction, decode_params, decode_params_map, encode_params, first_param_i32,
-    first_param_string, required_param_i32, required_param_string,
+    FrameHeader, Transaction, decode_params, decode_params_map, encode_params, encode_vec_params,
+    first_param_i32, first_param_string, required_param_i32, required_param_string,
 };
 use crate::transaction_type::TransactionType;
 use futures_util::future::BoxFuture;
@@ -218,9 +218,7 @@ where
     match pool.get().await {
         Ok(mut conn) => match op(&mut conn).await {
             Ok(params) => {
-                let pairs: Vec<(FieldId, &[u8])> =
-                    params.iter().map(|(id, d)| (*id, d.as_slice())).collect();
-                let payload = encode_params(&pairs);
+                let payload = encode_vec_params(&params);
                 Ok(Transaction {
                     header: reply_header(&header, 0, payload.len()),
                     payload,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -438,6 +438,19 @@ pub fn encode_params(params: &[(FieldId, &[u8])]) -> Vec<u8> {
     buf
 }
 
+/// Convenience for encoding a vector of owned parameter values.
+///
+/// This converts a `&[(FieldId, Vec<u8>)]` slice into the borrowed
+/// form expected by [`encode_params`]. It avoids repeating the
+/// conversion logic at call sites.
+pub fn encode_vec_params(params: &[(FieldId, Vec<u8>)]) -> Vec<u8> {
+    let borrowed: Vec<(FieldId, &[u8])> = params
+        .iter()
+        .map(|(id, bytes)| (*id, bytes.as_slice()))
+        .collect();
+    encode_params(&borrowed)
+}
+
 /// Return the first value for `field` in a parameter map as a `String`.
 ///
 /// Returns `Ok(None)` if the field is absent and an error if the bytes are not


### PR DESCRIPTION
## Summary
- add `encode_vec_params` to convert owned parameter vectors
- use the new helper in `run_news_tx`

## Testing
- `cargo clippy`
- `cargo test --quiet`
- `cargo test --manifest-path validator/Cargo.toml --quiet`
- `./scripts/validate_mermaid.py docs/*.md`

------
https://chatgpt.com/codex/tasks/task_e_6846e0c73ccc8322bc8d8aa5e06b905b