### PR TITLE
Add SQLite feature checks and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Tokio keeps everything asynchronous, and this project aims to be the skeleton
 for a more complete Hotline implementation. See the `docs/` directory for a dive
 into the protocol and how we juggle SQLite and PostgreSQL migrations.
 
+If you use SQLite as the persistence engine, ensure your build of SQLite
+includes the `JSON1` extension and support for recursive common table
+expressions (CTEs). The server verifies these features on startup and will
+fail to run if they are missing.
+
 ## Running
 
 Build the project and run the daemon. Specify a bind address and

--- a/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
+++ b/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
@@ -149,6 +149,7 @@ where
 * **Use backend-suffixed files (`up.postgres.sql` / `up.sqlite.sql`)** whenever DDL diverges – Diesel automatically chooses the correct one.
 * Keep Rust-side types in `schema.rs` backend-agnostic (`Integer`, `Text`, `Bool`, `Timestamp`).
 * For features that SQLite simply lacks (JSONB, expression indexes, row-level security) you must either introduce conditional code paths or limit those features to the Postgres deployment.
+* When using SQLite, ensure your SQLite build was compiled with the `JSON1` extension and support for recursive CTEs.
 
 With that structure you can `cargo build --features postgres` for the version that targets *postgresql-embedded* (or a real server) and `cargo build --features sqlite` for the lightweight single-file deployment, without touching the migration history.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,9 @@ use tokio::task::JoinSet;
 use tokio::time::timeout;
 
 use diesel_async::AsyncConnection;
-use mxd::db::{DbConnection, DbPool, create_user, establish_pool, run_migrations};
+use mxd::db::{
+    DbConnection, DbPool, audit_sqlite_features, create_user, establish_pool, run_migrations,
+};
 use mxd::handler::{Context as HandlerContext, Session, handle_request};
 use mxd::models;
 use mxd::protocol;
@@ -140,6 +142,7 @@ async fn main() -> Result<()> {
     let pool = establish_pool(&database).await;
     {
         let mut conn = pool.get().await.expect("failed to get db connection");
+        audit_sqlite_features(&mut conn).await?;
         run_migrations(&mut conn).await?;
     }
 


### PR DESCRIPTION
## Summary
- verify JSON1 and recursive CTEs on startup
- mention SQLite feature requirements in README and database guide
- add audit feature unit test

## Testing
- `cargo fmt --all`
- `cargo clippy`
- `cargo test`
- `cd validator && cargo test`
- `nixie docs/*.md` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848b6eb13fc832284a60a7ee53c55d7