### PR TITLE
Refactor shared SQL for news path lookups

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -249,6 +249,13 @@ fn news_error_reply(header: &FrameHeader, err: CategoryError) -> Transaction {
                 payload: Vec::new(),
             }
         }
+        CategoryError::Serde(e) => {
+            error!("serialization error: {e}");
+            Transaction {
+                header: reply_header(header, ERR_INTERNAL_SERVER, 0),
+                payload: Vec::new(),
+            }
+        }
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -64,6 +64,8 @@ pub enum CategoryError {
     InvalidPath,
     #[error(transparent)]
     Diesel(#[from] diesel::result::Error),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
 }
 
 async fn bundle_id_from_path(
@@ -73,7 +75,7 @@ async fn bundle_id_from_path(
     use diesel::sql_types::{Integer, Text};
     use diesel_cte_ext::with_recursive;
 
-    let (json, len) = match prepare_path(path) {
+    let (json, len) = match prepare_path(path)? {
         Some(t) => t,
         None => return Ok(None),
     };
@@ -183,7 +185,7 @@ async fn category_id_from_path(conn: &mut DbConnection, path: &str) -> Result<i3
     use diesel::sql_types::{Integer, Text};
     use diesel_cte_ext::with_recursive;
 
-    let (json, len) = match prepare_path(path) {
+    let (json, len) = match prepare_path(path)? {
         Some(t) => t,
         None => return Err(CategoryError::InvalidPath),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod handler;
 pub mod header_util;
 pub mod login;
 pub mod models;
+pub mod news_path;
 pub mod protocol;
 pub mod schema;
 pub mod transaction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod handler;
 pub mod header_util;
 pub mod login;
 pub mod models;
-pub mod news_path;
+pub(crate) mod news_path;
 pub mod protocol;
 pub mod schema;
 pub mod transaction;

--- a/src/news_path.rs
+++ b/src/news_path.rs
@@ -1,0 +1,33 @@
+macro_rules! step_sql {
+    ($jt:literal) => {
+        concat!(
+            "SELECT tree.idx + 1 AS idx, b.id AS id \n",
+            "FROM tree \n",
+            "JOIN json_each(?) seg ON seg.key = tree.idx \n",
+            $jt,
+            " news_bundles b ON b.name = seg.value AND \n  ((tree.id IS NULL AND b.parent_bundle_id IS NULL) OR b.parent_bundle_id = tree.id)"
+        )
+    };
+}
+
+pub(crate) const CTE_SEED_SQL: &str = "SELECT 0 AS idx, NULL AS id";
+pub(crate) const BUNDLE_STEP_SQL: &str = step_sql!("JOIN");
+pub(crate) const CATEGORY_STEP_SQL: &str = step_sql!("LEFT JOIN");
+pub(crate) const BUNDLE_BODY_SQL: &str = "SELECT id FROM tree WHERE idx = ?";
+pub(crate) const CATEGORY_BODY_SQL: &str = concat!(
+    "SELECT c.id AS id \n",
+    "FROM news_categories c \n",
+    "JOIN json_each(?) seg ON seg.key = ? \n",
+    "WHERE c.name = seg.value AND c.bundle_id IS (SELECT id FROM tree WHERE idx = ?)"
+);
+
+pub(crate) fn prepare_path(path: &str) -> Option<(String, usize)> {
+    let trimmed = path.trim_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let parts: Vec<String> = trimmed.split('/').map(|s| s.to_string()).collect();
+    let len = parts.len();
+    let json = serde_json::to_string(&parts).expect("serialize path segments");
+    Some((json, len))
+}

--- a/src/news_path.rs
+++ b/src/news_path.rs
@@ -1,3 +1,9 @@
+/// Generate the recursive CTE step SQL used for traversing news bundle paths.
+///
+/// The `$jt` argument specifies the join type (`"JOIN"` or `"LEFT JOIN"`) used
+/// when linking the current tree node to the `news_bundles` table.  The
+/// resulting SQL selects the next bundle in the path by comparing the segment
+/// at `tree.idx` to the bundle name.
 macro_rules! step_sql {
     ($jt:literal) => {
         concat!(
@@ -30,4 +36,27 @@ pub(crate) fn prepare_path(path: &str) -> Option<(String, usize)> {
     let len = parts.len();
     let json = serde_json::to_string(&parts).expect("serialize path segments");
     Some((json, len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_step_sql_matches_expected() {
+        let expected = "SELECT tree.idx + 1 AS idx, b.id AS id \n\
+FROM tree \n\
+JOIN json_each(?) seg ON seg.key = tree.idx \n\
+JOIN news_bundles b ON b.name = seg.value AND \n  ((tree.id IS NULL AND b.parent_bundle_id IS NULL) OR b.parent_bundle_id = tree.id)";
+        assert_eq!(BUNDLE_STEP_SQL, expected);
+    }
+
+    #[test]
+    fn category_step_sql_matches_expected() {
+        let expected = "SELECT tree.idx + 1 AS idx, b.id AS id \n\
+FROM tree \n\
+JOIN json_each(?) seg ON seg.key = tree.idx \n\
+LEFT JOIN news_bundles b ON b.name = seg.value AND \n  ((tree.id IS NULL AND b.parent_bundle_id IS NULL) OR b.parent_bundle_id = tree.id)";
+        assert_eq!(CATEGORY_STEP_SQL, expected);
+    }
 }

--- a/src/news_path.rs
+++ b/src/news_path.rs
@@ -61,6 +61,20 @@ LEFT JOIN news_bundles b ON b.name = seg.value AND \n  ((tree.id IS NULL AND b.p
     }
 
     #[test]
+    fn bundle_body_sql_matches_expected() {
+        assert_eq!(BUNDLE_BODY_SQL, "SELECT id FROM tree WHERE idx = ?");
+    }
+
+    #[test]
+    fn category_body_sql_matches_expected() {
+        let expected = "SELECT c.id AS id \n\
+FROM news_categories c \n\
+JOIN json_each(?) seg ON seg.key = ? \n\
+WHERE c.name = seg.value AND c.bundle_id IS (SELECT id FROM tree WHERE idx = ?)";
+        assert_eq!(CATEGORY_BODY_SQL, expected);
+    }
+
+    #[test]
     fn prepare_path_empty() {
         assert!(prepare_path("").unwrap().is_none());
         assert!(prepare_path("/").unwrap().is_none());


### PR DESCRIPTION
## Summary
- add `news_path` module with shared constants and helper
- use new helper in `bundle_id_from_path` and `category_id_from_path`
- expose `news_path` from crate root

## Testing
- `cargo clippy`
- `cargo test --workspace --quiet`
- `nixie docs/*.md`

------
https://chatgpt.com/codex/tasks/task_e_684741f20fcc8322b8240232562b76af

## Summary by Sourcery

Extract shared SQL and path preparation logic into a new news_path module and update all news path lookup functions and error handling to use it

Enhancements:
- Introduce news_path module with shared CTE SQL constants and prepare_path helper
- Refactor bundle and category path lookup functions to use shared SQL constants and helper
- Rename CategoryError to PathLookupError and add a serde_json error variant
- Update command error replies to handle the new PathLookupError type
- Expose the news_path module from the crate root

Tests:
- Add unit tests for SQL constants and prepare_path helper behavior