### PR TITLE
Ensure handshake replies are validated

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -129,6 +129,9 @@ pub fn handshake(stream: &mut TcpStream) -> std::io::Result<()> {
     stream.write_all(&buf)?;
     let mut reply = [0u8; 8];
     stream.read_exact(&mut reply)?;
+    assert_eq!(&reply[0..4], b"TRTP", "protocol mismatch in handshake reply");
+    let code = u32::from_be_bytes(reply[4..8].try_into().unwrap());
+    assert_eq!(code, 0, "handshake returned error code {}", code);
     Ok(())
 }
 

--- a/tests/payload_reject.rs
+++ b/tests/payload_reject.rs
@@ -15,6 +15,13 @@ fn handshake(stream: &mut TcpStream) -> std::io::Result<()> {
     stream.write_all(&buf)?;
     let mut reply = [0u8; 8];
     stream.read_exact(&mut reply)?;
+    assert_eq!(
+        &reply[0..4],
+        b"TRTP",
+        "protocol mismatch in handshake reply"
+    );
+    let code = u32::from_be_bytes(reply[4..8].try_into().unwrap());
+    assert_eq!(code, 0, "handshake returned error code {}", code);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- assert on protocol and error code in `handshake` helper
- add the same validation to the payload reject test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `mxd`)*
- `cargo clippy --manifest-path validator/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --all --quiet`
- `cargo test --manifest-path validator/Cargo.toml --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68475629079c83229111e9bf537c63a7

## Summary by Sourcery

Ensure handshake helpers and tests validate the protocol header and error code in handshake replies

Enhancements:
- Validate handshake replies in test util by asserting protocol header and error code

Tests:
- Add protocol and error code validation to the payload_reject handshake test