### PR TITLE
Add code coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: taiki-e/install-action@cargo-llvm-cov@v2
+
+      - name: Generate coverage
+        run: |
+          cargo llvm-cov --workspace --all-features \
+                         --lcov --output-path lcov.info \
+                         --codecov --output-path codecov.json
+
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info,codecov.json
+          fail_ci_if_error: true
+          flags: unittests
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      target: 80%
+    project:
+      threshold: 0.5%
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -490,6 +490,10 @@ pub fn encode_params(params: &[(FieldId, &[u8])]) -> Result<Vec<u8>, Transaction
 /// This converts a `&[(FieldId, Vec<u8>)]` slice into the borrowed
 /// form expected by [`encode_params`]. It avoids repeating the
 /// conversion logic at call sites.
+///
+/// # Errors
+/// Returns a [`TransactionError`] if any of the parameters exceed the
+/// allowed size when encoded.
 #[must_use = "use the encoded bytes"]
 pub fn encode_vec_params(params: &[(FieldId, Vec<u8>)]) -> Result<Vec<u8>, TransactionError> {
     let borrowed: Vec<(FieldId, &[u8])> = params


### PR DESCRIPTION
## Summary
- document potential error when encoding vector params
- add a coverage workflow that posts Codecov results on PRs
- enforce coverage thresholds via `codecov.yml`

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test --quiet`
- `cargo test --quiet` in `validator/`


------
https://chatgpt.com/codex/tasks/task_e_6848aca4bdbc83229b815dd3e7be6c07