### PR TITLE
Fix encode_params overflow handling

### DIFF
--- a/src/bin/gen_corpus.rs
+++ b/src/bin/gen_corpus.rs
@@ -13,7 +13,7 @@ fn login_tx() -> Transaction {
         (FieldId::Login, b"alice".as_ref()),
         (FieldId::Password, b"secret".as_ref()),
     ];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params).expect("encode");
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -44,7 +44,7 @@ fn get_file_list_tx() -> Transaction {
 
 fn news_category_root_tx() -> Transaction {
     let params = [(FieldId::NewsPath, b"/".as_ref())];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params).expect("encode");
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -59,7 +59,7 @@ fn news_category_root_tx() -> Transaction {
 
 fn news_article_titles_tx() -> Transaction {
     let params = [(FieldId::NewsPath, b"General".as_ref())];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params).expect("encode");
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -79,7 +79,7 @@ fn news_article_data_tx() -> Transaction {
         (FieldId::NewsArticleId, id_bytes.as_ref()),
         (FieldId::NewsDataFlavor, b"text/plain".as_ref()),
     ];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params).expect("encode");
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -175,7 +175,7 @@ impl Command {
                     .iter()
                     .map(|f| (FieldId::FileName, f.name.as_bytes()))
                     .collect();
-                let payload = encode_params(&params);
+                let payload = encode_params(&params)?;
                 Ok(Transaction {
                     header: reply_header(&header, 0, payload.len()),
                     payload,
@@ -228,7 +228,7 @@ where
     match pool.get().await {
         Ok(mut conn) => match op(&mut conn).await {
             Ok(params) => {
-                let payload = encode_vec_params(&params);
+                let payload = encode_vec_params(&params)?;
                 Ok(Transaction {
                     header: reply_header(&header, 0, payload.len()),
                     payload,

--- a/src/login.rs
+++ b/src/login.rs
@@ -24,7 +24,7 @@ pub async fn handle_login(
             let params = encode_params(&[(
                 FieldId::Version,
                 &crate::protocol::CLIENT_VERSION.to_be_bytes(),
-            )]);
+            )])?;
             (0u32, params)
         } else {
             (1u32, Vec::new())

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ async fn main() -> Result<()> {
         let cmd = match cmd {
             Commands::CreateUser(args) => {
                 let defaults: CreateUserArgs = load_subcommand_config("MXD_", "create-user")?;
-                Commands::CreateUser(merge_cli_over_defaults(defaults, args))
+                Commands::CreateUser(merge_cli_over_defaults(&defaults, &args)?)
             }
         };
         return cmd.run(&cfg);

--- a/tests/file_list.rs
+++ b/tests/file_list.rs
@@ -21,7 +21,7 @@ fn list_files_acl() -> Result<(), Box<dyn std::error::Error>> {
         (FieldId::Login, b"alice".as_ref()),
         (FieldId::Password, b"secret".as_ref()),
     ];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -90,7 +90,7 @@ fn list_files_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     handshake(&mut stream)?;
 
     // send GetFileNameList with bogus payload
-    let params = encode_params(&[(FieldId::Other(999), b"bogus".as_ref())]);
+    let params = encode_params(&[(FieldId::Other(999), b"bogus".as_ref())])?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -36,7 +36,7 @@ fn list_news_articles_invalid_path() -> Result<(), Box<dyn std::error::Error>> {
     handshake(&mut stream)?;
 
     let params = vec![(FieldId::NewsPath, b"Missing".as_ref())];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -68,7 +68,7 @@ fn list_news_articles_valid_path() -> Result<(), Box<dyn std::error::Error>> {
     handshake(&mut stream)?;
 
     let params = vec![(FieldId::NewsPath, b"General".as_ref())];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -155,7 +155,7 @@ fn get_news_article_data() -> Result<(), Box<dyn std::error::Error>> {
     let id_bytes = 1i32.to_be_bytes();
     params.push((FieldId::NewsArticleId, id_bytes.as_ref()));
     params.push((FieldId::NewsDataFlavor, b"text/plain".as_ref()));
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -226,7 +226,7 @@ fn post_news_article_root() -> Result<(), Box<dyn std::error::Error>> {
     params.push((FieldId::NewsArticleFlags, flag_bytes.as_ref()));
     params.push((FieldId::NewsDataFlavor, b"text/plain".as_ref()));
     params.push((FieldId::NewsArticleData, b"hi".as_ref()));
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -63,7 +63,7 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
 
     let params = vec![(FieldId::NewsPath, b"/".as_ref())];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -150,7 +150,7 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(&reply[0..4], b"TRTP");
     assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
 
-    let payload = encode_params(&[]);
+    let payload = encode_params(&[])?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -222,7 +222,7 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
     assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
 
     let params = vec![(FieldId::NewsPath, b"some/path".as_ref())];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -267,7 +267,7 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(&reply[0..4], b"TRTP");
     assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
 
-    let payload = encode_params(&[]);
+    let payload = encode_params(&[])?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -369,7 +369,7 @@ fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
     stream.read_exact(&mut reply)?;
 
     let params = vec![(FieldId::NewsPath, b"Bundle/Sub".as_ref())];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params)?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,

--- a/tests/payload_reject.rs
+++ b/tests/payload_reject.rs
@@ -32,7 +32,7 @@ fn download_banner_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
     handshake(&mut stream)?;
 
-    let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())]);
+    let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())])?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -62,7 +62,7 @@ fn user_name_list_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
     handshake(&mut stream)?;
 
-    let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())]);
+    let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())])?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -247,7 +247,7 @@ fn duplicate_news_category_fields_allowed() {
         (FieldId::NewsCategory, b"General".as_ref()),
         (FieldId::NewsCategory, b"Updates".as_ref()),
     ];
-    let payload = encode_params(&params);
+    let payload = encode_params(&params).unwrap();
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,


### PR DESCRIPTION
## Summary
- avoid unwrapping `u16` conversions in `encode_params`
- adjust call sites and tests for new `Result` return type
- fix compile error when merging CLI defaults

## Testing
- `cargo clippy`
- `cargo test --lib --tests` *(fails: server exited before signaling readiness)*
- `cargo test` in `validator` crate

------
https://chatgpt.com/codex/tasks/task_e_68489b22d85c832283d06fbde6f1bdc1