### PR TITLE
Generalize news path CTE to support multiple backends

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel::sqlite::SqliteConnection;
+use diesel::sqlite::{Sqlite, SqliteConnection};
 use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::bb8::Pool;
@@ -134,7 +134,7 @@ async fn bundle_id_from_path(
     let len_i32: i32 = i32::try_from(len).map_err(|_| PathLookupError::InvalidPath)?;
     let body = sql_query(BUNDLE_BODY_SQL).bind::<Integer, _>(len_i32);
 
-    let query = build_path_cte(step, body);
+    let query = build_path_cte::<Sqlite, _, _>(step, body);
 
     let res: Option<BunId> = query.get_result(conn).await.optional()?;
     match res.and_then(|b| b.id) {
@@ -270,7 +270,7 @@ async fn category_id_from_path(
         .bind::<Integer, _>(len_minus_one)
         .bind::<Integer, _>(len_minus_one);
 
-    let query = build_path_cte(step, body);
+    let query = build_path_cte::<Sqlite, _, _>(step, body);
 
     let res: Option<CatId> = query.get_result(conn).await.optional()?;
     res.map(|c| c.id).ok_or(PathLookupError::InvalidPath)


### PR DESCRIPTION
## Summary
- allow `build_path_cte` to work with any `RecursiveBackend`
- update call sites to specify backend type

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6848cc1a27188322847d630bb96287cf