### PR TITLE
Integrate ortho-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +236,18 @@ checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-dispatch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a558b9547b590c876e46e301da15d3b0e93b0384fd50d2c7870f7ea86760df5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -452,6 +479,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,7 +759,9 @@ dependencies = [
  "diesel-async",
  "diesel_cte_ext",
  "diesel_migrations",
+ "figment",
  "futures-util",
+ "ortho_config",
  "rand",
  "serde",
  "serde_json",
@@ -718,6 +769,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "uncased",
+ "xdg",
 ]
 
 [[package]]
@@ -768,6 +821,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ortho_config"
+version = "0.1.0"
+source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+dependencies = [
+ "clap",
+ "clap-dispatch",
+ "figment",
+ "ortho_config_macros",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml",
+ "uncased",
+ "xdg",
+]
+
+[[package]]
+name = "ortho_config_macros"
+version = "0.1.0"
+source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +879,29 @@ dependencies = [
  "base64ct",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -851,6 +954,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1244,6 +1360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1623,18 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "argon2",
  "chrono",
  "clap",
+ "clap-dispatch",
  "diesel",
  "diesel-async",
  "diesel_cte_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +758,7 @@ dependencies = [
 name = "mxd"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "argon2",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "android-tzdata"
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1"
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 uncased = "0.9"
 xdg = "3"
+anyhow = "1"
 
 [dev-dependencies]
 test-util = { path = "test-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,16 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
+ortho_config = { git = "https://github.com/leynos/ortho-config" }
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 diesel_cte_ext = { path = "diesel_cte_ext" }
 futures-util = "0.3"
 tracing = "0.1"
+figment = { version = "0.10", features = ["toml", "env"] }
+uncased = "0.9"
+xdg = "3"
 
 [dev-dependencies]
 test-util = { path = "test-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 diesel_cte_ext = { path = "diesel_cte_ext" }
 futures-util = "0.3"
 tracing = "0.1"
-figment = { version = "0.10", features = ["toml", "env"] }
+figment = { version = "0.10", features = ["toml", "env", "test"] }
 uncased = "0.9"
 xdg = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ figment = { version = "0.10", features = ["toml", "env", "test"] }
 uncased = "0.9"
 xdg = "3"
 anyhow = "1"
+clap-dispatch = "0.1"
 
 [dev-dependencies]
 test-util = { path = "test-util" }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -146,7 +146,7 @@ impl Command {
         peer: SocketAddr,
         pool: DbPool,
         session: &mut crate::handler::Session,
-    ) -> Result<Transaction, Box<dyn std::error::Error>> {
+    ) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>> {
         match self {
             Command::Login {
                 username,
@@ -207,7 +207,7 @@ async fn run_news_tx<F>(
     pool: DbPool,
     header: FrameHeader,
     op: F,
-) -> Result<Transaction, Box<dyn std::error::Error>>
+) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>>
 where
     for<'c> F: FnOnce(
             &'c mut DbConnection,
@@ -256,7 +256,7 @@ async fn handle_category_list(
     pool: DbPool,
     header: FrameHeader,
     path: Option<String>,
-) -> Result<Transaction, Box<dyn std::error::Error>> {
+) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>> {
     run_news_tx(pool, header, move |conn| {
         Box::pin(async move {
             let names = list_names_at_path(conn, path.as_deref()).await?;
@@ -274,7 +274,7 @@ async fn handle_article_titles(
     pool: DbPool,
     header: FrameHeader,
     path: String,
-) -> Result<Transaction, Box<dyn std::error::Error>> {
+) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>> {
     run_news_tx(pool, header, move |conn| {
         Box::pin(async move {
             let names = list_article_titles(conn, &path).await?;
@@ -293,7 +293,7 @@ async fn handle_article_data(
     header: FrameHeader,
     path: String,
     article_id: i32,
-) -> Result<Transaction, Box<dyn std::error::Error>> {
+) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>> {
     use crate::db::get_article;
     run_news_tx(pool, header, move |conn| {
         Box::pin(async move {
@@ -359,7 +359,7 @@ async fn handle_post_article(
     flags: i32,
     data_flavor: String,
     data: String,
-) -> Result<Transaction, Box<dyn std::error::Error>> {
+) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>> {
     use crate::db::create_root_article;
     run_news_tx(pool, header, move |conn| {
         Box::pin(async move {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -27,7 +27,7 @@ pub async fn handle_request(
     ctx: &Context,
     session: &mut Session,
     frame: &[u8],
-) -> Result<Transaction, Box<dyn std::error::Error>> {
+) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>> {
     let tx = parse_transaction(frame)?;
     let cmd = Command::from_transaction(tx)?;
     let reply = cmd.process(ctx.peer, ctx.pool.clone(), session).await?;

--- a/src/login.rs
+++ b/src/login.rs
@@ -15,7 +15,7 @@ pub async fn handle_login(
     username: String,
     password: String,
     header: FrameHeader,
-) -> Result<Transaction, Box<dyn std::error::Error>> {
+) -> Result<Transaction, Box<dyn std::error::Error + Send + Sync + 'static>> {
     let mut conn = pool.get().await?;
     let user = get_user_by_name(&mut conn, &username).await?;
     let (error, payload) = if let Some(u) = user {

--- a/validator/Cargo.lock
+++ b/validator/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +818,7 @@ dependencies = [
 name = "mxd"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "argon2",
  "chrono",
  "clap",

--- a/validator/Cargo.lock
+++ b/validator/Cargo.lock
@@ -115,6 +115,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +199,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +251,18 @@ checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-dispatch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a558b9547b590c876e46e301da15d3b0e93b0384fd50d2c7870f7ea86760df5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -488,6 +515,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +681,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,13 +819,17 @@ dependencies = [
  "diesel-async",
  "diesel_cte_ext",
  "diesel_migrations",
+ "figment",
  "futures-util",
+ "ortho_config",
  "rand",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tracing",
+ "uncased",
+ "xdg",
 ]
 
 [[package]]
@@ -840,6 +893,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ortho_config"
+version = "0.1.0"
+source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+dependencies = [
+ "clap",
+ "clap-dispatch",
+ "figment",
+ "ortho_config_macros",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml",
+ "uncased",
+ "xdg",
+]
+
+[[package]]
+name = "ortho_config_macros"
+version = "0.1.0"
+source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +951,29 @@ dependencies = [
  "base64ct",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -923,6 +1026,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1367,6 +1483,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1835,18 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/validator/Cargo.lock
+++ b/validator/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "argon2",
  "chrono",
  "clap",
+ "clap-dispatch",
  "diesel",
  "diesel-async",
  "diesel_cte_ext",


### PR DESCRIPTION
## Summary
- add `ortho_config` and related crates
- parse environment and file configuration with OrthoConfig
- merge CLI over config defaults in main

## Testing
- `cargo test`
- `cargo test` in `validator`
- `nixie docs/*.md`
- `cargo clippy`

------
https://chatgpt.com/codex/tasks/task_e_684757264a488322816b21e1b8fb23ae

## Summary by Sourcery

Integrate OrthoConfig into the application to unify configuration loading from environment, dotfiles, and CLI, introduce a `create-user` subcommand, and refactor error handling and dependency management accordingly.

New Features:
- Introduce OrthoConfig-based `AppConfig` to load defaults from environment variables, dotfiles, and CLI flags
- Add `create-user` subcommand powered by clap-dispatch with automatic merging of CLI inputs over config defaults

Enhancements:
- Refactor `main`, handler, and command modules to use the new config system and merge CLI over config defaults
- Standardize error return types to `Box<dyn Error + Send + Sync + 'static>` across async handlers
- Rename `Context` to `HandlerContext` and streamline function signatures

Build:
- Add `ortho_config`, `figment`, `clap-dispatch`, `xdg`, `uncased`, and `anyhow` dependencies in Cargo.toml

Tests:
- Add unit tests for environment, file, and CLI configuration loading with OrthoConfig