### PR TITLE
Pin ortho-config to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -831,14 +831,13 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 [[package]]
 name = "ortho_config"
 version = "0.1.0"
-source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+source = "git+https://github.com/leynos/ortho-config?tag=v0.1.0#f7524ef4e57a1e5bb84ab17871711445e5875b74"
 dependencies = [
  "clap",
  "clap-dispatch",
  "figment",
  "ortho_config_macros",
  "serde",
- "serde_json",
  "thiserror",
  "toml",
  "uncased",
@@ -848,7 +847,7 @@ dependencies = [
 [[package]]
 name = "ortho_config_macros"
 version = "0.1.0"
-source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+source = "git+https://github.com/leynos/ortho-config?tag=v0.1.0#f7524ef4e57a1e5bb84ab17871711445e5875b74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1047,7 +1046,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1191,7 +1190,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
-ortho_config = { git = "https://github.com/leynos/ortho-config" }
+ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.1.0" }
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/validator/Cargo.lock
+++ b/validator/Cargo.lock
@@ -499,7 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -903,14 +903,13 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 [[package]]
 name = "ortho_config"
 version = "0.1.0"
-source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+source = "git+https://github.com/leynos/ortho-config?tag=v0.1.0#f7524ef4e57a1e5bb84ab17871711445e5875b74"
 dependencies = [
  "clap",
  "clap-dispatch",
  "figment",
  "ortho_config_macros",
  "serde",
- "serde_json",
  "thiserror",
  "toml",
  "uncased",
@@ -920,7 +919,7 @@ dependencies = [
 [[package]]
 name = "ortho_config_macros"
 version = "0.1.0"
-source = "git+https://github.com/leynos/ortho-config#54c53fccf2cc1602eef4564c12bba4f78cc55242"
+source = "git+https://github.com/leynos/ortho-config?tag=v0.1.0#f7524ef4e57a1e5bb84ab17871711445e5875b74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1157,7 +1156,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1170,7 +1169,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1314,7 +1313,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- use the v0.1.0 tag for `ortho-config` in Cargo.toml
- update lockfiles to reflect the new dependency source

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: doc_markdown, items-after-statements, missing_errors_doc, double_must_use)*
- `cargo test` *(fails to compile mxd bin)*
- `cargo test -p validator --manifest-path validator/Cargo.toml`
- `nixie docs/chat-schema.md`

------
https://chatgpt.com/codex/tasks/task_e_6848332ad1748322864886d4fc2f4c6a