### PR TITLE
Enable recursive bundle lookup

### DIFF
--- a/migrations/00000000000005_add_bundle_name_parent_index/down.sql
+++ b/migrations/00000000000005_add_bundle_name_parent_index/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_bundles_name_parent;
+

--- a/migrations/00000000000005_add_bundle_name_parent_index/up.sql
+++ b/migrations/00000000000005_add_bundle_name_parent_index/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_bundles_name_parent ON news_bundles(name, parent_bundle_id);
+

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -302,3 +302,88 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
     assert!(names.is_empty());
     Ok(())
 }
+
+#[test]
+fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
+    use mxd::models::{NewBundle, NewCategory};
+    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            run_migrations(&mut conn).await?;
+            create_bundle(
+                &mut conn,
+                &NewBundle {
+                    parent_bundle_id: None,
+                    name: "Bundle",
+                },
+            )
+            .await?;
+            create_bundle(
+                &mut conn,
+                &NewBundle {
+                    parent_bundle_id: Some(1),
+                    name: "Sub",
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "Inside",
+                    bundle_id: Some(2),
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    })?;
+
+    let port = server.port();
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    let mut handshake = Vec::new();
+    handshake.extend_from_slice(b"TRTP");
+    handshake.extend_from_slice(&0u32.to_be_bytes());
+    handshake.extend_from_slice(&1u16.to_be_bytes());
+    handshake.extend_from_slice(&0u16.to_be_bytes());
+    stream.write_all(&handshake)?;
+    let mut reply = [0u8; 8];
+    stream.read_exact(&mut reply)?;
+
+    let params = vec![(FieldId::NewsPath, b"Bundle/Sub".as_ref())];
+    let payload = encode_params(&params);
+    let header = FrameHeader {
+        flags: 0,
+        is_reply: 0,
+        ty: TransactionType::NewsCategoryNameList.into(),
+        id: 5,
+        error: 0,
+        total_size: payload.len() as u32,
+        data_size: payload.len() as u32,
+    };
+    let tx = Transaction { header, payload };
+    stream.write_all(&tx.to_bytes())?;
+
+    let mut hdr_buf = [0u8; 20];
+    stream.read_exact(&mut hdr_buf)?;
+    let hdr = FrameHeader::from_bytes(&hdr_buf);
+    let mut data = vec![0u8; hdr.data_size as usize];
+    stream.read_exact(&mut data)?;
+    let reply_tx = Transaction {
+        header: hdr,
+        payload: data,
+    };
+    let params = decode_params(&reply_tx.payload)?;
+    let names: Vec<String> = params
+        .into_iter()
+        .filter_map(|(id, d)| {
+            if id == FieldId::NewsCategory {
+                Some(String::from_utf8(d).unwrap())
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(names, vec!["Inside"]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support recursive queries for news bundle paths using diesel_cte_ext
- check nested category listing

## Testing
- `cargo clippy`
- `cargo test --quiet`
- `cd validator && cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846f75bb1a083229b9593c48072a519

## Summary by Sourcery

Enable recursive bundle and category path resolution using SQL CTEs and validate nested category listing.

New Features:
- Support recursive resolution of nested bundle and category paths via diesel_cte_ext and CTE queries.

Enhancements:
- Replace manual iterative DB lookups in bundle_id_from_path and category_id_from_path with centralized recursive CTE SQL constants.

Build:
- Add migration to create index on news_bundles(name, parent_bundle_id) for efficient path queries.

Tests:
- Add integration test for nested news category listing via recursive bundle lookup.