### PR TITLE
Fix compile error and CLI defaults

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,19 +86,19 @@ impl Run for CreateUserArgs {
 #[ortho_config(prefix = "MXD_")]
 struct AppConfig {
     #[ortho_config(default = "0.0.0.0:5500".to_string())]
-    #[arg(long)]
+    #[arg(long, default_value_t = String::from("0.0.0.0:5500"))]
     bind: String,
     #[ortho_config(default = "mxd.db".to_string())]
-    #[arg(long)]
+    #[arg(long, default_value_t = String::from("mxd.db"))]
     database: String,
     #[ortho_config(default = Params::DEFAULT_M_COST)]
-    #[arg(long)]
+    #[arg(long, default_value_t = Params::DEFAULT_M_COST)]
     argon2_m_cost: u32,
     #[ortho_config(default = Params::DEFAULT_T_COST)]
-    #[arg(long)]
+    #[arg(long, default_value_t = Params::DEFAULT_T_COST)]
     argon2_t_cost: u32,
     #[ortho_config(default = Params::DEFAULT_P_COST)]
-    #[arg(long)]
+    #[arg(long, default_value_t = Params::DEFAULT_P_COST)]
     argon2_p_cost: u32,
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -465,7 +465,7 @@ pub fn decode_params_map(
 /// Returns [`TransactionError::PayloadTooLarge`] if the number of parameters
 /// or any data length exceeds `u16::MAX`.
 #[must_use = "use the encoded bytes"]
-pub fn encode_params(params: &[(FieldId, &[u8])]) -> Vec<u8>, TransactionError> {
+pub fn encode_params(params: &[(FieldId, &[u8])]) -> Result<Vec<u8>, TransactionError> {
     let mut buf = Vec::new();
     buf.extend_from_slice(
         &u16::try_from(params.len())
@@ -491,7 +491,7 @@ pub fn encode_params(params: &[(FieldId, &[u8])]) -> Vec<u8>, TransactionError> 
 /// form expected by [`encode_params`]. It avoids repeating the
 /// conversion logic at call sites.
 #[must_use = "use the encoded bytes"]
-pub fn encode_vec_params(params: &[(FieldId, Vec<u8>)]) -> Vec<u8>, TransactionError> {
+pub fn encode_vec_params(params: &[(FieldId, Vec<u8>)]) -> Result<Vec<u8>, TransactionError> {
     let borrowed: Vec<(FieldId, &[u8])> = params
         .iter()
         .map(|(id, bytes)| (*id, bytes.as_slice()))


### PR DESCRIPTION
## Summary
- correct return types for encode params helpers
- add default values to CLI arguments so tests can run

## Testing
- `cargo test --quiet`
- `cargo test --quiet` in `validator` crate

------
https://chatgpt.com/codex/tasks/task_e_6848a9422fd48322b8430e2e855905f6