### PR TITLE
Add must_use annotations

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -65,6 +65,7 @@ impl Command {
     ///
     /// # Errors
     /// Returns an error if required parameters are missing or cannot be parsed.
+    #[must_use = "handle the result"]
     pub fn from_transaction(tx: Transaction) -> Result<Self, &'static str> {
         let ty = TransactionType::from(tx.header.ty);
         if !ty.allows_payload() && !tx.payload.is_empty() {
@@ -150,6 +151,7 @@ impl Command {
     /// # Errors
     /// Returns an error if database access fails or the command cannot be
     /// handled.
+    #[must_use = "handle the result"]
     pub async fn process(
         self,
         peer: SocketAddr,

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,10 +11,11 @@ pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 pub type DbConnection = SyncConnectionWrapper<SqliteConnection>;
 pub type DbPool = Pool<DbConnection>;
 
-/// Create a pooled connection to the SQLite database.
+/// Create a pooled connection to the `SQLite` database.
 ///
 /// # Panics
 /// Panics if the connection pool cannot be created.
+#[must_use = "handle the pool"]
 pub async fn establish_pool(database_url: &str) -> DbPool {
     let config = AsyncDieselConnectionManager::<DbConnection>::new(database_url);
     Pool::builder()
@@ -27,6 +28,7 @@ pub async fn establish_pool(database_url: &str) -> DbPool {
 ///
 /// # Errors
 /// Returns any error produced by Diesel while running migrations.
+#[must_use = "handle the result"]
 pub async fn run_migrations(conn: &mut DbConnection) -> QueryResult<()> {
     use diesel::result::Error as DieselError;
     conn.spawn_blocking(|c| {
@@ -44,6 +46,7 @@ pub async fn run_migrations(conn: &mut DbConnection) -> QueryResult<()> {
 ///
 /// # Errors
 /// Returns any error produced by the underlying database query.
+#[must_use = "handle the result"]
 pub async fn get_user_by_name(
     conn: &mut DbConnection,
     name: &str,
@@ -60,6 +63,7 @@ pub async fn get_user_by_name(
 ///
 /// # Errors
 /// Returns any error produced by the insertion query.
+#[must_use = "handle the result"]
 pub async fn create_user(
     conn: &mut DbConnection,
     user: &crate::models::NewUser<'_>,
@@ -118,6 +122,7 @@ async fn bundle_id_from_path(
 ///
 /// # Errors
 /// Returns an error if the path is invalid or the query fails.
+#[must_use = "handle the result"]
 pub async fn list_names_at_path(
     conn: &mut DbConnection,
     path: Option<&str>,
@@ -163,6 +168,7 @@ pub async fn list_names_at_path(
 ///
 /// # Errors
 /// Returns any error produced by the database.
+#[must_use = "handle the result"]
 pub async fn create_category(
     conn: &mut DbConnection,
     cat: &crate::models::NewCategory<'_>,
@@ -178,6 +184,7 @@ pub async fn create_category(
 ///
 /// # Errors
 /// Returns any error produced by the database.
+#[must_use = "handle the result"]
 pub async fn create_bundle(
     conn: &mut DbConnection,
     bun: &crate::models::NewBundle<'_>,
@@ -193,6 +200,7 @@ pub async fn create_bundle(
 ///
 /// # Errors
 /// Returns an error if the path is invalid or the query fails.
+#[must_use = "handle the result"]
 pub async fn get_article(
     conn: &mut DbConnection,
     path: &str,
@@ -247,12 +255,13 @@ async fn category_id_from_path(
 ///
 /// # Errors
 /// Returns an error if the path is invalid or the query fails.
+#[must_use = "handle the result"]
 pub async fn list_article_titles(
     conn: &mut DbConnection,
     path: &str,
 ) -> Result<Vec<String>, PathLookupError> {
-    let cat_id = category_id_from_path(conn, path).await?;
     use crate::schema::news_articles::dsl as a;
+    let cat_id = category_id_from_path(conn, path).await?;
     let titles = a::news_articles
         .filter(a::category_id.eq(cat_id))
         .filter(a::parent_article_id.is_null())
@@ -268,6 +277,7 @@ pub async fn list_article_titles(
 ///
 /// # Errors
 /// Returns an error if the path is invalid or the insertion fails.
+#[must_use = "handle the result"]
 pub async fn create_root_article(
     conn: &mut DbConnection,
     path: &str,
@@ -330,6 +340,7 @@ pub async fn create_root_article(
 ///
 /// # Errors
 /// Returns any error produced by the database.
+#[must_use = "handle the result"]
 pub async fn create_file(
     conn: &mut DbConnection,
     file: &crate::models::NewFileEntry<'_>,
@@ -342,6 +353,7 @@ pub async fn create_file(
 ///
 /// # Errors
 /// Returns any error produced by the database.
+#[must_use = "handle the result"]
 pub async fn add_file_acl(
     conn: &mut DbConnection,
     acl: &crate::models::NewFileAcl,
@@ -359,6 +371,7 @@ pub async fn add_file_acl(
 ///
 /// # Errors
 /// Returns any error produced by the database.
+#[must_use = "handle the result"]
 pub async fn list_files_for_user(
     conn: &mut DbConnection,
     uid: i32,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -24,6 +24,10 @@ impl Context {
 }
 
 /// Parse and handle a single request frame without performing network I/O.
+///
+/// # Errors
+/// Returns an error if the transaction cannot be parsed or processed.
+#[must_use = "handle the result"]
 pub async fn handle_request(
     ctx: &Context,
     session: &mut Session,

--- a/src/login.rs
+++ b/src/login.rs
@@ -8,6 +8,10 @@ use crate::users::verify_password;
 use tracing::{info, warn};
 
 /// Handle a user login request.
+///
+/// # Errors
+/// Returns an error if database access fails or credentials are invalid.
+#[must_use = "handle the result"]
 pub async fn handle_login(
     peer: SocketAddr,
     session: &mut crate::handler::Session,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -47,7 +47,10 @@ pub enum HandshakeError {
 }
 
 /// Parse the 12-byte client handshake message.
-#[must_use]
+///
+/// # Errors
+/// Returns an error if the message is malformed or the version is unsupported.
+#[must_use = "handle the result"]
 pub fn parse_handshake(buf: &[u8; HANDSHAKE_LEN]) -> Result<Handshake, HandshakeError> {
     if &buf[0..4] != PROTOCOL_ID {
         return Err(HandshakeError::InvalidProtocol);
@@ -66,7 +69,7 @@ pub fn parse_handshake(buf: &[u8; HANDSHAKE_LEN]) -> Result<Handshake, Handshake
 }
 
 /// Convert a [`HandshakeError`] into a numeric error code for clients.
-#[must_use]
+#[must_use = "handle the result"]
 pub fn handshake_error_code(err: &HandshakeError) -> u32 {
     match err {
         HandshakeError::InvalidProtocol => HANDSHAKE_ERR_INVALID,
@@ -82,6 +85,7 @@ pub fn handshake_error_code(err: &HandshakeError) -> u32 {
 ///
 /// # Errors
 /// Returns any I/O error encountered while sending the reply.
+#[must_use = "handle the result"]
 pub async fn write_handshake_reply<W>(writer: &mut W, error_code: u32) -> io::Result<()>
 where
     W: AsyncWriteExt + Unpin,

--- a/src/users.rs
+++ b/src/users.rs
@@ -8,6 +8,7 @@ use argon2::{
 ///
 /// # Errors
 /// Returns any error produced by the underlying hashing implementation.
+#[must_use = "handle the result"]
 pub fn hash_password(argon2: &Argon2, pw: &str) -> Result<String, Error> {
     let salt = SaltString::generate(&mut OsRng);
     Ok(argon2.hash_password(pw.as_bytes(), &salt)?.to_string())


### PR DESCRIPTION
## Summary
- mark public APIs with `#[must_use]` and document errors
- update docs to fix clippy lints

## Testing
- `cargo clippy --all-targets -- -D warnings` *(fails: cast-possible-truncation and unexpected cfg in main)*
- `cargo test --all --no-fail-fast` *(fails to compile bin due to unexpected cfg and type mismatch)*
- `cargo test --no-fail-fast` in validator crate
- `nixie docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_68489a3c31a0832299e003f2f5ffddfb