### PR TITLE
Switch validator to hx client

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Integration tests live in the repository's `tests/` directory.
 
 ## Validation harness
 
-The `validator` crate provides a compatibility check using the `shx` client and
-`expectrl` to ensure mxd speaks the Hotline protocol correctly. Install `shx`
+The `validator` crate provides a compatibility check using the `hx` client and
+`expectrl` to ensure mxd speaks the Hotline protocol correctly. Install `hx`
 version 0.2.4 and make sure it's on your `PATH` before running:
 
 ```bash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,7 +52,7 @@ already been implemented in the repository are checked off.
 
 ## Compatibility and Testing
 
-- [x] Integration validator crate using `shx`
+- [x] Integration validator crate using `hx`
 - [x] Fuzzing harness with AFL++
   - [ ] Regular execution of fuzzing
 - [ ] Full protocol coverage in tests

--- a/validator/Cargo.lock
+++ b/validator/Cargo.lock
@@ -1514,7 +1514,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "validator"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "expectrl",
+ "mxd",
  "nix 0.27.1",
  "tempfile",
  "test-util",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -11,3 +11,5 @@ nix = { version = "0.27", optional = false, features = ["signal"] }
 
 [dev-dependencies]
 test-util = { path = "../test-util" }
+mxd = { path = ".." }
+argon2 = { version = "0.5", features = ["std"] }

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,2 +1,2 @@
-// Validator crate providing integration tests using `expectrl` and the `shx` client.
+// Validator crate providing integration tests using `expectrl` and the `hx` client.
 // Currently no public API is exposed. Tests are located in `tests/`.

--- a/validator/tests/login.rs
+++ b/validator/tests/login.rs
@@ -4,39 +4,36 @@ use which::which;
 
 #[test]
 fn login_validation() -> Result<(), Box<dyn std::error::Error>> {
-    if which("shx").is_err() {
-        eprintln!("shx not installed; skipping test");
+    if which("hx").is_err() {
+        eprintln!("hx not installed; skipping test");
         return Ok(());
     }
 
     let server = TestServer::start_with_setup("../Cargo.toml", |db| {
-        let status = std::process::Command::new("cargo")
-            .args([
-                "run",
-                "--manifest-path",
-                "../Cargo.toml",
-                "--quiet",
-                "--",
-                "--database",
-                db.to_str().expect("db path utf8"),
-                "create-user",
-                "test",
-                "secret",
-            ])
-            .status()?;
-        if status.success() {
-            Ok(())
-        } else {
-            Err("failed to create user".into())
-        }
+        test_util::with_db(db, |conn| {
+            Box::pin(async move {
+                use argon2::Argon2;
+                use mxd::models::NewUser;
+                use mxd::users::hash_password;
+                use mxd::db::create_user;
+
+                let argon2 = Argon2::default();
+                let hashed = hash_password(&argon2, "secret")?;
+                let new_user = NewUser {
+                    username: "test",
+                    password: &hashed,
+                };
+                create_user(conn, &new_user).await?;
+                Ok(())
+            })
+        })
     })?;
 
     let port = server.port();
-    let mut p = spawn(format!("shx 127.0.0.1 {}", port))?;
-    p.expect(Regex("MXD"))?;
-    p.send_line("LOGIN test secret")?;
-    p.expect(Regex("OK"))?;
+    let mut p = spawn("hx")?;
+    p.expect(Regex("HX"))?;
+    p.send_line(format!("/server -l test -p secret 127.0.0.1 {}", port))?;
+    p.expect(Regex("connected"))?;
     p.send_line("/quit")?;
-    p.expect(Regex("OK"))?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- use the hx binary for validator tests
- create test users directly via the database
- document hx usage in README and roadmap

## Testing
- `cargo clippy --manifest-path validator/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path validator/Cargo.toml --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6848b7668d4c83228cc03e4a608e2c18