### PR TITLE
Run mdformat for markdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,45 +2,70 @@
 
 ## Code Style and Structure
 
-* **Code is for humans.** Write your code with clarity and empathy—assume a tired teammate will need to debug it at 3 a.m.
-* **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or complexity. Don't echo the obvious.
-* **Clarity over cleverness.** Be concise, but favour explicit over terse or obscure idioms. Prefer code that's easy to follow.
-* **Use functions and composition.** Avoid repetition by extracting reusable logic. Prefer generators or comprehensions, and declarative code to imperative repetition when readable.
-* **Small, meaningful functions.** Functions must be small, clear in purpose, single responsibility, and obey command/query segregation.
-* **Clear commit messages.** Commit messages should be descriptive, explaining what was changed and why.
-* **Name things precisely.** Use clear, descriptive variable and function names. For booleans, prefer names with `is`, `has`, or `should`.
-* **Structure logically.** Each file should encapsulate a coherent module. Group related code (e.g., models + utilities + fixtures) close together.
-* **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers related to a domain concept rather than splitting by type.
+- **Code is for humans.** Write your code with clarity and empathy—assume a
+  tired teammate will need to debug it at 3 a.m.
+- **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or
+  complexity. Don't echo the obvious.
+- **Clarity over cleverness.** Be concise, but favour explicit over terse or
+  obscure idioms. Prefer code that's easy to follow.
+- **Use functions and composition.** Avoid repetition by extracting reusable
+  logic. Prefer generators or comprehensions, and declarative code to imperative
+  repetition when readable.
+- **Small, meaningful functions.** Functions must be small, clear in purpose,
+  single responsibility, and obey command/query segregation.
+- **Clear commit messages.** Commit messages should be descriptive, explaining
+  what was changed and why.
+- **Name things precisely.** Use clear, descriptive variable and function names.
+  For booleans, prefer names with `is`, `has`, or `should`.
+- **Structure logically.** Each file should encapsulate a coherent module. Group
+  related code (e.g., models + utilities + fixtures) close together.
+- **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
+  related to a domain concept rather than splitting by type.
 
 ## Documentation Maintenance
 
-* **Reference:** Use the markdown files within the `docs/` directory as a knowledge base and source of truth for project requirements, dependency choices, and architectural decisions.
-* **Update:** When new decisions are made, requirements change, libraries are added/removed, or architectural patterns evolve, **proactively update** the relevant file(s) in the `docs/` directory to reflect the latest state. Ensure the documentation remains accurate and current.
+- **Reference:** Use the markdown files within the `docs/` directory as a
+  knowledge base and source of truth for project requirements, dependency
+  choices, and architectural decisions.
+- **Update:** When new decisions are made, requirements change, libraries are
+  added/removed, or architectural patterns evolve, **proactively update** the
+  relevant file(s) in the `docs/` directory to reflect the latest state. Ensure
+  the documentation remains accurate and current.
 
 ## Rust Specific Guidance
-This repository is written in Rust and uses Cargo for building and dependency management. Contributors should follow these best practices when working on the project:
 
-* Run `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` before committing.
-* Clippy warnings MUST be disallowed.
-* Where a function is too long, extract meaningfully named helper functions adhering to separation of concerns and CQRS.
-* Where a function has too many parameters, group related parameters in meaningfully named structs.
-* Where a function is returning a large error consider using `Arc` to reduce the amount of data returned.
-* Write unit and behavioural tests for new functionality. Run both before and after making any change.
-* Document public APIs using Rustdoc comments (`///`) so documentation can be generated with cargo doc.
-* Prefer immutable data and avoid unnecessary `mut` bindings.
-* Handle errors with the `Result` type instead of panicking where feasible.
-* Use explicit version ranges in `Cargo.toml` and keep dependencies up-to-date.
-* Avoid `unsafe` code unless absolutely necessary and document any usage clearly.
-* **Do not construct SQL by concatenating strings.** Always use Diesel's query builder or parameter binding to avoid injection vulnerabilities.
+This repository is written in Rust and uses Cargo for building and dependency
+management. Contributors should follow these best practices when working on the
+project:
+
+- Run `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` before
+  committing.
+- Clippy warnings MUST be disallowed.
+- Where a function is too long, extract meaningfully named helper functions
+  adhering to separation of concerns and CQRS.
+- Where a function has too many parameters, group related parameters in
+  meaningfully named structs.
+- Where a function is returning a large error consider using `Arc` to reduce the
+  amount of data returned.
+- Write unit and behavioural tests for new functionality. Run both before and
+  after making any change.
+- Document public APIs using Rustdoc comments (`///`) so documentation can be
+  generated with cargo doc.
+- Prefer immutable data and avoid unnecessary `mut` bindings.
+- Handle errors with the `Result` type instead of panicking where feasible.
+- Use explicit version ranges in `Cargo.toml` and keep dependencies up-to-date.
+- Avoid `unsafe` code unless absolutely necessary and document any usage
+  clearly.
+- **Do not construct SQL by concatenating strings.** Always use Diesel's query
+  builder or parameter binding to avoid injection vulnerabilities.
 
 **Behavioral tests for the `mxd` application should be placed in the repository
 top-level `tests/` directory (not under `validator/tests`).**
 
 ## Markdown Guidance
 
-* Validate Markdown files using `markdownlint`.
-* Validate Markdown Mermaid diagrams using `nixie`.
+- Validate Markdown files using `markdownlint`.
+- Validate Markdown Mermaid diagrams using `nixie`.
 
-**These practices will help maintain a high-quality codebase and make collaboration easier**
-
-
+**These practices will help maintain a high-quality codebase and make
+collaboration easier**

--- a/diesel_cte_ext/README.md
+++ b/diesel_cte_ext/README.md
@@ -1,6 +1,9 @@
 # diesel_cte_ext
 
-`diesel_cte_ext` adds a small helper for building recursive [Common Table Expressions](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE) with Diesel. The crate exports the `with_recursive` function which constructs a query representing a `WITH RECURSIVE` block.
+`diesel_cte_ext` adds a small helper for building recursive
+[Common Table Expressions](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE)
+with Diesel. The crate exports the `with_recursive` function which constructs a
+query representing a `WITH RECURSIVE` block.
 
 ```rust
 use diesel::dsl::sql;
@@ -17,24 +20,28 @@ let rows: Vec<i32> = with_recursive::<diesel::sqlite::Sqlite, _, _, _>(
 .load(&mut conn)?;
 ```
 
-The builder works with either SQLite or PostgreSQL depending on the enabled Cargo feature. It can be used with synchronous or asynchronous Diesel connections.
+The builder works with either SQLite or PostgreSQL depending on the enabled
+Cargo feature. It can be used with synchronous or asynchronous Diesel
+connections.
 
 ## Capabilities
 
-* Construct a single recursive CTE with a seed query, step query and body.
-* Tested with both SQLite and PostgreSQL back ends.
-* Compatible with Diesel 2.x synchronous and `diesel-async` connections.
+- Construct a single recursive CTE with a seed query, step query and body.
+- Tested with both SQLite and PostgreSQL back ends.
+- Compatible with Diesel 2.x synchronous and `diesel-async` connections.
 
 ## Limitations
 
-* Only supports a single CTE block and requires manually listing column names.
-* No integration with Diesel's query DSL or schema inference.
-* Crate is unpublished and APIs may change without notice.
+- Only supports a single CTE block and requires manually listing column names.
+- No integration with Diesel's query DSL or schema inference.
+- Crate is unpublished and APIs may change without notice.
 
 ## Next steps
 
-Future improvements could include typed column support, better integration with Diesel's query builder, and support for multiple chained CTEs.
+Future improvements could include typed column support, better integration with
+Diesel's query builder, and support for multiple chained CTEs.
 
 ## Caveats
 
-This crate is experimental. Error handling is minimal and the API may evolve. Use at your own risk.
+This crate is experimental. Error handling is minimal and the API may evolve.
+Use at your own risk.

--- a/docs/chat-schema.md
+++ b/docs/chat-schema.md
@@ -1,8 +1,10 @@
 # Database Schema Design for HXD Chat Functionality
 
-The following schema maps the chat workflows described in the protocol to a relational design. It mirrors the style used for the news system and keeps compatibility with SQLite.
+The following schema maps the chat workflows described in the protocol to a
+relational design. It mirrors the style used for the news system and keeps
+compatibility with SQLite.
 
----
+______________________________________________________________________
 
 ```mermaid
 erDiagram
@@ -52,7 +54,7 @@ erDiagram
     users       ||--o{ chat_invites    : receives
 ```
 
----
+______________________________________________________________________
 
 ```sql
 CREATE TABLE chat_rooms (
@@ -94,11 +96,22 @@ CREATE INDEX idx_chat_messages_user ON chat_messages(user_id);
 CREATE INDEX idx_chat_invites_invited ON chat_invites(invited_user_id);
 ```
 
-### Why these tables?
+## Why these tables?
 
-* **Chat rooms and messages** – Transactions `Send Chat (105)` and `Chat Message (106)` operate on a room context and carry options bits for alternative styles【F:docs/protocol.md†L284-L306】.
-* **Joining and leaving** – `Join Chat (115)` and `Leave Chat (116)` maintain membership lists which map directly to `chat_participants`【F:docs/protocol.md†L309-L338】【F:docs/protocol.md†L339-L351】.
-* **Invitations** – Private chats are created and managed through `Invite New Chat (112)` and related transactions (113/114), so `chat_invites` records outstanding invitations and who sent them【F:docs/protocol.md†L364-L407】.
-* **Subjects** – `Set Chat Subject (120)` triggers `Notify Chat Subject (119)` to broadcast topic changes, stored in `chat_rooms.subject`【F:docs/protocol.md†L352-L361】.
+- **Chat rooms and messages** – Transactions `Send Chat (105)` and
+  `Chat Message (106)` operate on a room context and carry options bits for
+  alternative styles【F:docs/protocol.md†L284-L306】.
+- **Joining and leaving** – `Join Chat (115)` and `Leave Chat (116)` maintain
+  membership lists which map directly to
+  `chat_participants`【F:docs/protocol.md†L309-L338】【F:docs/protocol.md†L339-L351】.
+- **Invitations** – Private chats are created and managed through
+  `Invite New Chat (112)` and related transactions (113/114), so `chat_invites`
+  records outstanding invitations and who sent
+  them【F:docs/protocol.md†L364-L407】.
+- **Subjects** – `Set Chat Subject (120)` triggers `Notify Chat Subject (119)`
+  to broadcast topic changes, stored in
+  `chat_rooms.subject`【F:docs/protocol.md†L352-L361】.
 
-This schema complements the existing users table and allows efficient retrieval of room participants, chat history, and pending invites while matching the protocol’s workflow.
+This schema complements the existing users table and allows efficient retrieval
+of room participants, chat history, and pending invites while matching the
+protocol’s workflow.

--- a/docs/file-sharing-design.md
+++ b/docs/file-sharing-design.md
@@ -2,39 +2,91 @@
 
 ## Introduction
 
-This guide describes how to implement the **file-sharing component** of a Hotline-inspired BBS server. It covers the design and implementation of file transactions analogous to Hotline protocol codes **200–213** – including directory listing, file upload/download (with resume support), folder creation/deletion, moving/renaming, aliasing, folder upload/download, and file metadata updates. We focus exclusively on file sharing, **reusing the existing user/ACL architecture** from the broader application. Our implementation is backend-agnostic, using Rust’s `object_store` crate for storage so it can target AWS S3, Azure Blob, local files, etc. We will address how to map a classic hierarchical folder tree onto the flat keyspace of object storage, handle resumable transfers via byte ranges and multipart uploads, model **aliases**, **dropboxes**, **upload folders**, and **file comments** in the database, and enforce **folder-level and per-file ACLs**. We also discuss trade-offs in metadata synchronization, consistency, and performance.
+This guide describes how to implement the **file-sharing component** of a
+Hotline-inspired BBS server. It covers the design and implementation of file
+transactions analogous to Hotline protocol codes **200–213** – including
+directory listing, file upload/download (with resume support), folder
+creation/deletion, moving/renaming, aliasing, folder upload/download, and file
+metadata updates. We focus exclusively on file sharing, **reusing the existing
+user/ACL architecture** from the broader application. Our implementation is
+backend-agnostic, using Rust’s `object_store` crate for storage so it can target
+AWS S3, Azure Blob, local files, etc. We will address how to map a classic
+hierarchical folder tree onto the flat keyspace of object storage, handle
+resumable transfers via byte ranges and multipart uploads, model **aliases**,
+**dropboxes**, **upload folders**, and **file comments** in the database, and
+enforce **folder-level and per-file ACLs**. We also discuss trade-offs in
+metadata synchronization, consistency, and performance.
 
 ## Protocol Alignment with Hotline Transactions (200–213)
 
-Hotline defined a set of binary transactions for file operations, which our server will emulate at a high level. The relevant operations and their Hotline transaction IDs are:
+Hotline defined a set of binary transactions for file operations, which our
+server will emulate at a high level. The relevant operations and their Hotline
+transaction IDs are:
 
-* **GetFileNameList (200)** – List directory contents.
-* **DownloadFile (202)** – Download a single file (supports resume).
-* **UploadFile (203)** – Upload a single file (supports resume).
-* **DeleteFile (204)** – Delete a file (or folder).
-* **NewFolder (205)** – Create a new folder.
-* **GetFileInfo (206)** – Retrieve file/folder info (size, dates, comment, etc).
-* **SetFileInfo (207)** – Set file/folder info (e.g. rename or comment).
-* **MoveFile (208)** – Move or rename a file/folder.
-* **MakeFileAlias (209)** – Create an alias (link) to a file.
-* **DownloadFolder (210)** – Download an entire folder (with subfolders).
-* **UploadFolder (213)** – Upload an entire folder (including subfolders).
+- **GetFileNameList (200)** – List directory contents.
+- **DownloadFile (202)** – Download a single file (supports resume).
+- **UploadFile (203)** – Upload a single file (supports resume).
+- **DeleteFile (204)** – Delete a file (or folder).
+- **NewFolder (205)** – Create a new folder.
+- **GetFileInfo (206)** – Retrieve file/folder info (size, dates, comment, etc).
+- **SetFileInfo (207)** – Set file/folder info (e.g. rename or comment).
+- **MoveFile (208)** – Move or rename a file/folder.
+- **MakeFileAlias (209)** – Create an alias (link) to a file.
+- **DownloadFolder (210)** – Download an entire folder (with subfolders).
+- **UploadFolder (213)** – Upload an entire folder (including subfolders).
 
-Our server will implement analogous commands for these operations. Each operation will validate the user’s access rights and then perform the necessary database and storage actions. We ensure that our design aligns with Hotline’s features (like partial transfers and aliases) while using modern technologies for robustness and scalability.
+Our server will implement analogous commands for these operations. Each
+operation will validate the user’s access rights and then perform the necessary
+database and storage actions. We ensure that our design aligns with Hotline’s
+features (like partial transfers and aliases) while using modern technologies
+for robustness and scalability.
 
 ## System Architecture Overview
 
-**Core Components:** The file-sharing subsystem consists of a relational **database** for metadata & permissions and an **object storage** service for file content. The server logic (written in Rust) mediates between client requests, the DB, and the object store: for example, a download request triggers a DB lookup and an object store read stream. By leveraging the Rust **`object_store`** crate, we can easily swap underlying storage (local filesystem, S3, Azure, etc.) without code changes. All storage access is asynchronous and stream-oriented for efficiency. The **ACL and user management** are part of the broader application schema and are reused here – meaning file/folder permissions are stored and enforced using the same tables and logic that manage chat or news access rights, rather than a separate silo.
+**Core Components:** The file-sharing subsystem consists of a relational
+**database** for metadata & permissions and an **object storage** service for
+file content. The server logic (written in Rust) mediates between client
+requests, the DB, and the object store: for example, a download request triggers
+a DB lookup and an object store read stream. By leveraging the Rust
+**`object_store`** crate, we can easily swap underlying storage (local
+filesystem, S3, Azure, etc.) without code changes. All storage access is
+asynchronous and stream-oriented for efficiency. The **ACL and user management**
+are part of the broader application schema and are reused here – meaning
+file/folder permissions are stored and enforced using the same tables and logic
+that manage chat or news access rights, rather than a separate silo.
 
-**Workflow Example:** When a client requests a file (DownloadFile), the server will 1) authenticate and check ACLs, 2) find the file’s metadata in the DB (name, size, object key, etc.), and 3) stream the file content from the object store to the client (possibly in Hotline’s “flattened file” format). Uploads follow the reverse: the server receives data and streams it into the object store (possibly via multipart upload for large files) and then records metadata in the DB. Directory listings read from the DB and return a list of entries with attributes. All operations use the DB as the source of truth for directory structure and metadata, which ensures strong consistency for listings and ACL enforcement. The object store holds only file data and is treated as a flat blob store.
+**Workflow Example:** When a client requests a file (DownloadFile), the server
+will 1) authenticate and check ACLs, 2) find the file’s metadata in the DB
+(name, size, object key, etc.), and 3) stream the file content from the object
+store to the client (possibly in Hotline’s “flattened file” format). Uploads
+follow the reverse: the server receives data and streams it into the object
+store (possibly via multipart upload for large files) and then records metadata
+in the DB. Directory listings read from the DB and return a list of entries with
+attributes. All operations use the DB as the source of truth for directory
+structure and metadata, which ensures strong consistency for listings and ACL
+enforcement. The object store holds only file data and is treated as a flat blob
+store.
 
-**Storage Abstraction:** We do *not* rely on filesystem semantics or cloud-specific APIs directly – instead, we use the abstraction provided by `object_store::ObjectStore`. This trait provides methods to put and get objects, list with prefixes, and handle multipart uploads in a uniform way. This lets the same code run against local disk, S3, Azure, Google Cloud, etc., configured by a URL or builder at runtime. All file reads/writes are done through this API, keeping our implementation backend-agnostic.
+**Storage Abstraction:** We do *not* rely on filesystem semantics or
+cloud-specific APIs directly – instead, we use the abstraction provided by
+`object_store::ObjectStore`. This trait provides methods to put and get objects,
+list with prefixes, and handle multipart uploads in a uniform way. This lets the
+same code run against local disk, S3, Azure, Google Cloud, etc., configured by a
+URL or builder at runtime. All file reads/writes are done through this API,
+keeping our implementation backend-agnostic.
 
-The diagram below shows the core data model (ERD) for the file-sharing component, including how it ties into the user/permission system.
+The diagram below shows the core data model (ERD) for the file-sharing
+component, including how it ties into the user/permission system.
 
 ## Data Model and Schema
 
-To model files, folders, and related features, we define a **FileNode** table representing an item in the hierarchy (which might be a folder, a file, or an alias pointer). We also integrate with existing **User**, **Group**, and **Permission/ACL** tables from the application for access control. Each file or folder can have fine-grained ACL entries (linking to users or groups) in the shared permissions table. We include fields for metadata like size, timestamps, and comments. Below is the ER diagram in Mermaid notation:
+To model files, folders, and related features, we define a **FileNode** table
+representing an item in the hierarchy (which might be a folder, a file, or an
+alias pointer). We also integrate with existing **User**, **Group**, and
+**Permission/ACL** tables from the application for access control. Each file or
+folder can have fine-grained ACL entries (linking to users or groups) in the
+shared permissions table. We include fields for metadata like size, timestamps,
+and comments. Below is the ER diagram in Mermaid notation:
 
 ```mermaid
 erDiagram
@@ -86,9 +138,33 @@ erDiagram
 
 In this model:
 
-* **FileNode** is a unified table for files, folders, and aliases. Each entry has a `type` indicating what it is. Every node (except the root) has a `parent_id` linking to a folder. File entries have an `object_key` pointing to data in object storage, a `size`, and perhaps MIME/type info (not shown here). Folder entries have no `object_key` (since they contain no data object) and size may be 0 or used for count. Alias entries have an `alias_target_id` referencing another FileNode (the original file). All nodes can have a `comment` (Hotline allowed user comments on files/folders). `is_dropbox` marks a folder as a **drop box** (a special upload-only folder – explained later). We also record creation timestamps and the user who created/uploaded the file.
-* **Permission** is the shared ACL table (simplified for our context). It can reference any resource in the system; for file sharing we use it to store folder-level or file-level permissions. Each entry grants certain `privileges` (bitmask flags) to a principal (which can be an individual User or a Group). The privileges bits correspond to actions like download, upload, delete, etc., as defined by the application (following Hotline’s privilege definitions). For example, bit 2 might be “Download File”, bit 1 “Upload File”, bit 0 “Delete File”, etc., matching Hotline’s Access Privileges. A **folder-type privilege** in Hotline can be applied per folder via such entries. If no specific Permission entry exists for a given file or folder, the user’s global access rights (stored in `User.global_access` bitmask) apply as default.
-* **User, Group, UserGroup** are part of the existing system to manage accounts and group membership. They are included here to illustrate that permissions can be granted to groups as well as users. The `Permission.principal_type` and `principal_id` together refer to either a user or a group. For example, you could give a “Guests” group download rights to a particular folder, or assign an individual user upload rights.
+- **FileNode** is a unified table for files, folders, and aliases. Each entry
+  has a `type` indicating what it is. Every node (except the root) has a
+  `parent_id` linking to a folder. File entries have an `object_key` pointing to
+  data in object storage, a `size`, and perhaps MIME/type info (not shown here).
+  Folder entries have no `object_key` (since they contain no data object) and
+  size may be 0 or used for count. Alias entries have an `alias_target_id`
+  referencing another FileNode (the original file). All nodes can have a
+  `comment` (Hotline allowed user comments on files/folders). `is_dropbox` marks
+  a folder as a **drop box** (a special upload-only folder – explained later).
+  We also record creation timestamps and the user who created/uploaded the file.
+- **Permission** is the shared ACL table (simplified for our context). It can
+  reference any resource in the system; for file sharing we use it to store
+  folder-level or file-level permissions. Each entry grants certain `privileges`
+  (bitmask flags) to a principal (which can be an individual User or a Group).
+  The privileges bits correspond to actions like download, upload, delete, etc.,
+  as defined by the application (following Hotline’s privilege definitions). For
+  example, bit 2 might be “Download File”, bit 1 “Upload File”, bit 0 “Delete
+  File”, etc., matching Hotline’s Access Privileges. A **folder-type privilege**
+  in Hotline can be applied per folder via such entries. If no specific
+  Permission entry exists for a given file or folder, the user’s global access
+  rights (stored in `User.global_access` bitmask) apply as default.
+- **User, Group, UserGroup** are part of the existing system to manage accounts
+  and group membership. They are included here to illustrate that permissions
+  can be granted to groups as well as users. The `Permission.principal_type` and
+  `principal_id` together refer to either a user or a group. For example, you
+  could give a “Guests” group download rights to a particular folder, or assign
+  an individual user upload rights.
 
 Below is an example SQL DDL that implements this schema:
 
@@ -142,43 +218,152 @@ CREATE TABLE Permission (
 -- (For file sharing, resource_type might be 'file' or 'folder'; both map to FileNode IDs.)
 ```
 
-This schema allows us to represent the complete file system hierarchy and access controls:
+This schema allows us to represent the complete file system hierarchy and access
+controls:
 
-* A folder’s contents are FileNode entries with that folder’s ID as their parent\_id. We can traverse parent\_id links to resolve full paths or to enforce inherited rules.
-* An alias is simply a FileNode of type 'alias' pointing to another FileNode (its target). It has its own name and parent (so it appears in a directory), but no object\_key or size of its own – it uses the target’s data.
-* A dropbox is indicated by `is_dropbox=true` on a folder (and likely also by specific Permission entries on that folder to restrict access; see **Access Control** below).
-* Upload folders (for the *UploadFolder* transaction) are not a special type in the schema – they are created dynamically as normal folders when a user initiates a folder upload. The process of handling folder uploads is covered in the implementation sections, but no additional static schema is needed.
-* File comments are stored in the `comment` field of FileNode. Both files and folders can have comments (Hotline had a separate privilege for setting folder comments vs file comments, which we can enforce via privileges bits 28 and 29 respectively).
+- A folder’s contents are FileNode entries with that folder’s ID as their
+  parent_id. We can traverse parent_id links to resolve full paths or to enforce
+  inherited rules.
+- An alias is simply a FileNode of type 'alias' pointing to another FileNode
+  (its target). It has its own name and parent (so it appears in a directory),
+  but no object_key or size of its own – it uses the target’s data.
+- A dropbox is indicated by `is_dropbox=true` on a folder (and likely also by
+  specific Permission entries on that folder to restrict access; see **Access
+  Control** below).
+- Upload folders (for the *UploadFolder* transaction) are not a special type in
+  the schema – they are created dynamically as normal folders when a user
+  initiates a folder upload. The process of handling folder uploads is covered
+  in the implementation sections, but no additional static schema is needed.
+- File comments are stored in the `comment` field of FileNode. Both files and
+  folders can have comments (Hotline had a separate privilege for setting folder
+  comments vs file comments, which we can enforce via privileges bits 28 and 29
+  respectively).
 
-All critical fields are indexed or constrained for performance and integrity (e.g. unique name per folder, foreign keys to cascade deletions of sub-items, etc.). We now discuss how this schema is used in implementation for each operation.
+All critical fields are indexed or constrained for performance and integrity
+(e.g. unique name per folder, foreign keys to cascade deletions of sub-items,
+etc.). We now discuss how this schema is used in implementation for each
+operation.
 
 ## Hierarchical Structure Mapping to Object Storage
 
-Object storage systems use a **flat key namespace** – there is no true directory hierarchy on the backend. Any notion of folders is typically an illusion maintained by naming conventions and prefix queries. For example, in an S3-like store, an object key `"docs/reports/file.pdf"` might *appear* as if `docs` and `reports` are folders, but actually it’s just a single key with slashes in its name. Folders have no intrinsic metadata in object stores – their existence is implied by object keys. Therefore, we must map our hierarchical Hotline-style file system onto a flat keyspace. We do this as follows:
+Object storage systems use a **flat key namespace** – there is no true directory
+hierarchy on the backend. Any notion of folders is typically an illusion
+maintained by naming conventions and prefix queries. For example, in an S3-like
+store, an object key `"docs/reports/file.pdf"` might *appear* as if `docs` and
+`reports` are folders, but actually it’s just a single key with slashes in its
+name. Folders have no intrinsic metadata in object stores – their existence is
+implied by object keys. Therefore, we must map our hierarchical Hotline-style
+file system onto a flat keyspace. We do this as follows:
 
-* **Database as Source of Truth:** The **FileNode** hierarchy in the database is the authoritative representation of directories, subdirectories, and file names. We do **not** rely on the object store to list or organize directories. This allows us to attach metadata (permissions, comments, etc.) to directories themselves, which object stores cannot do. Folders in our system are logical constructs (entries in the DB) and need not correspond to any physical object in the store.
-* **Object Key Design:** For actual file content, we generate an **object key** for each file stored. A simple strategy is to use a path-like key mirroring the file’s path (e.g., combine parent folder names and filename). However, **we prefer using a unique identifier** (like the FileNode `id` or a UUID) as the object key, decoupling it from the human-readable path. This approach avoids expensive renames or copies in storage when a file is moved or renamed in the hierarchy. For example, if file *"Manual.pdf"* (id 42) is stored with key `"files/42.pdf"`, moving it to a different folder in the DB does not require moving the object or changing the key. In contrast, if we had used `"Docs/Manual.pdf"` as the key, renaming the "Docs" folder would require renaming every object under it. By mapping each file to a **stable flat key**, we keep storage operations simple and atomic (create/delete) and handle renames purely in metadata.
-* **Folder Listing:** When a client requests a directory listing (GetFileNameList), the server queries the DB for FileNodes with `parent_id` = that folder’s ID. The object store is not consulted at all for listing; thus, we are immune to any object store listing consistency issues and can include additional info (file type, size, comments) directly from the DB. If using ID-based object keys, the server might on occasion verify the object exists (e.g., using a HEAD request via object\_store for sanity), but that’s optional and can be done in background audits. If we used path-based keys, we could use object\_store’s `list` with a prefix filter, but we would still need the DB to get comments and permissions, so it's simpler to rely entirely on the DB for structure.
-* **Folder Creation and Deletion:** Creating a folder (NewFolder command) results in a new FileNode of type 'folder' in the DB. **No object is created in the store** for it (consistent with object stores not needing a placeholder object for directories). Deleting a folder in the DB (if empty or via recursive delete) will involve deleting all descendant FileNode records and all associated objects for files – we can use object\_store’s delete functionality for each file’s object. Deletion of a folder in object storage is thus just deletion of the contained objects (since the folder itself is conceptual).
-* **Path Resolution:** Since clients and protocol refer to files by “path” (folder names + filename), the server will need to resolve those into a FileNode ID. This can be done with recursive DB queries (e.g., find child by name under parent, etc.). To optimize, one could store a full path string or a path hash for quick lookups, but that complicates updates on move/rename. Instead, we can traverse stepwise or use indexed queries on parent+name (the unique constraint helps here). For example, to find `"/Uploads/2025/Report.pdf"`, we would find the root “Uploads” folder, then find child “2025” under it, then “Report.pdf” under that. These lookups are typically fast with proper indexes. The final file node gives us the `object_key` to access the content.
+- **Database as Source of Truth:** The **FileNode** hierarchy in the database is
+  the authoritative representation of directories, subdirectories, and file
+  names. We do **not** rely on the object store to list or organize directories.
+  This allows us to attach metadata (permissions, comments, etc.) to directories
+  themselves, which object stores cannot do. Folders in our system are logical
+  constructs (entries in the DB) and need not correspond to any physical object
+  in the store.
+- **Object Key Design:** For actual file content, we generate an **object key**
+  for each file stored. A simple strategy is to use a path-like key mirroring
+  the file’s path (e.g., combine parent folder names and filename). However,
+  **we prefer using a unique identifier** (like the FileNode `id` or a UUID) as
+  the object key, decoupling it from the human-readable path. This approach
+  avoids expensive renames or copies in storage when a file is moved or renamed
+  in the hierarchy. For example, if file *"Manual.pdf"* (id 42) is stored with
+  key `"files/42.pdf"`, moving it to a different folder in the DB does not
+  require moving the object or changing the key. In contrast, if we had used
+  `"Docs/Manual.pdf"` as the key, renaming the "Docs" folder would require
+  renaming every object under it. By mapping each file to a **stable flat key**,
+  we keep storage operations simple and atomic (create/delete) and handle
+  renames purely in metadata.
+- **Folder Listing:** When a client requests a directory listing
+  (GetFileNameList), the server queries the DB for FileNodes with `parent_id` =
+  that folder’s ID. The object store is not consulted at all for listing; thus,
+  we are immune to any object store listing consistency issues and can include
+  additional info (file type, size, comments) directly from the DB. If using
+  ID-based object keys, the server might on occasion verify the object exists
+  (e.g., using a HEAD request via object_store for sanity), but that’s optional
+  and can be done in background audits. If we used path-based keys, we could use
+  object_store’s `list` with a prefix filter, but we would still need the DB to
+  get comments and permissions, so it's simpler to rely entirely on the DB for
+  structure.
+- **Folder Creation and Deletion:** Creating a folder (NewFolder command)
+  results in a new FileNode of type 'folder' in the DB. **No object is created
+  in the store** for it (consistent with object stores not needing a placeholder
+  object for directories). Deleting a folder in the DB (if empty or via
+  recursive delete) will involve deleting all descendant FileNode records and
+  all associated objects for files – we can use object_store’s delete
+  functionality for each file’s object. Deletion of a folder in object storage
+  is thus just deletion of the contained objects (since the folder itself is
+  conceptual).
+- **Path Resolution:** Since clients and protocol refer to files by “path”
+  (folder names + filename), the server will need to resolve those into a
+  FileNode ID. This can be done with recursive DB queries (e.g., find child by
+  name under parent, etc.). To optimize, one could store a full path string or a
+  path hash for quick lookups, but that complicates updates on move/rename.
+  Instead, we can traverse stepwise or use indexed queries on parent+name (the
+  unique constraint helps here). For example, to find
+  `"/Uploads/2025/Report.pdf"`, we would find the root “Uploads” folder, then
+  find child “2025” under it, then “Report.pdf” under that. These lookups are
+  typically fast with proper indexes. The final file node gives us the
+  `object_key` to access the content.
 
-This mapping strategy ensures we maintain a **hierarchical view** for users and ACLs, while the underlying storage remains a flat pool of objects identified by opaque keys. It leverages the strengths of each: the database handles relationships and rich metadata, and the object store handles large binary data efficiently.
+This mapping strategy ensures we maintain a **hierarchical view** for users and
+ACLs, while the underlying storage remains a flat pool of objects identified by
+opaque keys. It leverages the strengths of each: the database handles
+relationships and rich metadata, and the object store handles large binary data
+efficiently.
 
 ## File Operations Implementation
 
-We now detail how each major file-sharing command is implemented in the backend, following the schema and architecture above. Each operation is described with its permission checks, database actions, and storage interactions. All operations use Rust’s async features and the `object_store` interface for I/O, enabling high-throughput, non-blocking transfers.
+We now detail how each major file-sharing command is implemented in the backend,
+following the schema and architecture above. Each operation is described with
+its permission checks, database actions, and storage interactions. All
+operations use Rust’s async features and the `object_store` interface for I/O,
+enabling high-throughput, non-blocking transfers.
 
 ### Directory Listing – *GetFileNameList (200)*
 
-When the client requests a directory listing of a given path (or root), the server performs:
+When the client requests a directory listing of a given path (or root), the
+server performs:
 
-1. **Path Resolution:** Determine which folder to list. If the request includes a path, we lookup the FileNode for that folder. If no path given, we use the root folder (by convention, the root might be a FileNode with parent\_id = NULL).
-2. **Permission Check:** Ensure the user has rights to list/browse this folder. Hotline did not have a separate “list folder” privilege bit, but effectively, to see files one needed Download permission on that folder or the special *View Drop Boxes (30)* privilege for hidden dropboxes. In our system, we can treat listing as requiring at least read access. If the folder is a dropbox (`is_dropbox=true`) and the user lacks the special view privilege, we will return an empty list (the folder will appear empty to them, even though files might be present) – this mimics Hotline’s behavior of upload-only dropboxes.
-3. **Query DB:** Fetch all FileNodes where parent\_id = folder’s ID. This yields all files, subfolders, and aliases in that directory. We will retrieve attributes needed for the listing: the name, type (to know if it’s a folder or alias), size (for files or aliases), modification timestamp, and comment. We also may query permissions to filter out any items the user shouldn’t see individually (e.g., if a specific file has an ACL denying this user, you might choose to omit it from the list or mark it locked). In most cases, if the user can list the directory, they can see the names of items; more granular hiding of specific files is optional.
-4. **Construct Response:** We send the list of entries. The Hotline protocol expects each entry as a “File name with info” structure (transaction field 200), which includes the item name plus info like size, type flags, dates, and comment. We populate these from the DB. For alias entries, we set a flag/indicator in the info (Hotline likely had a bit to denote alias) and we might include the alias’s target size/comment. For folders, size could be sent as 0 or as a special flag indicating a folder (the client usually distinguished by type, not size).
-5. **Sorting/Paging:** We can sort entries alphabetically or by type as needed (Hotline sorted folders and files separately). If a directory has many entries, we may implement paging (though Hotline protocol may not have defined paging – it likely sent all at once). In a modern implementation, consider limiting list size for performance, but for parity we can send all.
+1. **Path Resolution:** Determine which folder to list. If the request includes
+   a path, we lookup the FileNode for that folder. If no path given, we use the
+   root folder (by convention, the root might be a FileNode with parent_id =
+   NULL).
+2. **Permission Check:** Ensure the user has rights to list/browse this folder.
+   Hotline did not have a separate “list folder” privilege bit, but effectively,
+   to see files one needed Download permission on that folder or the special
+   *View Drop Boxes (30)* privilege for hidden dropboxes. In our system, we can
+   treat listing as requiring at least read access. If the folder is a dropbox
+   (`is_dropbox=true`) and the user lacks the special view privilege, we will
+   return an empty list (the folder will appear empty to them, even though files
+   might be present) – this mimics Hotline’s behavior of upload-only dropboxes.
+3. **Query DB:** Fetch all FileNodes where parent_id = folder’s ID. This yields
+   all files, subfolders, and aliases in that directory. We will retrieve
+   attributes needed for the listing: the name, type (to know if it’s a folder
+   or alias), size (for files or aliases), modification timestamp, and comment.
+   We also may query permissions to filter out any items the user shouldn’t see
+   individually (e.g., if a specific file has an ACL denying this user, you
+   might choose to omit it from the list or mark it locked). In most cases, if
+   the user can list the directory, they can see the names of items; more
+   granular hiding of specific files is optional.
+4. **Construct Response:** We send the list of entries. The Hotline protocol
+   expects each entry as a “File name with info” structure (transaction field
+   200), which includes the item name plus info like size, type flags, dates,
+   and comment. We populate these from the DB. For alias entries, we set a
+   flag/indicator in the info (Hotline likely had a bit to denote alias) and we
+   might include the alias’s target size/comment. For folders, size could be
+   sent as 0 or as a special flag indicating a folder (the client usually
+   distinguished by type, not size).
+5. **Sorting/Paging:** We can sort entries alphabetically or by type as needed
+   (Hotline sorted folders and files separately). If a directory has many
+   entries, we may implement paging (though Hotline protocol may not have
+   defined paging – it likely sent all at once). In a modern implementation,
+   consider limiting list size for performance, but for parity we can send all.
 
-This operation is primarily DB-bound. It is typically fast since it’s an indexed lookup by parent\_id. The response assembly is straightforward. Example pseudo-code using Rust and an async SQL client might look like:
+This operation is primarily DB-bound. It is typically fast since it’s an indexed
+lookup by parent_id. The response assembly is straightforward. Example
+pseudo-code using Rust and an async SQL client might look like:
 
 ```rust
 async fn list_directory(path: &str, user: &User) -> Result<Vec<ListEntry>, Error> {
@@ -204,16 +389,38 @@ async fn list_directory(path: &str, user: &User) -> Result<Vec<ListEntry>, Error
 }
 ```
 
-Note: The above is illustrative; actual code would need to join with alias target to get size if alias, etc.
+Note: The above is illustrative; actual code would need to join with alias
+target to get size if alias, etc.
 
 ### File Download – *DownloadFile (202)*
 
-Downloading a file involves streaming the file’s bytes from object storage to the client, potentially starting at a byte offset if resuming. Implementation steps:
+Downloading a file involves streaming the file’s bytes from object storage to
+the client, potentially starting at a byte offset if resuming. Implementation
+steps:
 
-1. **Locate File:** Resolve the requested file path to a FileNode (type should be 'file' or 'alias'). If it’s an alias, we resolve to its target file (follow FileNode.alias\_target\_id chain).
-2. **Permission Check:** Verify the user has download rights. This means either a global privilege (Hotline’s “Download File (2)” which may be set in their account) and no folder-specific denial, or a specific allow on that file/folder via Permission table. Also check if the file is in a dropbox and the user is not allowed to view it – in which case deny (users typically cannot download from dropboxes unless they have the special access). If the file has an ACL entry and the user (or their group) isn’t listed with download permission, we reject.
-3. **Retrieve Metadata:** From the FileNode, get the `object_key`, size, and other metadata. This also helps with resume: if the client provided a resume offset (Hotline’s *File resume data* field (203) in the request), we will use it to start reading from that byte position.
-4. **Open Object Stream:** Using the `object_store` API, we fetch the object. We can either request the entire object or a range. The `ObjectStore` trait provides `get` for full object and `get_ranges` for byte ranges. For a resumable download, we’ll do a range request starting at the resume offset until end-of-file. For example:
+1. **Locate File:** Resolve the requested file path to a FileNode (type should
+   be 'file' or 'alias'). If it’s an alias, we resolve to its target file
+   (follow FileNode.alias_target_id chain).
+
+2. **Permission Check:** Verify the user has download rights. This means either
+   a global privilege (Hotline’s “Download File (2)” which may be set in their
+   account) and no folder-specific denial, or a specific allow on that
+   file/folder via Permission table. Also check if the file is in a dropbox and
+   the user is not allowed to view it – in which case deny (users typically
+   cannot download from dropboxes unless they have the special access). If the
+   file has an ACL entry and the user (or their group) isn’t listed with
+   download permission, we reject.
+
+3. **Retrieve Metadata:** From the FileNode, get the `object_key`, size, and
+   other metadata. This also helps with resume: if the client provided a resume
+   offset (Hotline’s *File resume data* field (203) in the request), we will use
+   it to start reading from that byte position.
+
+4. **Open Object Stream:** Using the `object_store` API, we fetch the object. We
+   can either request the entire object or a range. The `ObjectStore` trait
+   provides `get` for full object and `get_ranges` for byte ranges. For a
+   resumable download, we’ll do a range request starting at the resume offset
+   until end-of-file. For example:
 
    ```rust
    let path = object_store::path::Path::from(file_node.object_key.clone());
@@ -225,39 +432,122 @@ Downloading a file involves streaming the file’s bytes from object storage to 
    };
    ```
 
-   This yields an async stream of bytes (`impl Stream<Item=Result<Bytes, Error>>`). The object\_store library will handle efficiently ranging the request (coalescing multiple small ranges if needed).
-5. **Send Data:** We stream the bytes to the client over the network. According to the Hotline protocol, the server first sends a reply with a **Reference number** and the total transfer size. Then the client opens a separate data connection (to port+1) and the server sends the file data prefaced by a 4-byte `'HTXF'` header and some metadata. In our implementation, we compose the “flattened file object” structure as required, which includes an **info fork** (with file metadata like create/modify dates, comment, name length, etc.) followed by a **data fork** containing the raw bytes. We can generate this on the fly: first send the info fork (which is small), then stream the data fork directly from object\_store. We do not buffer the entire file in memory; we read chunk by chunk and forward to the socket (this is where Rust’s async stream shines, allowing backpressure).
-6. **Resuming:** If the request included a resume offset, the `Transfer size` we report will be (file\_size - offset) and we will start sending from that offset. The client will append the incoming bytes to its existing partial file. Since our object store read was started at `offset`, this is naturally handled. We just need to ensure the “flattened file” header we send still includes the full file metadata (Hotline’s format likely expects the original file length in the info fork even if starting mid-file). We comply with the protocol by providing the resume functionality but not altering the file’s identity.
+   This yields an async stream of bytes
+   (`impl Stream<Item=Result<Bytes, Error>>`). The object_store library will
+   handle efficiently ranging the request (coalescing multiple small ranges if
+   needed).
 
-This operation’s performance considerations: using range requests avoids sending data the client already has. The `object_store` abstraction will handle range gets in a single HTTP Range request or equivalent, which is efficient. We also rely on the fact that object reads are atomic and consistent (once a file is uploaded and finalized, we get a consistent byte stream).
+5. **Send Data:** We stream the bytes to the client over the network. According
+   to the Hotline protocol, the server first sends a reply with a **Reference
+   number** and the total transfer size. Then the client opens a separate data
+   connection (to port+1) and the server sends the file data prefaced by a
+   4-byte `'HTXF'` header and some metadata. In our implementation, we compose
+   the “flattened file object” structure as required, which includes an **info
+   fork** (with file metadata like create/modify dates, comment, name length,
+   etc.) followed by a **data fork** containing the raw bytes. We can generate
+   this on the fly: first send the info fork (which is small), then stream the
+   data fork directly from object_store. We do not buffer the entire file in
+   memory; we read chunk by chunk and forward to the socket (this is where
+   Rust’s async stream shines, allowing backpressure).
 
-**Hotline Compatibility Note:** Hotline’s “Download File” was followed by a “Download Info (211)” server transaction with a reference number, then the actual data on a new connection. We emulate this by our control-plane (main connection) sending a response that triggers the data-plane connection. The specifics of managing multiple sockets is beyond this guide’s scope, but the idea is to separate metadata exchange from bulk data transfer, which matches our approach of streaming from object\_store once the transfer is negotiated.
+6. **Resuming:** If the request included a resume offset, the `Transfer size` we
+   report will be (file_size - offset) and we will start sending from that
+   offset. The client will append the incoming bytes to its existing partial
+   file. Since our object store read was started at `offset`, this is naturally
+   handled. We just need to ensure the “flattened file” header we send still
+   includes the full file metadata (Hotline’s format likely expects the original
+   file length in the info fork even if starting mid-file). We comply with the
+   protocol by providing the resume functionality but not altering the file’s
+   identity.
+
+This operation’s performance considerations: using range requests avoids sending
+data the client already has. The `object_store` abstraction will handle range
+gets in a single HTTP Range request or equivalent, which is efficient. We also
+rely on the fact that object reads are atomic and consistent (once a file is
+uploaded and finalized, we get a consistent byte stream).
+
+**Hotline Compatibility Note:** Hotline’s “Download File” was followed by a
+“Download Info (211)” server transaction with a reference number, then the
+actual data on a new connection. We emulate this by our control-plane (main
+connection) sending a response that triggers the data-plane connection. The
+specifics of managing multiple sockets is beyond this guide’s scope, but the
+idea is to separate metadata exchange from bulk data transfer, which matches our
+approach of streaming from object_store once the transfer is negotiated.
 
 ### File Upload – *UploadFile (203)*
 
-Uploading a file involves receiving data from the client and storing it to the object store, possibly with support for resuming if the transfer is interrupted. The steps:
+Uploading a file involves receiving data from the client and storing it to the
+object store, possibly with support for resuming if the transfer is interrupted.
+The steps:
 
-1. **Prepare Destination:** Identify the target directory and new file name from the request fields (Hotline sends *File path* and *File name* in the request). Resolve the target folder via DB (must exist and be writable by user). Check if a file by that name already exists in that folder:
+1. **Prepare Destination:** Identify the target directory and new file name from
+   the request fields (Hotline sends *File path* and *File name* in the
+   request). Resolve the target folder via DB (must exist and be writable by
+   user). Check if a file by that name already exists in that folder:
 
-   * If yes and protocol expects overwrite, we might delete or move the old file if the user has rights (e.g., “Any Name (26)” privilege in Hotline allowed overriding files). Otherwise, we may refuse or rename the new file (Hotline had an “Any Name” privilege meaning user could upload a file with a name that already exists, possibly overwriting). Our implementation can allow overwrite if user has Delete rights on the existing file or a similar rule. If overwriting, we will delete the old FileNode and its object before proceeding (or mark it as replaced).
-   * If no conflict, proceed to create.
+   - If yes and protocol expects overwrite, we might delete or move the old file
+     if the user has rights (e.g., “Any Name (26)” privilege in Hotline allowed
+     overriding files). Otherwise, we may refuse or rename the new file (Hotline
+     had an “Any Name” privilege meaning user could upload a file with a name
+     that already exists, possibly overwriting). Our implementation can allow
+     overwrite if user has Delete rights on the existing file or a similar rule.
+     If overwriting, we will delete the old FileNode and its object before
+     proceeding (or mark it as replaced).
+   - If no conflict, proceed to create.
 
-2. **Permission Check:** Verify the user can upload to this folder. This requires the “Upload File (1)” permission either globally or on that folder. If the folder is a **dropbox**, typically all users have upload rights but not view; in our system, we’d likely give the “everyone” group an upload permission on that folder. So check accordingly. Also, if the folder is flagged read-only for the user, deny.
+2. **Permission Check:** Verify the user can upload to this folder. This
+   requires the “Upload File (1)” permission either globally or on that folder.
+   If the folder is a **dropbox**, typically all users have upload rights but
+   not view; in our system, we’d likely give the “everyone” group an upload
+   permission on that folder. So check accordingly. Also, if the folder is
+   flagged read-only for the user, deny.
 
-3. **Create DB Record:** Insert a new FileNode for the file. We mark its `parent_id`, name, type='file', and set `size=0` initially. We can also store `created_by` = user’s ID and a timestamp. We generate a new `object_key` for it. At this point, depending on strategy, we might not commit the DB transaction until the file content is fully received (to avoid a record for a file that fails to upload). However, not having a DB entry means we have nowhere to attach a partial state. A compromise is to insert it with a status flag “incomplete” (not shown in schema for brevity) and update status when done. For simplicity, assume we will add the entry after a successful upload, or remove it on failure. We must also decide how to handle the scenario of resuming an interrupted upload – the DB entry could remain and we append to it later, or we might require the client to reinitiate and treat it as new (except where resume is explicitly supported). The Hotline protocol does have a resume for uploads, implied by *File transfer options* and *File resume data* fields, so we strive to support it.
+3. **Create DB Record:** Insert a new FileNode for the file. We mark its
+   `parent_id`, name, type='file', and set `size=0` initially. We can also store
+   `created_by` = user’s ID and a timestamp. We generate a new `object_key` for
+   it. At this point, depending on strategy, we might not commit the DB
+   transaction until the file content is fully received (to avoid a record for a
+   file that fails to upload). However, not having a DB entry means we have
+   nowhere to attach a partial state. A compromise is to insert it with a status
+   flag “incomplete” (not shown in schema for brevity) and update status when
+   done. For simplicity, assume we will add the entry after a successful upload,
+   or remove it on failure. We must also decide how to handle the scenario of
+   resuming an interrupted upload – the DB entry could remain and we append to
+   it later, or we might require the client to reinitiate and treat it as new
+   (except where resume is explicitly supported). The Hotline protocol does have
+   a resume for uploads, implied by *File transfer options* and *File resume
+   data* fields, so we strive to support it.
 
-4. **Receive Data:** The client, after sending the upload request, will open a data connection (port+1) and send an HTXF header and then the “flattened file” content. We parse the incoming stream:
+4. **Receive Data:** The client, after sending the upload request, will open a
+   data connection (port+1) and send an HTXF header and then the “flattened
+   file” content. We parse the incoming stream:
 
-   * First, read the 4-byte header and control fields (we expect `'HTXF'` and some protocol bytes).
-   * Then, read the “flattened file object” content. It begins with an **INFO fork** describing the file metadata. We’ll parse out details:
+   - First, read the 4-byte header and control fields (we expect `'HTXF'` and
+     some protocol bytes).
 
-     * Possibly a platform (Mac/Win) and file type/creator codes (we can ignore or store as part of metadata if needed).
-     * The create and modify timestamps – we can store these in FileNode (or just set `created_at` now and `updated_at` as modify time).
-     * Name and comment are included here: the name we already have from the request; the comment (if any) we should extract and save to FileNode.comment.
-     * There may be other flags (we can ignore compression since none is used).
-     * We continue reading until the end of the INFO fork (the format gives lengths, so we know where it ends).
-   * Next comes the **DATA fork header** and then the file’s binary content. The header provides the data fork size (which should match the file size). We use that size for validation.
-   * We then stream the incoming data bytes to storage. For efficiency and memory safety, we do not buffer everything. Instead, we initiate a multipart upload to the object store. Using `ObjectStore::put_multipart` gives us a `WriteMultipart` handle that we can feed bytes into in chunks. For example:
+   - Then, read the “flattened file object” content. It begins with an **INFO
+     fork** describing the file metadata. We’ll parse out details:
+
+     - Possibly a platform (Mac/Win) and file type/creator codes (we can ignore
+       or store as part of metadata if needed).
+     - The create and modify timestamps – we can store these in FileNode (or
+       just set `created_at` now and `updated_at` as modify time).
+     - Name and comment are included here: the name we already have from the
+       request; the comment (if any) we should extract and save to
+       FileNode.comment.
+     - There may be other flags (we can ignore compression since none is used).
+     - We continue reading until the end of the INFO fork (the format gives
+       lengths, so we know where it ends).
+
+   - Next comes the **DATA fork header** and then the file’s binary content. The
+     header provides the data fork size (which should match the file size). We
+     use that size for validation.
+
+   - We then stream the incoming data bytes to storage. For efficiency and
+     memory safety, we do not buffer everything. Instead, we initiate a
+     multipart upload to the object store. Using `ObjectStore::put_multipart`
+     gives us a `WriteMultipart` handle that we can feed bytes into in chunks.
+     For example:
 
    ```rust
    let store_path = object_store::path::Path::from(new_file.object_key.clone());
@@ -270,209 +560,941 @@ Uploading a file involves receiving data from the client and storing it to the o
    writer.finish().await?;  // complete the multipart upload atomically:contentReference[oaicite:71]{index=71}
    ```
 
-   The `WriteMultipart` internally buffers to the required part size and uploads parts in parallel or sequentially as needed. This ensures the upload is efficient and can handle large files without memory bloat.
+   The `WriteMultipart` internally buffers to the required part size and uploads
+   parts in parallel or sequentially as needed. This ensures the upload is
+   efficient and can handle large files without memory bloat.
 
-5. **Resumable Upload:** If the client indicated a resume (Hotline uses a *File resume data* field in the server’s reply to an upload request to tell the client where to resume), our server needs to handle interrupted uploads. One approach: when an upload is interrupted, we keep the DB entry (marked incomplete) and do not finalize the multipart upload. The object\_store may have staged parts; we store the multipart upload ID and parts info somewhere (perhaps a temporary DB table or in-memory map). When the client reconnects to resume, it sends an UploadFile request with a flag indicating resume. We look up the existing entry and find how many bytes were received (or which parts completed). We then respond with *File resume data* = number of bytes already stored (Hotline’s mechanism was to let server tell client how much it got, so client can send the rest). Then the client will send only the remaining bytes. In our implementation, we can re-open or continue the multipart upload:
+5. **Resumable Upload:** If the client indicated a resume (Hotline uses a *File
+   resume data* field in the server’s reply to an upload request to tell the
+   client where to resume), our server needs to handle interrupted uploads. One
+   approach: when an upload is interrupted, we keep the DB entry (marked
+   incomplete) and do not finalize the multipart upload. The object_store may
+   have staged parts; we store the multipart upload ID and parts info somewhere
+   (perhaps a temporary DB table or in-memory map). When the client reconnects
+   to resume, it sends an UploadFile request with a flag indicating resume. We
+   look up the existing entry and find how many bytes were received (or which
+   parts completed). We then respond with *File resume data* = number of bytes
+   already stored (Hotline’s mechanism was to let server tell client how much it
+   got, so client can send the rest). Then the client will send only the
+   remaining bytes. In our implementation, we can re-open or continue the
+   multipart upload:
 
-   * If the object\_store crate allows reusing the existing upload (some cloud APIs allow listing parts and continuing), we use the saved upload ID and continue writing new parts. If not easily possible, an alternative is to start a new upload and skip already received bytes of the file (but skipping means we need the client to also skip sending them, which is what the resume protocol does). So the client only sends what’s missing. We then either append that to the existing object (not trivial in object store unless continuing multi-part) or we could store it as a separate object and later merge – not ideal.
-   * Ideally, we rely on the multi-part continuation: e.g., AWS S3 allows you to resume a multipart upload if you have the upload ID and part numbers already uploaded. We would have to keep track of the next byte/part needed. Given our use of `WriteMultipart`, we might need a custom approach for resume (since `WriteMultipart` might not expose a mid-upload state easily). A simpler approach: don’t finalize the multipart and on resume, start a new one and throw away the partial object. But that would waste what was uploaded. Instead, to implement true resume, we might manually manage parts: e.g., on first upload attempt, store each part number and ETag as they complete. On resume, call object\_store’s low-level API to initiate a *MultipartUpload* with the same upload ID (if supported by crate) and skip to the last completed part. This is complex, so an easier design might be:
-   * **Alternate Resume Design:** On interruption, *do not create the DB entry at all*. Instead, have the client re-upload the file (modern approach, or use a separate partial file mechanism). However, since Hotline clearly had resume, we should support it.
-   * For brevity, assume we manage to continue the multipart. The server’s reply to an UploadFile request could include field 203 (File resume data) if it knows some bytes are already present. If resume is at protocol-level, the client would include a flag in *File transfer options (204)* indicating resume and not send already-sent data again. We then append new data and finalize.
+   - If the object_store crate allows reusing the existing upload (some cloud
+     APIs allow listing parts and continuing), we use the saved upload ID and
+     continue writing new parts. If not easily possible, an alternative is to
+     start a new upload and skip already received bytes of the file (but
+     skipping means we need the client to also skip sending them, which is what
+     the resume protocol does). So the client only sends what’s missing. We then
+     either append that to the existing object (not trivial in object store
+     unless continuing multi-part) or we could store it as a separate object and
+     later merge – not ideal.
+   - Ideally, we rely on the multi-part continuation: e.g., AWS S3 allows you to
+     resume a multipart upload if you have the upload ID and part numbers
+     already uploaded. We would have to keep track of the next byte/part needed.
+     Given our use of `WriteMultipart`, we might need a custom approach for
+     resume (since `WriteMultipart` might not expose a mid-upload state easily).
+     A simpler approach: don’t finalize the multipart and on resume, start a new
+     one and throw away the partial object. But that would waste what was
+     uploaded. Instead, to implement true resume, we might manually manage
+     parts: e.g., on first upload attempt, store each part number and ETag as
+     they complete. On resume, call object_store’s low-level API to initiate a
+     *MultipartUpload* with the same upload ID (if supported by crate) and skip
+     to the last completed part. This is complex, so an easier design might be:
+   - **Alternate Resume Design:** On interruption, *do not create the DB entry
+     at all*. Instead, have the client re-upload the file (modern approach, or
+     use a separate partial file mechanism). However, since Hotline clearly had
+     resume, we should support it.
+   - For brevity, assume we manage to continue the multipart. The server’s reply
+     to an UploadFile request could include field 203 (File resume data) if it
+     knows some bytes are already present. If resume is at protocol-level, the
+     client would include a flag in *File transfer options (204)* indicating
+     resume and not send already-sent data again. We then append new data and
+     finalize.
 
-   In summary, resumable upload is challenging but achievable: it requires tracking of upload state. Our system could simplify it by chunking the file in the client (the Hotline client likely does) and treating each chunk as an independent put with an offset. We won’t delve deeper due to complexity, but this design acknowledges the need and outlines a solution (track bytes received, client only sends remainder, use multi-part append).
+   In summary, resumable upload is challenging but achievable: it requires
+   tracking of upload state. Our system could simplify it by chunking the file
+   in the client (the Hotline client likely does) and treating each chunk as an
+   independent put with an offset. We won’t delve deeper due to complexity, but
+   this design acknowledges the need and outlines a solution (track bytes
+   received, client only sends remainder, use multi-part append).
 
-6. **Finalize and Commit:** Once all bytes are received and the multipart upload is finished successfully (which atomically creates the object in the store), we update the database. If we deferred inserting the FileNode, insert it now; if we inserted earlier with size 0, update its `size` to the real size and possibly update `updated_at` and set any status to complete. We also save the comment extracted from the info fork. The file is now available for others to download.
+6. **Finalize and Commit:** Once all bytes are received and the multipart upload
+   is finished successfully (which atomically creates the object in the store),
+   we update the database. If we deferred inserting the FileNode, insert it now;
+   if we inserted earlier with size 0, update its `size` to the real size and
+   possibly update `updated_at` and set any status to complete. We also save the
+   comment extracted from the info fork. The file is now available for others to
+   download.
 
-7. **Response:** The server sends a confirmation. In Hotline protocol, the client might not get a special “upload succeeded” message except maybe a generic success or an updated file list broadcast. In our case, we can simply return a success status on the control connection. The client might then request a directory refresh.
+7. **Response:** The server sends a confirmation. In Hotline protocol, the
+   client might not get a special “upload succeeded” message except maybe a
+   generic success or an updated file list broadcast. In our case, we can simply
+   return a success status on the control connection. The client might then
+   request a directory refresh.
 
-**Hotline notes:** The *UploadFile (203)* in Hotline had an optional field for file size (108) if not resuming, which the client provides. We can use that to cross-check that we received the correct amount of data. Hotline also had the server send back a *Reference number (107)* and optionally *File resume data (203)* if resuming. In our implementation, we might generate an internal reference (not really needed if we handle on same connection) and use resume data if applicable.
+**Hotline notes:** The *UploadFile (203)* in Hotline had an optional field for
+file size (108) if not resuming, which the client provides. We can use that to
+cross-check that we received the correct amount of data. Hotline also had the
+server send back a *Reference number (107)* and optionally *File resume data
+(203)* if resuming. In our implementation, we might generate an internal
+reference (not really needed if we handle on same connection) and use resume
+data if applicable.
 
 ### New Folder – *NewFolder (205)*
 
 Creating a directory is a simple metadata operation:
 
-1. **Resolve Parent Path:** Identify the parent directory in which to create the new folder. This comes from the request (Hotline’s fields would include a *File path* for the parent, and *File name* for the new folder).
-2. **Permission Check:** Verify the user has permission to create folders in that location. Hotline defined a “Create Folder (5)” privilege. The server should check either a general “Create Folder” right (if any user can, which might be covered by a combination of Upload and other rights) or a folder-specific rule. We might say if the user can upload to that parent, they can also create subfolders, or enforce a separate bit. For fidelity, implement bit 5 as needed.
-3. **DB Insert:** Create a new FileNode of type 'folder' with the given name and parent\_id = parent folder’s ID. Initialize its `comment` (empty by default), and `created_by` the user’s ID. Set `is_dropbox` to false by default (unless we allow user to create a dropbox specifically – usually dropboxes are set up by admins). The new folder inherits no special permissions automatically, meaning it will by default be accessible to those who had access to the parent (unless inheritance rules apply via code). We could optionally copy the parent’s ACL entries to this new folder to mirror inherited permissions (Hotline likely had per-folder ACL that needed setting separately, but we can ease management by copying parent ACL as initial ACL for child).
-4. **Object Store:** No object storage action is needed – we don’t create any blob for an empty folder.
-5. **Return Result:** Confirm success to client. The client might then issue a GetFileNameList on the parent to see the new folder.
+1. **Resolve Parent Path:** Identify the parent directory in which to create the
+   new folder. This comes from the request (Hotline’s fields would include a
+   *File path* for the parent, and *File name* for the new folder).
+2. **Permission Check:** Verify the user has permission to create folders in
+   that location. Hotline defined a “Create Folder (5)” privilege. The server
+   should check either a general “Create Folder” right (if any user can, which
+   might be covered by a combination of Upload and other rights) or a
+   folder-specific rule. We might say if the user can upload to that parent,
+   they can also create subfolders, or enforce a separate bit. For fidelity,
+   implement bit 5 as needed.
+3. **DB Insert:** Create a new FileNode of type 'folder' with the given name and
+   parent_id = parent folder’s ID. Initialize its `comment` (empty by default),
+   and `created_by` the user’s ID. Set `is_dropbox` to false by default (unless
+   we allow user to create a dropbox specifically – usually dropboxes are set up
+   by admins). The new folder inherits no special permissions automatically,
+   meaning it will by default be accessible to those who had access to the
+   parent (unless inheritance rules apply via code). We could optionally copy
+   the parent’s ACL entries to this new folder to mirror inherited permissions
+   (Hotline likely had per-folder ACL that needed setting separately, but we can
+   ease management by copying parent ACL as initial ACL for child).
+4. **Object Store:** No object storage action is needed – we don’t create any
+   blob for an empty folder.
+5. **Return Result:** Confirm success to client. The client might then issue a
+   GetFileNameList on the parent to see the new folder.
 
 ### Move/Rename File or Folder – *MoveFile (208)* and *SetFileInfo (207)*
 
-Hotline distinguished moving (208) vs setting info (207), but effectively a rename could be handled via SetFileInfo (for just changing the name or comment) and a move to a different folder via MoveFile. We handle both:
+Hotline distinguished moving (208) vs setting info (207), but effectively a
+rename could be handled via SetFileInfo (for just changing the name or comment)
+and a move to a different folder via MoveFile. We handle both:
 
-* **Move File/Folder (208):**
+- **Move File/Folder (208):**
 
-  1. **Identify Source and Destination:** The request will specify a source file/folder path and a destination path (likely including the new folder or new location). For a move within the same parent with a different name, Hotline might still use Move or might treat as rename. Regardless, we get the source FileNode and the target parent folder (and possibly a new name). The protocol’s fields 201, 202 for file name and path, and 212 for “File new path” (destination) indicate the new location. If the destination path ends with a folder and no new name is given, it implies moving with same name; if a new name is part of dest, that’s effectively a move+rename.
-  2. **Permission Check:** Check that the user can remove the item from its current location and add it to the new location. Hotline had a single “Move File (4)” privilege bit for files and “Move Folder (8)” for folders. If we strictly follow that, a user with those bits can move an item from any folder they can see to any other folder they can see. In practice, you might also require Create rights on destination and Delete on source, but since Hotline explicitly lists Move as a privilege, we honor that: the user must have the Move permission for that item’s current folder (and perhaps also for the destination folder). In our ACL model, we could enforce: user must have privilege 4 (move) on the source item’s parent, and privilege 5 (create folder) or upload permission on the destination parent. Administrators with “Upload Anywhere (25)” could possibly override location restrictions.
-  3. **DB Update:** Update the FileNode’s `parent_id` to the new folder’s ID and/or update its `name` if it’s also a rename. This is an atomic update in the DB. We must ensure no name collision in the destination (the UNIQUE(parent\_id,name) constraint will protect us – we should check and fail if violated). For moving folders, all child FileNodes remain linked to the same parent IDs (only the moved folder’s own parent changes), so the tree is effectively spliced out and moved. **Important:** If we stored any kind of full path or had object keys tied to path, this is where complexity arises:
+  1. **Identify Source and Destination:** The request will specify a source
+     file/folder path and a destination path (likely including the new folder or
+     new location). For a move within the same parent with a different name,
+     Hotline might still use Move or might treat as rename. Regardless, we get
+     the source FileNode and the target parent folder (and possibly a new name).
+     The protocol’s fields 201, 202 for file name and path, and 212 for “File
+     new path” (destination) indicate the new location. If the destination path
+     ends with a folder and no new name is given, it implies moving with same
+     name; if a new name is part of dest, that’s effectively a move+rename.
 
-     * If using **ID-based object\_key** (our design), we do *not* change object\_key at all. The files inside a moved folder keep their keys (since keys were just IDs). So we do not need to touch the object store for any file – a huge performance win (moves are instant regardless of data size).
-     * If we had used **path-based keys**, moving a file would require renaming its object in storage (which usually means copy+delete). Similarly moving a folder would entail renaming every object under that folder’s path – potentially thousands of operations and a lot of data movement. This is exactly why we chose flat key mapping. In our design, *no object store operation is needed for a metadata move*.
-  4. **Permissions:** If the item had specific ACL entries, we might consider whether to transfer or update them if moving across different sections. Typically, the ACL entries move along with the item (since they are tied to the FileNode’s id). But if the destination folder has different restrictions, an admin might manually adjust ACLs after. We do not automatically drop or change existing per-file ACLs on move. One exception: if an alias is moved, nothing special; if a dropbox folder is moved out from under a protected area, it remains a dropbox unless changed. This is all left to admin policy; our system just moves the node.
-  5. **Object Store:** As noted, no direct action required if keys are unchanged. If we did need to rename keys (path-coupled keys design), we would have to: for a single file, use `object_store.copy(src, dst)` if available (some object stores allow server-side copy) then delete the old; for a folder, iterate through all descendant files and do the same, which would be very slow and prone to failure mid-way. Avoided in our approach.
-  6. **Result:** Notify success. The client will likely refresh the old and new locations in its UI.
+  2. **Permission Check:** Check that the user can remove the item from its
+     current location and add it to the new location. Hotline had a single “Move
+     File (4)” privilege bit for files and “Move Folder (8)” for folders. If we
+     strictly follow that, a user with those bits can move an item from any
+     folder they can see to any other folder they can see. In practice, you
+     might also require Create rights on destination and Delete on source, but
+     since Hotline explicitly lists Move as a privilege, we honor that: the user
+     must have the Move permission for that item’s current folder (and perhaps
+     also for the destination folder). In our ACL model, we could enforce: user
+     must have privilege 4 (move) on the source item’s parent, and privilege 5
+     (create folder) or upload permission on the destination parent.
+     Administrators with “Upload Anywhere (25)” could possibly override location
+     restrictions.
 
-* **Rename / Set Info (207):**
-  Renaming a file or folder within the same parent can be treated as a special case of move (new parent = same, just name changes). The protocol’s SetFileInfo (207) likely covers changing a file’s comment or attributes, and possibly rename (Hotline had separate “Rename File (3)” and “Rename Folder (7)” privileges). Implementation:
+  3. **DB Update:** Update the FileNode’s `parent_id` to the new folder’s ID
+     and/or update its `name` if it’s also a rename. This is an atomic update in
+     the DB. We must ensure no name collision in the destination (the
+     UNIQUE(parent_id,name) constraint will protect us – we should check and
+     fail if violated). For moving folders, all child FileNodes remain linked to
+     the same parent IDs (only the moved folder’s own parent changes), so the
+     tree is effectively spliced out and moved. **Important:** If we stored any
+     kind of full path or had object keys tied to path, this is where complexity
+     arises:
+
+     - If using **ID-based object_key** (our design), we do *not* change
+       object_key at all. The files inside a moved folder keep their keys (since
+       keys were just IDs). So we do not need to touch the object store for any
+       file – a huge performance win (moves are instant regardless of data
+       size).
+     - If we had used **path-based keys**, moving a file would require renaming
+       its object in storage (which usually means copy+delete). Similarly moving
+       a folder would entail renaming every object under that folder’s path –
+       potentially thousands of operations and a lot of data movement. This is
+       exactly why we chose flat key mapping. In our design, *no object store
+       operation is needed for a metadata move*.
+
+  4. **Permissions:** If the item had specific ACL entries, we might consider
+     whether to transfer or update them if moving across different sections.
+     Typically, the ACL entries move along with the item (since they are tied to
+     the FileNode’s id). But if the destination folder has different
+     restrictions, an admin might manually adjust ACLs after. We do not
+     automatically drop or change existing per-file ACLs on move. One exception:
+     if an alias is moved, nothing special; if a dropbox folder is moved out
+     from under a protected area, it remains a dropbox unless changed. This is
+     all left to admin policy; our system just moves the node.
+
+  5. **Object Store:** As noted, no direct action required if keys are
+     unchanged. If we did need to rename keys (path-coupled keys design), we
+     would have to: for a single file, use `object_store.copy(src, dst)` if
+     available (some object stores allow server-side copy) then delete the old;
+     for a folder, iterate through all descendant files and do the same, which
+     would be very slow and prone to failure mid-way. Avoided in our approach.
+
+  6. **Result:** Notify success. The client will likely refresh the old and new
+     locations in its UI.
+
+- **Rename / Set Info (207):** Renaming a file or folder within the same parent
+  can be treated as a special case of move (new parent = same, just name
+  changes). The protocol’s SetFileInfo (207) likely covers changing a file’s
+  comment or attributes, and possibly rename (Hotline had separate “Rename File
+  (3)” and “Rename Folder (7)” privileges). Implementation:
 
   1. **Identify target:** Locate the FileNode in question via path or ID.
-  2. **Permission Check:** If the operation is renaming, ensure user has rename rights on that item (bits 3 or 7 as appropriate). If setting the comment, ensure they have “Set File Comment (28)” or “Set Folder Comment (29)” for that item. Often, these might be bundled: e.g., an admin or owner can do both. We enforce accordingly.
-  3. **Apply changes:** For rename, update the `name` field in DB (ensuring uniqueness in parent). Since we do not encode name in object\_key, no storage changes needed – just as with moves, this is a pure metadata edit. For comment changes, update the `comment` field. Also possibly update other metadata like custom icon or flags if the protocol supported (Hotline “SetFileInfo” might allow changing file’s Mac type/creator or mod date, etc. – in modern context, not too relevant, but we could allow an admin to set timestamps or such).
-  4. **Object Store:** Not needed (unless we wanted to propagate something like content-type metadata – but that can also be stored in DB or derived).
+  2. **Permission Check:** If the operation is renaming, ensure user has rename
+     rights on that item (bits 3 or 7 as appropriate). If setting the comment,
+     ensure they have “Set File Comment (28)” or “Set Folder Comment (29)” for
+     that item. Often, these might be bundled: e.g., an admin or owner can do
+     both. We enforce accordingly.
+  3. **Apply changes:** For rename, update the `name` field in DB (ensuring
+     uniqueness in parent). Since we do not encode name in object_key, no
+     storage changes needed – just as with moves, this is a pure metadata edit.
+     For comment changes, update the `comment` field. Also possibly update other
+     metadata like custom icon or flags if the protocol supported (Hotline
+     “SetFileInfo” might allow changing file’s Mac type/creator or mod date,
+     etc. – in modern context, not too relevant, but we could allow an admin to
+     set timestamps or such).
+  4. **Object Store:** Not needed (unless we wanted to propagate something like
+     content-type metadata – but that can also be stored in DB or derived).
   5. **Result:** Return success.
 
-Renames are very fast and safe in this design, which is a significant improvement over a file-system based approach that would require moving data or locking the file during rename. We only update a row in the DB.
+Renames are very fast and safe in this design, which is a significant
+improvement over a file-system based approach that would require moving data or
+locking the file during rename. We only update a row in the DB.
 
 ### Create Alias – *MakeFileAlias (209)*
 
-An alias in Hotline is like a shortcut or symbolic link to a file (possibly even to a folder, though named “MakeFileAlias”, we assume it’s mainly for files). Implementation:
+An alias in Hotline is like a shortcut or symbolic link to a file (possibly even
+to a folder, though named “MakeFileAlias”, we assume it’s mainly for files).
+Implementation:
 
-1. **Identify Target and Destination:** The request provides the existing file’s path (source) and a new path for the alias (destination folder and alias name). We locate the target FileNode (must be type 'file'; we should confirm that aliasing a folder is either not allowed or handled similarly). Locate the destination folder and the alias name from the request.
-2. **Permission Check:** Check the user has privilege to create an alias. Hotline’s “Make Alias (31)” is a folder-level privilege, meaning users might be allowed/disallowed to create aliases in a given folder. Our ACL model can support that (bit 31 on the folder). Also, the user should have read access to the target file in the first place (no point aliasing something they can’t access). In some cases, an admin might create an alias specifically to grant access in another area – we handle access at use time anyway. So require at least that the user *can* see the target file (download permission there), and can create items in the destination.
-3. **DB Insert:** Create a new FileNode entry of type 'alias' in the destination folder with the given alias name. Set its `alias_target_id` to the target file’s ID. We do *not* create any object\_key for it (no actual data for alias). We might set its `size` equal to the target’s size, or leave it as 0 and always resolve at runtime. In the Hotline flattened file listing, an alias likely shows the original’s size and maybe an alias icon. To easily show correct size in listings, we can store `size` of an alias as a copy of target’s size at creation. However, if the target file changes (re-uploaded or replaced), that size would not auto-update. It might be acceptable (the alias could show an outdated size until perhaps an update occurs). Alternatively, always resolve at list time: if an entry is type alias, fetch target’s size live. That’s simple: join FileNode alias with FileNode target in the listing query. We can do that and keep alias.size just for convenience or not use it. Similarly for comments – Hotline may have allowed an alias to have its own comment separate from the original file’s comment, or it could show the original’s comment. We might let the user set a distinct comment on the alias. For simplicity, we’ll treat alias comment as independent (so one could describe the link). The protocol doesn’t clarify that; our design choice.
-4. **Object Store:** No action – the alias doesn’t add data or duplicate the file. It’s just another DB pointer to the same object data.
-5. **Access semantics:** We need to consider how access control works via an alias. The alias appears in a folder possibly with different permissions than the original file’s folder. Our approach is: treat the alias as a distinct node for permission checks. I.e., when a user tries to download via the alias, we check their permissions to that alias (which typically inherits the destination folder’s permissions). We do **not** require that the user have permission on the original location. This means an alias can be used to **expose a file to users who otherwise wouldn’t have access** to the original’s folder. This matches how aliases are useful. However, to avoid security issues, only privileged users (with Make Alias rights) can create such an alias in a location where others might see it. Once created, the alias itself can have its own ACL entries if needed (inherited from dest folder). So effectively, the alias is its own resource pointing to data. When serving an alias download, the server will resolve the alias to get the object\_key, but will enforce ACL on the alias node. If the alias node permits the user to download (e.g. because the dest folder is public), the download proceeds even if the original file’s folder was restricted. This behavior should be documented for admins, as it is a deliberate capability (e.g., an admin can put an alias of a file from a restricted area into a public area to share it without duplicating the file). If instead one wanted alias to obey original’s ACL, one could implement that check, but we assume the intention of alias is to bypass original location restrictions (Hotline likely allowed that usage).
-6. **Return Result:** Confirm success. The client will now see the alias in the destination directory (perhaps with an alias badge in the UI).
+1. **Identify Target and Destination:** The request provides the existing file’s
+   path (source) and a new path for the alias (destination folder and alias
+   name). We locate the target FileNode (must be type 'file'; we should confirm
+   that aliasing a folder is either not allowed or handled similarly). Locate
+   the destination folder and the alias name from the request.
+2. **Permission Check:** Check the user has privilege to create an alias.
+   Hotline’s “Make Alias (31)” is a folder-level privilege, meaning users might
+   be allowed/disallowed to create aliases in a given folder. Our ACL model can
+   support that (bit 31 on the folder). Also, the user should have read access
+   to the target file in the first place (no point aliasing something they can’t
+   access). In some cases, an admin might create an alias specifically to grant
+   access in another area – we handle access at use time anyway. So require at
+   least that the user *can* see the target file (download permission there),
+   and can create items in the destination.
+3. **DB Insert:** Create a new FileNode entry of type 'alias' in the destination
+   folder with the given alias name. Set its `alias_target_id` to the target
+   file’s ID. We do *not* create any object_key for it (no actual data for
+   alias). We might set its `size` equal to the target’s size, or leave it as 0
+   and always resolve at runtime. In the Hotline flattened file listing, an
+   alias likely shows the original’s size and maybe an alias icon. To easily
+   show correct size in listings, we can store `size` of an alias as a copy of
+   target’s size at creation. However, if the target file changes (re-uploaded
+   or replaced), that size would not auto-update. It might be acceptable (the
+   alias could show an outdated size until perhaps an update occurs).
+   Alternatively, always resolve at list time: if an entry is type alias, fetch
+   target’s size live. That’s simple: join FileNode alias with FileNode target
+   in the listing query. We can do that and keep alias.size just for convenience
+   or not use it. Similarly for comments – Hotline may have allowed an alias to
+   have its own comment separate from the original file’s comment, or it could
+   show the original’s comment. We might let the user set a distinct comment on
+   the alias. For simplicity, we’ll treat alias comment as independent (so one
+   could describe the link). The protocol doesn’t clarify that; our design
+   choice.
+4. **Object Store:** No action – the alias doesn’t add data or duplicate the
+   file. It’s just another DB pointer to the same object data.
+5. **Access semantics:** We need to consider how access control works via an
+   alias. The alias appears in a folder possibly with different permissions than
+   the original file’s folder. Our approach is: treat the alias as a distinct
+   node for permission checks. I.e., when a user tries to download via the
+   alias, we check their permissions to that alias (which typically inherits the
+   destination folder’s permissions). We do **not** require that the user have
+   permission on the original location. This means an alias can be used to
+   **expose a file to users who otherwise wouldn’t have access** to the
+   original’s folder. This matches how aliases are useful. However, to avoid
+   security issues, only privileged users (with Make Alias rights) can create
+   such an alias in a location where others might see it. Once created, the
+   alias itself can have its own ACL entries if needed (inherited from dest
+   folder). So effectively, the alias is its own resource pointing to data. When
+   serving an alias download, the server will resolve the alias to get the
+   object_key, but will enforce ACL on the alias node. If the alias node permits
+   the user to download (e.g. because the dest folder is public), the download
+   proceeds even if the original file’s folder was restricted. This behavior
+   should be documented for admins, as it is a deliberate capability (e.g., an
+   admin can put an alias of a file from a restricted area into a public area to
+   share it without duplicating the file). If instead one wanted alias to obey
+   original’s ACL, one could implement that check, but we assume the intention
+   of alias is to bypass original location restrictions (Hotline likely allowed
+   that usage).
+6. **Return Result:** Confirm success. The client will now see the alias in the
+   destination directory (perhaps with an alias badge in the UI).
 
 ### Download Entire Folder – *DownloadFolder (210)*
 
-Downloading a whole folder (and its subfolders) as one operation is more complex. Hotline’s protocol for this (210) essentially allowed a client to retrieve multiple files in a folder through a sequence of actions. The server would enumerate all items in the folder recursively and then send them one by one (possibly over the data connection opened on port+1). The client could request to resume or skip particular files in the sequence. Our implementation will follow the same general approach:
+Downloading a whole folder (and its subfolders) as one operation is more
+complex. Hotline’s protocol for this (210) essentially allowed a client to
+retrieve multiple files in a folder through a sequence of actions. The server
+would enumerate all items in the folder recursively and then send them one by
+one (possibly over the data connection opened on port+1). The client could
+request to resume or skip particular files in the sequence. Our implementation
+will follow the same general approach:
 
 1. **Locate Folder:** Resolve the target folder path to its FileNode ID.
-2. **Permission Check:** Ensure user has Download permission for that folder and its contents. Here we have to consider sub-items. Simplest approach: require that the user has at least download access to the entire folder (Hotline’s privilege 2 on that folder), and then proceed. We will filter out any files within that they cannot download (if per-file ACLs exist). Alternatively, we could abort if any item is inaccessible. A better UX is to skip unauthorized files and only send what they can access. We take note of which those are.
-3. **Enumerate Items:** Gather a list of all files within the folder *and its subfolders* (recursively). We need a traversal. We can do a depth-first or breadth-first traversal in the DB:
 
-   * Start with the root of that folder and traverse down. For each subfolder, include its files and push its subfolders into queue. This yields a list of file paths or references. The order should be deterministic; perhaps alphabetical within each folder. Hotline likely sends in some sorted order. We can mimic or just do alphabetical for clarity.
-   * We could produce a flat list of all files with their relative path (from the folder being downloaded) ready to transfer.
-   * Also count them and sum their sizes. The protocol expects the server to first reply with the *Folder item count* and *Total transfer size*. We will send those so the client can display progress (e.g., “Downloading 10 files, total 50MB”). So we compute: number of files (excluding subfolders as separate items? Hotline’s field 220 “Folder item count” might count files; likely it includes files count) and total bytes = sum of sizes of those files.
-   * We then send a reply on the control connection containing those two numbers (and a reference number as usual for the forthcoming transfer).
-4. **Data Transfer Loop:** The client will connect on the data port (like with DownloadFile) and initiate the folder download transfer. The protocol involves a series of small request/response exchanges to send each file:
+2. **Permission Check:** Ensure user has Download permission for that folder and
+   its contents. Here we have to consider sub-items. Simplest approach: require
+   that the user has at least download access to the entire folder (Hotline’s
+   privilege 2 on that folder), and then proceed. We will filter out any files
+   within that they cannot download (if per-file ACLs exist). Alternatively, we
+   could abort if any item is inaccessible. A better UX is to skip unauthorized
+   files and only send what they can access. We take note of which those are.
 
-   * The server sends a header for each item (maybe including a flag indicating whether it’s a file or a folder). Actually, for a folder download, the server might need to also create the directory structure on client side. Hotline’s format likely sends a directory entry to instruct the client to create a subfolder, then sends files inside it. Indeed, in the UploadFolder protocol, there is an “Is folder” flag and a path item count to describe folder hierarchy. For DownloadFolder, it might be similar. Possibly the server first sends the folder structure, or the client creates subfolders as needed when it sees file paths.
-   * A simpler method for us: send files in a depth-first manner and ensure that before sending a file in a subfolder, we have sent an entry telling the client to create that subfolder. The Hotline protocol likely expects the client to reconstruct the directory tree. It might rely on the file path field in the header to include subfolder info. Actually \[15] lines 2423-2431 show the server sends a header containing a "File path" (rest of data) for each item, and the client uses that path to know where to store the file. So the client can create intermediate folders as needed. So we can send each file’s relative path.
-   * After sending an item header, the client responds with what action to take: either “Next file” (skip sending this file, move on), or “Resume file” with an offset if it already has part of it, or “Send file” to proceed with full download. This is quite low-level; essentially the client can choose to skip or resume. For our implementation, we will:
+3. **Enumerate Items:** Gather a list of all files within the folder *and its
+   subfolders* (recursively). We need a traversal. We can do a depth-first or
+   breadth-first traversal in the DB:
 
-     * Read the client’s request for each file. If it says skip, we just move on. If resume, it will provide an offset. We then stream the file from that offset (similar to DownloadFile logic, using get\_range). If full send, we stream from start.
-   * When sending a file’s data, we again leverage object\_store streaming. We already have the object keys from our enumerated list (the DB gave us each file’s object\_key and size). We open an async stream (with range if needed for resume) and pipe it to the network. We wrap it in the flattened file format (the same ‘FILP’ header and forks as a normal file download). So essentially, downloading a folder is like multiple sequential file downloads in one session, each preceded by a small header indicating which file is next.
-   * After each file is done, the client will either request the next file or end if done. The protocol has a “Next file (3)” action code to trigger sending the next header. We continue until all files are processed. Finally, presumably, we send a termination or simply close the connection.
-5. **Edge cases:** If the user doesn’t have access to certain files, we might either skip them entirely (not counting in the initial count perhaps), or send them but expect the client can’t download them (Hotline likely wouldn’t include them if user couldn’t download individually). Safer to exclude those from the list to avoid confusion. So our enumeration would filter out unauthorized files, adjusting the count/size accordingly.
-6. **Performance:** Downloading many files one-by-one can be slower than a single archive. As an enhancement, one might offer to compress the folder server-side (e.g., create a zip on the fly). But that deviates from Hotline’s protocol. Following Hotline, we do it sequentially. This approach can have a lot of overhead if thousands of small files (each file’s flattened header has \~128 bytes overhead plus a round-trip handshake). Hotline was designed for dial-up where this was acceptable; on modern broadband the overhead is negligible unless extremely many files. We ensure to stream efficiently and not load multiple files into memory at once. Our server might pipeline a bit by preparing the next file’s metadata while sending current file, but careful with ordering – probably not needed due to handshake.
+   - Start with the root of that folder and traverse down. For each subfolder,
+     include its files and push its subfolders into queue. This yields a list of
+     file paths or references. The order should be deterministic; perhaps
+     alphabetical within each folder. Hotline likely sends in some sorted order.
+     We can mimic or just do alphabetical for clarity.
+   - We could produce a flat list of all files with their relative path (from
+     the folder being downloaded) ready to transfer.
+   - Also count them and sum their sizes. The protocol expects the server to
+     first reply with the *Folder item count* and *Total transfer size*. We will
+     send those so the client can display progress (e.g., “Downloading 10 files,
+     total 50MB”). So we compute: number of files (excluding subfolders as
+     separate items? Hotline’s field 220 “Folder item count” might count files;
+     likely it includes files count) and total bytes = sum of sizes of those
+     files.
+   - We then send a reply on the control connection containing those two numbers
+     (and a reference number as usual for the forthcoming transfer).
 
-In summary, *DownloadFolder* is implemented as an orchestrated sequence of *DownloadFile* operations. We reuse the **download logic** for each file. We just add the surrounding control flow for multiple files and include subfolder path info in the headers so the client can replicate the structure.
+4. **Data Transfer Loop:** The client will connect on the data port (like with
+   DownloadFile) and initiate the folder download transfer. The protocol
+   involves a series of small request/response exchanges to send each file:
+
+   - The server sends a header for each item (maybe including a flag indicating
+     whether it’s a file or a folder). Actually, for a folder download, the
+     server might need to also create the directory structure on client side.
+     Hotline’s format likely sends a directory entry to instruct the client to
+     create a subfolder, then sends files inside it. Indeed, in the UploadFolder
+     protocol, there is an “Is folder” flag and a path item count to describe
+     folder hierarchy. For DownloadFolder, it might be similar. Possibly the
+     server first sends the folder structure, or the client creates subfolders
+     as needed when it sees file paths.
+
+   - A simpler method for us: send files in a depth-first manner and ensure that
+     before sending a file in a subfolder, we have sent an entry telling the
+     client to create that subfolder. The Hotline protocol likely expects the
+     client to reconstruct the directory tree. It might rely on the file path
+     field in the header to include subfolder info. Actually [15] lines
+     2423-2431 show the server sends a header containing a "File path" (rest of
+     data) for each item, and the client uses that path to know where to store
+     the file. So the client can create intermediate folders as needed. So we
+     can send each file’s relative path.
+
+   - After sending an item header, the client responds with what action to take:
+     either “Next file” (skip sending this file, move on), or “Resume file” with
+     an offset if it already has part of it, or “Send file” to proceed with full
+     download. This is quite low-level; essentially the client can choose to
+     skip or resume. For our implementation, we will:
+
+     - Read the client’s request for each file. If it says skip, we just move
+       on. If resume, it will provide an offset. We then stream the file from
+       that offset (similar to DownloadFile logic, using get_range). If full
+       send, we stream from start.
+
+   - When sending a file’s data, we again leverage object_store streaming. We
+     already have the object keys from our enumerated list (the DB gave us each
+     file’s object_key and size). We open an async stream (with range if needed
+     for resume) and pipe it to the network. We wrap it in the flattened file
+     format (the same ‘FILP’ header and forks as a normal file download). So
+     essentially, downloading a folder is like multiple sequential file
+     downloads in one session, each preceded by a small header indicating which
+     file is next.
+
+   - After each file is done, the client will either request the next file or
+     end if done. The protocol has a “Next file (3)” action code to trigger
+     sending the next header. We continue until all files are processed.
+     Finally, presumably, we send a termination or simply close the connection.
+
+5. **Edge cases:** If the user doesn’t have access to certain files, we might
+   either skip them entirely (not counting in the initial count perhaps), or
+   send them but expect the client can’t download them (Hotline likely wouldn’t
+   include them if user couldn’t download individually). Safer to exclude those
+   from the list to avoid confusion. So our enumeration would filter out
+   unauthorized files, adjusting the count/size accordingly.
+
+6. **Performance:** Downloading many files one-by-one can be slower than a
+   single archive. As an enhancement, one might offer to compress the folder
+   server-side (e.g., create a zip on the fly). But that deviates from Hotline’s
+   protocol. Following Hotline, we do it sequentially. This approach can have a
+   lot of overhead if thousands of small files (each file’s flattened header has
+   ~128 bytes overhead plus a round-trip handshake). Hotline was designed for
+   dial-up where this was acceptable; on modern broadband the overhead is
+   negligible unless extremely many files. We ensure to stream efficiently and
+   not load multiple files into memory at once. Our server might pipeline a bit
+   by preparing the next file’s metadata while sending current file, but careful
+   with ordering – probably not needed due to handshake.
+
+In summary, *DownloadFolder* is implemented as an orchestrated sequence of
+*DownloadFile* operations. We reuse the **download logic** for each file. We
+just add the surrounding control flow for multiple files and include subfolder
+path info in the headers so the client can replicate the structure.
 
 ### Upload Entire Folder – *UploadFolder (213)*
 
-Uploading a folder (with subfolders and files) is the inverse of DownloadFolder. The client will be sending multiple files and directory creations, and the server must reconstruct the hierarchy. According to the Hotline protocol, after initiating an UploadFolder, the client connects on the data port and then the server and client engage in a similar item-by-item exchange. Essentially, for each file or subfolder from the client’s local folder, the server will be told what it is and where to create it. Our implementation:
+Uploading a folder (with subfolders and files) is the inverse of DownloadFolder.
+The client will be sending multiple files and directory creations, and the
+server must reconstruct the hierarchy. According to the Hotline protocol, after
+initiating an UploadFolder, the client connects on the data port and then the
+server and client engage in a similar item-by-item exchange. Essentially, for
+each file or subfolder from the client’s local folder, the server will be told
+what it is and where to create it. Our implementation:
 
-1. **Initiation:** The client sends an UploadFolder request with the name of the folder they're uploading and the destination path on server. The server responds with a reference number, etc., like a normal upload, and then opens data connection. On the data connection, the client starts sending items. The initial item might be the top-level folder itself. The protocol fields include *Folder item count* and *Transfer size* as well, giving the server an idea of how many items and bytes will come. We can use those for progress or verification but it’s not strictly necessary for functionality.
-2. **Permission Check:** Verify the user can upload to the specified destination path (the parent into which the new folder will be created). That requires Upload rights on that parent (and Create Folder rights since a new folder is being made). In Hotline, starting an UploadFolder (213) required Upload File privilege, and the server likely just enforced that on target. We ensure they have rights on the target parent.
-3. **Receive Items:** The data stream from the client will contain a sequence of structures. From the protocol snippet:
+1. **Initiation:** The client sends an UploadFolder request with the name of the
+   folder they're uploading and the destination path on server. The server
+   responds with a reference number, etc., like a normal upload, and then opens
+   data connection. On the data connection, the client starts sending items. The
+   initial item might be the top-level folder itself. The protocol fields
+   include *Folder item count* and *Transfer size* as well, giving the server an
+   idea of how many items and bytes will come. We can use those for progress or
+   verification but it’s not strictly necessary for functionality.
 
-   * The client first waits for server's go-ahead (server likely sent a *Next file (3)* action to prompt first item). Then the client sends a structure that includes:
+2. **Permission Check:** Verify the user can upload to the specified destination
+   path (the parent into which the new folder will be created). That requires
+   Upload rights on that parent (and Create Folder rights since a new folder is
+   being made). In Hotline, starting an UploadFolder (213) required Upload File
+   privilege, and the server likely just enforced that on target. We ensure they
+   have rights on the target parent.
 
-     * A *data size* (length of this structure),
-     * An *“Is folder” flag* (0 or 1),
-     * A *Path item count* (number of path components),
-     * A *File name path* consisting of that many names.
-   * This essentially tells the server: “I have an item located at (for example) path count=2, names \[‘Subfolder’, ‘file.txt’], and it is a file or folder based on flag.” If is\_folder=1, it means the client is telling the server to create a folder (with that path). If is\_folder=0, it's about to send a file located at that path. The server can use the path names to determine where to create the item relative to the base folder being uploaded. For instance, if the user is uploading a folder “Photos” containing subfolder “Vacation” and file “image1.jpg” in it, the first item might be `is_folder=1, path_count=1, name="Photos"` (to create the root folder itself on server if not already created by the initial request – though likely the initial request’s File name was "Photos" and File path was destination, so server should create "Photos" in the destination before data transfer begins). Actually, given the fields 201 (File name) and 202 (File path) in the request, the server already knows to create a folder "Photos" at the target path on receiving the request (it might do that immediately). So that top-level folder is done. Then the client will send items inside it. E.g., `is_folder=1, path_count=2, names=["Photos","Vacation"]` to create "Vacation" subfolder. Then `is_folder=0, path_count=3, names=["Photos","Vacation","image1.jpg"]` followed by the file content for image1.jpg.
-   * Our server will parse each incoming item descriptor:
+3. **Receive Items:** The data stream from the client will contain a sequence of
+   structures. From the protocol snippet:
 
-     * If `is_folder == 1`: create a new folder FileNode. The path given is relative to the destination root of this upload, but likely includes the root as first component. We can ignore the first component if it's the main folder already created. Or perhaps the protocol doesn’t send the root again. Regardless, we map the path: find/create each folder in the path that doesn’t exist. We likely maintain a map of folder paths to FileNode IDs as we create them to avoid duplicates or re-creating. For example, when we get \["Photos","Vacation"], we already have "Photos" created (top-level), so we just create "Vacation" under it.
-     * If `is_folder == 0`: the item is a file. The structure will be immediately followed by the actual file data (the client, after sending the header, likely waits for server to request file download). Actually, from \[19] L2838-L2852 and L2890-L2898, it appears:
+   - The client first waits for server's go-ahead (server likely sent a *Next
+     file (3)* action to prompt first item). Then the client sends a structure
+     that includes:
 
-       * After each item header, the server can respond with the same actions (Next file, Resume file, Send file). So for a file item, the server should send a request to actually get the file data. It can choose to resume (if it somehow already has part – likely not in fresh upload) or to request send file. We will always request send (action 1) for new files. The client then sends the flattened file object content (with info and data forks). We then handle that exactly like a normal file upload (as in UploadFile logic above), except we already know the destination folder from the path.
-       * So essentially, on receiving a file item descriptor, we: resolve/ensure the parent folders from the path exist (should exist by now), create a FileNode for the file (or perhaps wait until content arrives to create). Then send an action=1 (Send file) to client. Then client sends the file bytes which we stream to object\_store via multipart. Once done, we finalize and confirm by sending Next file (3) to get the next item.
-     * If the server wanted to skip an item (maybe if it already exists), it could send Next file without asking for data, and the client would move on. Or if it wanted to resume an incomplete file (if reuploading and partially present), it could send Resume action (2) along with offset, and the client would then send only the remaining bytes. We can implement skip/resume logic if needed (e.g., to avoid duplicates). But typically, on a fresh upload, we’ll create everything anew and send action 1 for all files.
-   * This continues until all items have been processed. The client then likely signals end-of-folder (possibly by sending an empty item or the server knowing item\_count reached). In the protocol, the client knows how many items it told the server (Folder item count from initial request), so after that many, the transfer is done.
+     - A *data size* (length of this structure),
+     - An *“Is folder” flag* (0 or 1),
+     - A *Path item count* (number of path components),
+     - A *File name path* consisting of that many names.
+
+   - This essentially tells the server: “I have an item located at (for example)
+     path count=2, names [‘Subfolder’, ‘file.txt’], and it is a file or folder
+     based on flag.” If is_folder=1, it means the client is telling the server
+     to create a folder (with that path). If is_folder=0, it's about to send a
+     file located at that path. The server can use the path names to determine
+     where to create the item relative to the base folder being uploaded. For
+     instance, if the user is uploading a folder “Photos” containing subfolder
+     “Vacation” and file “image1.jpg” in it, the first item might be
+     `is_folder=1, path_count=1, name="Photos"` (to create the root folder
+     itself on server if not already created by the initial request – though
+     likely the initial request’s File name was "Photos" and File path was
+     destination, so server should create "Photos" in the destination before
+     data transfer begins). Actually, given the fields 201 (File name) and 202
+     (File path) in the request, the server already knows to create a folder
+     "Photos" at the target path on receiving the request (it might do that
+     immediately). So that top-level folder is done. Then the client will send
+     items inside it. E.g.,
+     `is_folder=1, path_count=2, names=["Photos","Vacation"]` to create
+     "Vacation" subfolder. Then
+     `is_folder=0, path_count=3, names=["Photos","Vacation","image1.jpg"]`
+     followed by the file content for image1.jpg.
+
+   - Our server will parse each incoming item descriptor:
+
+     - If `is_folder == 1`: create a new folder FileNode. The path given is
+       relative to the destination root of this upload, but likely includes the
+       root as first component. We can ignore the first component if it's the
+       main folder already created. Or perhaps the protocol doesn’t send the
+       root again. Regardless, we map the path: find/create each folder in the
+       path that doesn’t exist. We likely maintain a map of folder paths to
+       FileNode IDs as we create them to avoid duplicates or re-creating. For
+       example, when we get ["Photos","Vacation"], we already have "Photos"
+       created (top-level), so we just create "Vacation" under it.
+
+     - If `is_folder == 0`: the item is a file. The structure will be
+       immediately followed by the actual file data (the client, after sending
+       the header, likely waits for server to request file download). Actually,
+       from [19] L2838-L2852 and L2890-L2898, it appears:
+
+       - After each item header, the server can respond with the same actions
+         (Next file, Resume file, Send file). So for a file item, the server
+         should send a request to actually get the file data. It can choose to
+         resume (if it somehow already has part – likely not in fresh upload) or
+         to request send file. We will always request send (action 1) for new
+         files. The client then sends the flattened file object content (with
+         info and data forks). We then handle that exactly like a normal file
+         upload (as in UploadFile logic above), except we already know the
+         destination folder from the path.
+       - So essentially, on receiving a file item descriptor, we: resolve/ensure
+         the parent folders from the path exist (should exist by now), create a
+         FileNode for the file (or perhaps wait until content arrives to
+         create). Then send an action=1 (Send file) to client. Then client sends
+         the file bytes which we stream to object_store via multipart. Once
+         done, we finalize and confirm by sending Next file (3) to get the next
+         item.
+
+     - If the server wanted to skip an item (maybe if it already exists), it
+       could send Next file without asking for data, and the client would move
+       on. Or if it wanted to resume an incomplete file (if reuploading and
+       partially present), it could send Resume action (2) along with offset,
+       and the client would then send only the remaining bytes. We can implement
+       skip/resume logic if needed (e.g., to avoid duplicates). But typically,
+       on a fresh upload, we’ll create everything anew and send action 1 for all
+       files.
+
+   - This continues until all items have been processed. The client then likely
+     signals end-of-folder (possibly by sending an empty item or the server
+     knowing item_count reached). In the protocol, the client knows how many
+     items it told the server (Folder item count from initial request), so after
+     that many, the transfer is done.
+
 4. **DB and Storage Operations:** As described:
 
-   * For each new folder encountered, insert a FileNode (type='folder') in the appropriate parent. Use the name given. Inherit dropbox flag = false unless we decide differently (if client is uploading into a dropbox, the new subfolders could possibly be marked dropbox as well? Usually no, subfolders inside dropbox might also be dropbox by inheritance or not accessible – an edge consideration beyond protocol’s scope).
-   * For each file, when its data arrives, we create a FileNode (type='file', parent as resolved by path) and stream the content to object\_store (like normal upload). If a file already exists at that path and the user has right to overwrite, we might skip or replace it.
-   * Use the same multi-part upload handling. However, note we might have multiple files to upload, but we likely handle them sequentially, one `WriteMultipart` at a time, to simplify. This is fine.
-   * Comments and other metadata from the flatten info forks are captured for each file and stored.
-   * The structure allows nested subfolders, so we must maintain a context of the base upload folder. Possibly the server should have created the base folder when the initial 213 request came (the request has File name and File path – File name likely is the root folder to create). We do that upfront. Then the data connection will handle interior items.
-5. **Permission and ACLs:** All new files and folders created will by default inherit the destination’s permissions context. In other words, if you upload a folder into an area, those files initially have whatever access the parent folder implies (no special Permission entries of their own unless the parent had some inheritance logic). Our system doesn’t automatically create new ACL entries for each file; they will just be governed by parent folder’s ACL unless changed. This matches typical expectation – newly uploaded files in a folder are accessible to whoever can access that folder. If needed, an admin can set specific ACLs afterward.
-6. **Finish:** After processing the last item, the server closes out the transfer (perhaps sending a final Next file or simply closing connection). On the control channel, it may send a success notification.
+   - For each new folder encountered, insert a FileNode (type='folder') in the
+     appropriate parent. Use the name given. Inherit dropbox flag = false unless
+     we decide differently (if client is uploading into a dropbox, the new
+     subfolders could possibly be marked dropbox as well? Usually no, subfolders
+     inside dropbox might also be dropbox by inheritance or not accessible – an
+     edge consideration beyond protocol’s scope).
+   - For each file, when its data arrives, we create a FileNode (type='file',
+     parent as resolved by path) and stream the content to object_store (like
+     normal upload). If a file already exists at that path and the user has
+     right to overwrite, we might skip or replace it.
+   - Use the same multi-part upload handling. However, note we might have
+     multiple files to upload, but we likely handle them sequentially, one
+     `WriteMultipart` at a time, to simplify. This is fine.
+   - Comments and other metadata from the flatten info forks are captured for
+     each file and stored.
+   - The structure allows nested subfolders, so we must maintain a context of
+     the base upload folder. Possibly the server should have created the base
+     folder when the initial 213 request came (the request has File name and
+     File path – File name likely is the root folder to create). We do that
+     upfront. Then the data connection will handle interior items.
 
-This process effectively reuses the *UploadFile* logic repeatedly and the *NewFolder* logic for subfolders. It's more involved but conceptually straightforward.
+5. **Permission and ACLs:** All new files and folders created will by default
+   inherit the destination’s permissions context. In other words, if you upload
+   a folder into an area, those files initially have whatever access the parent
+   folder implies (no special Permission entries of their own unless the parent
+   had some inheritance logic). Our system doesn’t automatically create new ACL
+   entries for each file; they will just be governed by parent folder’s ACL
+   unless changed. This matches typical expectation – newly uploaded files in a
+   folder are accessible to whoever can access that folder. If needed, an admin
+   can set specific ACLs afterward.
+
+6. **Finish:** After processing the last item, the server closes out the
+   transfer (perhaps sending a final Next file or simply closing connection). On
+   the control channel, it may send a success notification.
+
+This process effectively reuses the *UploadFile* logic repeatedly and the
+*NewFolder* logic for subfolders. It's more involved but conceptually
+straightforward.
 
 ## Access Control Enforcement
 
-Security is crucial: the system must enforce **folder-level and per-file ACLs** on all operations. We have integrated our design with the shared permissions schema to achieve this. Key points of ACL enforcement in our implementation:
+Security is crucial: the system must enforce **folder-level and per-file ACLs**
+on all operations. We have integrated our design with the shared permissions
+schema to achieve this. Key points of ACL enforcement in our implementation:
 
-* **Privilege Model:** We adopt Hotline’s privilege bitmap scheme. Each user has a global privileges mask (`User.global_access`) which grants baseline rights (e.g., the user might have global Download permission bit = 1, Upload = 1, etc., if the admin allowed it). Additionally, each folder or file can have specific permission entries (`Permission` records) that override or refine these rights on that resource. Hotline distinguished *general privileges* vs *folder privileges*. In our model, global privileges are general; folder privileges can be set per folder via the Permission table. For example, a user might globally have no upload rights, but the admin could specifically allow them to upload to “Uploads” folder by adding a Permission entry for that user on that folder with the Upload bit enabled. Conversely, we can deny access by not granting a right in a context where the global would allow it – e.g., to create a **dropbox**, an admin would give everyone Upload rights (bit 1) on that folder but not give Download (bit 2), effectively making it write-only for them. Additionally, the **View Drop Boxes (30)** bit can be used globally to allow certain users (e.g., moderators) to see the contents of dropboxes; our server will check for that bit to decide if a user can list/download from a dropbox.
-* **ACL Enforcement Logic:** For each request, we perform checks as described in operations above. In general, the logic for a user `U` accessing resource `X` (file or folder) is:
+- **Privilege Model:** We adopt Hotline’s privilege bitmap scheme. Each user has
+  a global privileges mask (`User.global_access`) which grants baseline rights
+  (e.g., the user might have global Download permission bit = 1, Upload = 1,
+  etc., if the admin allowed it). Additionally, each folder or file can have
+  specific permission entries (`Permission` records) that override or refine
+  these rights on that resource. Hotline distinguished *general privileges* vs
+  *folder privileges*. In our model, global privileges are general; folder
+  privileges can be set per folder via the Permission table. For example, a user
+  might globally have no upload rights, but the admin could specifically allow
+  them to upload to “Uploads” folder by adding a Permission entry for that user
+  on that folder with the Upload bit enabled. Conversely, we can deny access by
+  not granting a right in a context where the global would allow it – e.g., to
+  create a **dropbox**, an admin would give everyone Upload rights (bit 1) on
+  that folder but not give Download (bit 2), effectively making it write-only
+  for them. Additionally, the **View Drop Boxes (30)** bit can be used globally
+  to allow certain users (e.g., moderators) to see the contents of dropboxes;
+  our server will check for that bit to decide if a user can list/download from
+  a dropbox.
 
-  1. Determine the set of privileges `P` that apply. Start with `P = U.global_access` (bitmask).
-  2. Find any Permission entries for resource X (or its parent if we consider inheritance). We do **not** automatically inherit ACLs from parent in this design, except that absence of an entry means the parent’s rules implicitly apply by virtue of user’s global rights and parent’s restrictions. If a Permission entry exists for X and for this user (or a group they belong to), it explicitly grants certain bits. We could interpret absence of a bit in that entry as a denial (override) or just not granting anything extra. There are different models:
+- **ACL Enforcement Logic:** For each request, we perform checks as described in
+  operations above. In general, the logic for a user `U` accessing resource `X`
+  (file or folder) is:
 
-     * *Additive ACL:* global rights + any folder-specific grants. In this model, if a folder has an entry granting a user Download, that user can download even if global disallowed (i.e., it’s an exception). And if the folder has no entry restricting it, a user with global right can proceed. If we want to allow explicit denial, we’d have to store negative rights (not in our schema). Instead, we implement it as additive with the understanding that admin can set global rights low (deny by default) and grant per folder as needed (or vice versa).
-     * *Override ACL:* if any entry exists for that resource or its parents, it could override global. Hotline’s documentation is a bit unclear, but the presence of folder-specific privileges suggests that if set, those define what the user can do in that folder, possibly irrespective of global. We might adopt: if a folder has any Permission entries for a given action, then only those listed can perform it in that folder (others implicitly denied, even if global says yes). This would align with the concept of dropbox: if a folder has an entry that only allows Upload to everyone, and no entry for Download (even though a user might have global download, the intention is to block it in this folder). So one rule could be: **folder-specific ACL overrides global** for that folder (and subcontents, unless subfolder has its own). This means when checking permissions, we first look for an entry on the resource (file or containing folder). If one exists for the relevant privilege, we abide by it (allow or deny if user not in list). If none exists, we defer to global.
-  3. Groups: If the user isn’t directly allowed but belongs to a group that is, that counts as allowed. We combine their group permissions (just OR the bits from any matching group entries).
-  4. Dropboxes: Marked by `is_dropbox=true`, these are effectively folders intended to be write-only for normal users. Implementation: We set such a folder’s ACL such that:
+  1. Determine the set of privileges `P` that apply. Start with
+     `P = U.global_access` (bitmask).
 
-     * `Permission(resource_id=dropbox_id, principal_type='group', principal_id=<Everyone>, privileges=UploadBit)` – granting upload to all.
-     * No permission granting Download or List to that group. According to our override rule, that means even if users have global download, they can’t download here since the folder has a specific ACL that *only* gave upload. Additionally, to hide contents, our code explicitly checks `if folder.is_dropbox and user lacks VIEW_DROPBOX then don’t list contents` as mentioned. So a normal user can upload (because of the allow entry) but cannot see files (because no allow entry for download and override logic kicks in, plus our listing filter). An admin or privileged user with the global “View Drop Boxes” bit will bypass the hiding and can list/download from it.
-  5. Per-file ACL: If a file itself has an entry (less common unless someone set a specific file to only be downloadable by certain users), we check that as well. Typically, if a file has a Permission entry, we treat that as authoritative for that file – e.g., mark a file as private to a user by giving only that user Download permission on it and no one else. Others will be denied even if they can list the folder. We can implement that by checking the Permission table for resource\_type='file', resource\_id=\<file\_id>. If an entry exists and the requesting user or their group is not in it with the needed bit, we deny.
-  6. We should also consider the “Any Name (26)” privilege which allowed users to override name restrictions – in our context, that might allow them to upload a file that overwrites an existing one or use reserved names. We can interpret it loosely: a user with that bit could overwrite files they don’t own, or use illegal characters, etc. This is an edge case – we mention it as a known privilege but specifics left out in code; an admin can always do such actions anyway.
+  2. Find any Permission entries for resource X (or its parent if we consider
+     inheritance). We do **not** automatically inherit ACLs from parent in this
+     design, except that absence of an entry means the parent’s rules implicitly
+     apply by virtue of user’s global rights and parent’s restrictions. If a
+     Permission entry exists for X and for this user (or a group they belong
+     to), it explicitly grants certain bits. We could interpret absence of a bit
+     in that entry as a denial (override) or just not granting anything extra.
+     There are different models:
+
+     - *Additive ACL:* global rights + any folder-specific grants. In this
+       model, if a folder has an entry granting a user Download, that user can
+       download even if global disallowed (i.e., it’s an exception). And if the
+       folder has no entry restricting it, a user with global right can proceed.
+       If we want to allow explicit denial, we’d have to store negative rights
+       (not in our schema). Instead, we implement it as additive with the
+       understanding that admin can set global rights low (deny by default) and
+       grant per folder as needed (or vice versa).
+     - *Override ACL:* if any entry exists for that resource or its parents, it
+       could override global. Hotline’s documentation is a bit unclear, but the
+       presence of folder-specific privileges suggests that if set, those define
+       what the user can do in that folder, possibly irrespective of global. We
+       might adopt: if a folder has any Permission entries for a given action,
+       then only those listed can perform it in that folder (others implicitly
+       denied, even if global says yes). This would align with the concept of
+       dropbox: if a folder has an entry that only allows Upload to everyone,
+       and no entry for Download (even though a user might have global download,
+       the intention is to block it in this folder). So one rule could be:
+       **folder-specific ACL overrides global** for that folder (and
+       subcontents, unless subfolder has its own). This means when checking
+       permissions, we first look for an entry on the resource (file or
+       containing folder). If one exists for the relevant privilege, we abide by
+       it (allow or deny if user not in list). If none exists, we defer to
+       global.
+
+  3. Groups: If the user isn’t directly allowed but belongs to a group that is,
+     that counts as allowed. We combine their group permissions (just OR the
+     bits from any matching group entries).
+
+  4. Dropboxes: Marked by `is_dropbox=true`, these are effectively folders
+     intended to be write-only for normal users. Implementation: We set such a
+     folder’s ACL such that:
+
+  - `Permission(resource_id=dropbox_id, principal_type='group',`
+    `principal_id=<Everyone>, privileges=UploadBit)` – granting upload to all.
+  - No permission granting Download or List to that group. According to our
+    override rule, that means even if users have global download, they can’t
+    download here since the folder has a specific ACL that *only* gave upload.
+    Additionally, to hide contents, our code explicitly checks
+    `if folder.is_dropbox and user lacks VIEW_DROPBOX then don’t list contents`
+    as mentioned. So a normal user can upload (because of the allow entry) but
+    cannot see files (because no allow entry for download and override logic
+    kicks in, plus our listing filter). An admin or privileged user with the
+    global “View Drop Boxes” bit will bypass the hiding and can list/download
+    from it.
+
+  1. Per-file ACL: If a file itself has an entry (less common unless someone set
+     a specific file to only be downloadable by certain users), we check that as
+     well. Typically, if a file has a Permission entry, we treat that as
+     authoritative for that file – e.g., mark a file as private to a user by
+     giving only that user Download permission on it and no one else. Others
+     will be denied even if they can list the folder. We can implement that by
+     checking the Permission table for resource_type='file',
+     resource_id=\<file_id>. If an entry exists and the requesting user or their
+     group is not in it with the needed bit, we deny.
+
+  2. We should also consider the “Any Name (26)” privilege which allowed users
+     to override name restrictions – in our context, that might allow them to
+     upload a file that overwrites an existing one or use reserved names. We can
+     interpret it loosely: a user with that bit could overwrite files they don’t
+     own, or use illegal characters, etc. This is an edge case – we mention it
+     as a known privilege but specifics left out in code; an admin can always do
+     such actions anyway.
 
 Applying these rules ensures that:
 
-* Users cannot perform operations they’re not allowed to. Each command implementation incorporated these checks (download, upload, delete, etc., all gated by checking the corresponding bit via either global or folder ACL). For example, a user attempting to delete a file triggers check for Delete File (bit 0) on that file’s folder (or file); attempting to move a folder triggers check for Move Folder (8) on source, and possibly Create rights on dest.
-* Aliases: As discussed, we decide that an alias’s accessibility is governed by the alias’s location. If a user can see and download the alias, the server will allow it, even if the original file was elsewhere. We do not separately check the original file’s ACL for that user. (However, we might check that original hasn’t been deleted or that the person creating the alias had access at creation time). Once alias exists, treat it as a normal file in that folder. This effectively means an alias can be used to *share* a file into a more accessible area. Admins should be cautious, but since only users with Make Alias privilege can create them, this is under control.
-* Admin Override: Typically there is an “admin” or “owner” who has all privileges. Hotline’s permission bitmap often had bit 25 *Upload Anywhere* and other bits for broad bypass. We can consider that if a user has a global flag that essentially grants all (or specifically one that says they’re an admin), our checks can short-circuit and allow. For instance, if `User.global_access` has all bits set (e.g., 0xFFFFFFFF), we treat them as full admin. Or if a certain high bit like 32 was reserved for administrator. Implementation-wise, we may just ensure that if they have been granted every relevant bit globally, they won’t be blocked by folder ACL (except maybe dropbox view if that’s not set – but an admin likely has that too).
-* **Auditing and Logging:** We should log permission failures for security auditing. E.g., if user tries to download a file without rights, we log it.
+- Users cannot perform operations they’re not allowed to. Each command
+  implementation incorporated these checks (download, upload, delete, etc., all
+  gated by checking the corresponding bit via either global or folder ACL). For
+  example, a user attempting to delete a file triggers check for Delete File
+  (bit 0) on that file’s folder (or file); attempting to move a folder triggers
+  check for Move Folder (8) on source, and possibly Create rights on dest.
+- Aliases: As discussed, we decide that an alias’s accessibility is governed by
+  the alias’s location. If a user can see and download the alias, the server
+  will allow it, even if the original file was elsewhere. We do not separately
+  check the original file’s ACL for that user. (However, we might check that
+  original hasn’t been deleted or that the person creating the alias had access
+  at creation time). Once alias exists, treat it as a normal file in that
+  folder. This effectively means an alias can be used to *share* a file into a
+  more accessible area. Admins should be cautious, but since only users with
+  Make Alias privilege can create them, this is under control.
+- Admin Override: Typically there is an “admin” or “owner” who has all
+  privileges. Hotline’s permission bitmap often had bit 25 *Upload Anywhere* and
+  other bits for broad bypass. We can consider that if a user has a global flag
+  that essentially grants all (or specifically one that says they’re an admin),
+  our checks can short-circuit and allow. For instance, if `User.global_access`
+  has all bits set (e.g., 0xFFFFFFFF), we treat them as full admin. Or if a
+  certain high bit like 32 was reserved for administrator. Implementation-wise,
+  we may just ensure that if they have been granted every relevant bit globally,
+  they won’t be blocked by folder ACL (except maybe dropbox view if that’s not
+  set – but an admin likely has that too).
+- **Auditing and Logging:** We should log permission failures for security
+  auditing. E.g., if user tries to download a file without rights, we log it.
 
-By centralizing permission checks in each operation handler, and using the common Permission table, we maintain consistency across features. The **shared permissions table** means a user’s access to files is managed in the same place as, say, their chat or news privileges – an admin can update one system. The bits we cited align with Hotline’s known privileges, so an admin interface can toggle those bits per user or per folder.
+By centralizing permission checks in each operation handler, and using the
+common Permission table, we maintain consistency across features. The **shared
+permissions table** means a user’s access to files is managed in the same place
+as, say, their chat or news privileges – an admin can update one system. The
+bits we cited align with Hotline’s known privileges, so an admin interface can
+toggle those bits per user or per folder.
 
 ## Metadata Consistency and Sync
 
-Because we split metadata (DB) and file content (object store), maintaining consistency is critical:
+Because we split metadata (DB) and file content (object store), maintaining
+consistency is critical:
 
-* **Two-Phase Operations:** For any create/upload, we have two steps (DB insert and object upload). We must handle failures in between. Our approach:
+- **Two-Phase Operations:** For any create/upload, we have two steps (DB insert
+  and object upload). We must handle failures in between. Our approach:
 
-  * On **file upload**: We can delay DB insertion until after the object upload completes successfully. This way, if the upload fails (network issue, etc.), we simply don’t have a DB record (so no “ghost” file appears in listings). The downside is if the client crashes after sending data but before we commit DB, the file is in object storage without record. To mitigate orphaned objects, we can either:
+  - On **file upload**: We can delay DB insertion until after the object upload
+    completes successfully. This way, if the upload fails (network issue, etc.),
+    we simply don’t have a DB record (so no “ghost” file appears in listings).
+    The downside is if the client crashes after sending data but before we
+    commit DB, the file is in object storage without record. To mitigate
+    orphaned objects, we can either:
 
-    * Use a *staging bucket or prefix* for incomplete uploads and only move to the final key on commit. That adds complexity.
-    * Or insert DB record at start with a flag (incomplete), then attempt upload. If upload fails, mark the record or remove it. If the server crashes mid-upload, the record remains flagged incomplete; a cleanup job could later remove it and any partial data (though in object storage, partial multipart uploads that aren’t completed do not produce a visible object, but they do consume storage until aborted).
-    * The `object_store` crate likely handles multipart such that if we don’t call `finish()`, the upload is not finalized (thus invisible). So an interrupted upload may leave an *in-progress* multipart that should be aborted later. We should track the upload ID and schedule an abort if the client never resumes. Many cloud providers auto-abort unfinished multi-part after some days.
-  * On **file delete**: We do the reverse order – remove the DB record first (so it disappears from listings immediately), then delete the object from storage. If the storage deletion fails (transient error), we’ll have an orphan object. But the DB no longer references it (dangling data). We can attempt the storage deletion again in a retry or background job. The risk is wasted storage. We prefer that over having a broken DB entry. Another strategy: mark file as “deleted” in DB (soft delete) until storage confirms deletion, but that complicates things. Simpler: best-effort delete and log errors. A periodic background cleaner can list orphan objects and remove them if needed.
-  * On **moves/renames**: Since these are DB-only (in our design), they either succeed or fail in DB. No partial storage action. So consistent by nature.
-  * On **folder delete**: We should ideally wrap it in a transaction: delete all child records in DB (cascading) and then for each object, attempt deletion. If an object deletion fails, we have already removed DB entries. As above, we log and maybe retry later. Perhaps do not commit DB transaction until all object deletions have succeeded? But that might not be feasible if many files (long transaction holding locks). It's often acceptable to commit DB first, then do storage cleanup out-of-tx. In case of failure, at worst storage has some straggler files which are not listed anywhere (harmless except cost). We can reclaim later. This trades strong immediate consistency for simplicity and performance.
-* **Transactional Integrity:** The DB operations themselves use transactions to maintain referential integrity. For example, when uploading a folder with many files, we might handle each file in its own small transaction (so one file’s failure doesn’t roll back the entire batch). That could leave half the files uploaded if there’s an error mid-way – which is fine, the user can resume or re-upload the rest. It’s similar to how it would be in a manual process. If we wanted all-or-nothing for an UploadFolder, we could wrap the entire operation in a transaction, but that is impractical if dozens of large files (the transaction would be huge and long-lived). Better to commit as we go and handle partial completion. The protocol’s resume actions allow continuing later.
-* **Object Store Consistency:** Modern object stores are typically strongly consistent for read-after-write and list-after-write (S3 now guarantees consistency for new puts and deletes). But historically, some had eventual consistency for listing. Since we rely on DB for listing, we avoid those issues entirely. For reading file content, once `put_multipart.finish()` returns success, the subsequent `get` will see the complete file. Our design assumes a single object store and that all server nodes (if multiple) use the same bucket and credentials. If multiple server instances handle requests, they all share the DB, so they all know about new files immediately via DB. If one instance uploads a file and adds DB entry, another instance’s subsequent listing will show it (since DB is updated), and a download request to that other instance will find the object (assuming the object store has it by then, which it should because the upload finished and committed).
-* **Concurrency considerations:** We should guard against race conditions like two clients uploading a file with the same name in the same folder simultaneously. With a DB unique constraint, one will fail on insert. We can catch that and respond with an error (or rename one automatically if we wanted). Similarly, two deletions at same time – one will fail to find the file if the other already removed it. These edge cases can be handled by transaction isolation or simple error checking (e.g., if a delete doesn’t find the record, assume it was already deleted).
-* **Metadata Sync:** If any direct changes occur in object storage outside our app (e.g. an admin manually adds a file to the bucket), our DB won’t know. We assume all modifications go through the app. We could have an administrative tool to sync – for example, scan the bucket for files with no DB entry and optionally import or remove them. But ideally, avoid out-of-band changes. One area to watch is file **size** and **last modified**: we store size in DB when uploading. If the actual object store content somehow differs (maybe someone replaced the object directly), DB would be wrong. Again, we assume no such unsupervised changes. If needed, one could verify content length via `head()` on object store when serving, but that’s extra overhead. Consistency in our controlled environment should be maintained by design.
-* **Performance vs Consistency Trade-off:** We favor consistency for user-facing metadata. So we do slightly redundant work like storing file size and mod time in DB (though the object store has this metadata too). This is to allow quick queries and avoid dependency on object store for every listing or info request. There’s a minor risk of inconsistency (like if someone manually changes object, as said). We accept that for the performance benefit. If an admin did such changes, they should run a sync job or manually update DB.
-* **Locking:** While writing file data, it might be wise to lock the DB entry (or its name) so another action (like someone trying to download the file midway or list it) doesn’t see an incomplete state. We could mark it incomplete; or at least ensure that if a user tries to download a file that is being uploaded, either they get an error or they wait. This probably rarely happens, but we can implement a simple check: don’t list incomplete files or mark them with a “(uploading)” status. Since Hotline allowed resuming, clients might see a partially uploaded file (0 bytes listed initially, then updated when done maybe). For simplicity, perhaps hide it until done or show size 0 until done. The details can be left out as this is an edge detail.
-* **ERD and Schema Sync:** The ER diagram and DDL we provided remain aligned – any changes in one should reflect in the other if iterating. In our final design, they match the described approach.
+    - Use a *staging bucket or prefix* for incomplete uploads and only move to
+      the final key on commit. That adds complexity.
+    - Or insert DB record at start with a flag (incomplete), then attempt
+      upload. If upload fails, mark the record or remove it. If the server
+      crashes mid-upload, the record remains flagged incomplete; a cleanup job
+      could later remove it and any partial data (though in object storage,
+      partial multipart uploads that aren’t completed do not produce a visible
+      object, but they do consume storage until aborted).
+    - The `object_store` crate likely handles multipart such that if we don’t
+      call `finish()`, the upload is not finalized (thus invisible). So an
+      interrupted upload may leave an *in-progress* multipart that should be
+      aborted later. We should track the upload ID and schedule an abort if the
+      client never resumes. Many cloud providers auto-abort unfinished
+      multi-part after some days.
+
+  - On **file delete**: We do the reverse order – remove the DB record first (so
+    it disappears from listings immediately), then delete the object from
+    storage. If the storage deletion fails (transient error), we’ll have an
+    orphan object. But the DB no longer references it (dangling data). We can
+    attempt the storage deletion again in a retry or background job. The risk is
+    wasted storage. We prefer that over having a broken DB entry. Another
+    strategy: mark file as “deleted” in DB (soft delete) until storage confirms
+    deletion, but that complicates things. Simpler: best-effort delete and log
+    errors. A periodic background cleaner can list orphan objects and remove
+    them if needed.
+
+  - On **moves/renames**: Since these are DB-only (in our design), they either
+    succeed or fail in DB. No partial storage action. So consistent by nature.
+
+  - On **folder delete**: We should ideally wrap it in a transaction: delete all
+    child records in DB (cascading) and then for each object, attempt deletion.
+    If an object deletion fails, we have already removed DB entries. As above,
+    we log and maybe retry later. Perhaps do not commit DB transaction until all
+    object deletions have succeeded? But that might not be feasible if many
+    files (long transaction holding locks). It's often acceptable to commit DB
+    first, then do storage cleanup out-of-tx. In case of failure, at worst
+    storage has some straggler files which are not listed anywhere (harmless
+    except cost). We can reclaim later. This trades strong immediate consistency
+    for simplicity and performance.
+
+- **Transactional Integrity:** The DB operations themselves use transactions to
+  maintain referential integrity. For example, when uploading a folder with many
+  files, we might handle each file in its own small transaction (so one file’s
+  failure doesn’t roll back the entire batch). That could leave half the files
+  uploaded if there’s an error mid-way – which is fine, the user can resume or
+  re-upload the rest. It’s similar to how it would be in a manual process. If we
+  wanted all-or-nothing for an UploadFolder, we could wrap the entire operation
+  in a transaction, but that is impractical if dozens of large files (the
+  transaction would be huge and long-lived). Better to commit as we go and
+  handle partial completion. The protocol’s resume actions allow continuing
+  later.
+
+- **Object Store Consistency:** Modern object stores are typically strongly
+  consistent for read-after-write and list-after-write (S3 now guarantees
+  consistency for new puts and deletes). But historically, some had eventual
+  consistency for listing. Since we rely on DB for listing, we avoid those
+  issues entirely. For reading file content, once `put_multipart.finish()`
+  returns success, the subsequent `get` will see the complete file. Our design
+  assumes a single object store and that all server nodes (if multiple) use the
+  same bucket and credentials. If multiple server instances handle requests,
+  they all share the DB, so they all know about new files immediately via DB. If
+  one instance uploads a file and adds DB entry, another instance’s subsequent
+  listing will show it (since DB is updated), and a download request to that
+  other instance will find the object (assuming the object store has it by then,
+  which it should because the upload finished and committed).
+
+- **Concurrency considerations:** We should guard against race conditions like
+  two clients uploading a file with the same name in the same folder
+  simultaneously. With a DB unique constraint, one will fail on insert. We can
+  catch that and respond with an error (or rename one automatically if we
+  wanted). Similarly, two deletions at same time – one will fail to find the
+  file if the other already removed it. These edge cases can be handled by
+  transaction isolation or simple error checking (e.g., if a delete doesn’t find
+  the record, assume it was already deleted).
+
+- **Metadata Sync:** If any direct changes occur in object storage outside our
+  app (e.g. an admin manually adds a file to the bucket), our DB won’t know. We
+  assume all modifications go through the app. We could have an administrative
+  tool to sync – for example, scan the bucket for files with no DB entry and
+  optionally import or remove them. But ideally, avoid out-of-band changes. One
+  area to watch is file **size** and **last modified**: we store size in DB when
+  uploading. If the actual object store content somehow differs (maybe someone
+  replaced the object directly), DB would be wrong. Again, we assume no such
+  unsupervised changes. If needed, one could verify content length via `head()`
+  on object store when serving, but that’s extra overhead. Consistency in our
+  controlled environment should be maintained by design.
+
+- **Performance vs Consistency Trade-off:** We favor consistency for user-facing
+  metadata. So we do slightly redundant work like storing file size and mod time
+  in DB (though the object store has this metadata too). This is to allow quick
+  queries and avoid dependency on object store for every listing or info
+  request. There’s a minor risk of inconsistency (like if someone manually
+  changes object, as said). We accept that for the performance benefit. If an
+  admin did such changes, they should run a sync job or manually update DB.
+
+- **Locking:** While writing file data, it might be wise to lock the DB entry
+  (or its name) so another action (like someone trying to download the file
+  midway or list it) doesn’t see an incomplete state. We could mark it
+  incomplete; or at least ensure that if a user tries to download a file that is
+  being uploaded, either they get an error or they wait. This probably rarely
+  happens, but we can implement a simple check: don’t list incomplete files or
+  mark them with a “(uploading)” status. Since Hotline allowed resuming, clients
+  might see a partially uploaded file (0 bytes listed initially, then updated
+  when done maybe). For simplicity, perhaps hide it until done or show size 0
+  until done. The details can be left out as this is an edge detail.
+
+- **ERD and Schema Sync:** The ER diagram and DDL we provided remain aligned –
+  any changes in one should reflect in the other if iterating. In our final
+  design, they match the described approach.
 
 ## Performance Considerations and Trade-offs
 
 Finally, we address strategies for ensuring good performance and scalability:
 
-* **Asynchronous I/O and Streaming:** Using async Rust and the `object_store` crate means we handle I/O with minimal threads and high throughput. Large file transfers are streamed directly from the object store to the client (or client to store) without buffering entire files in memory. This reduces memory usage and allows parallel transfers. For example, `object_store.get().into_stream()` lets us pipeline data to the network as it arrives. Similarly, `put_multipart` performs parallel uploads of chunks, exploiting network bandwidth. We can tune the multipart chunk size or concurrency via `PutMultipartOpts` if needed. This ensures even multi-gigabyte files can be handled efficiently and clients on fast connections get good throughput.
-* **Batch and Parallel Operations:** In cases like deleting or moving many files, we can perform object store deletions in parallel batches to speed up cleanup (the `object_store` API could be called concurrently on multiple keys). However, be mindful of API rate limits. Similarly, listing a folder with thousands of entries is just one DB query, which is fine as long as it’s indexed. If a folder has millions of files (not typical in BBS context), we’d implement pagination or lazy loading. The DigitalOcean docs remind that listing too many can be slow and often one might need to filter or page.
-* **Caching Metadata:** For extremely high read frequency (say a very popular file or folder), consider an in-memory cache or using an object cache (like storing the flattened file info in memory to avoid recomposing it every time). However, since DB access is relatively cheap and we have indexes, the bottleneck is usually network I/O, not reading metadata. Still, if needed, one could cache file attributes in a hash map keyed by file\_id, invalidated on updates. Given the scale of a typical BBS, this might be premature optimization.
-* **Content Delivery:** Though not asked, it's worth noting: if files are large and many users download them, using a CDN in front of the object store could offload traffic. Our design could integrate with that by generating pre-signed URLs or so, but since Hotline is a direct server model, we keep the server in the loop.
-* **Multipart Tuning:** The `object_store` crate by default might choose a part size (e.g., 10 MiB). For very large files, a smaller part size (e.g. 8 MiB) might improve parallelism; too small and overhead increases. We can adjust as needed. The library automatically coalesces range requests that are close together, improving efficiency if a client oddly asks for multiple ranges.
-* **Mermaid and Schema Efficiency:** (Performance of those isn’t relevant to runtime, they’re design artifacts, so skipping.)
-* **Large Folders and Zip Option:** If a user tries to download an entire huge folder, sequential transfer could be slow to set up each file. As mentioned, one could implement an optimization: compress the folder server-side. But that diverges from Hotline protocol. Alternatively, allow multiple files to be sent in parallel (Hotline did one at a time). To stick to spec, we won’t do parallel in the same request, but a user could manually start separate downloads. If we wanted, we could spawn multiple data connections to download subfolders in parallel. This would complicate the protocol sequence management. So likely not worth it unless in a custom extension.
-* **Indexing and Search:** If needed to search files by name or comment, ensure to add DB indexes (e.g., an index on FileNode.name could help wildcard searches, or use full-text for comments). Not directly asked but something to consider in a real implementation for usability.
-* **Scalability:** The design should handle growth in number of files. The DB approach can manage tens or hundreds of thousands of entries with proper indexing. Object storage can handle virtually unlimited objects. One concern on some object stores (like local filesystem via `object_store`) is having too many files in one directory. If we use ID as key and put all in one flat container, a local FS might slow down if we actually store each file on disk in one folder. For cloud stores, it’s fine. If using local for dev/test, we might incorporate a sharding of keys (like prefix object\_key with a few hex of the ID to distribute into subdirectories). This can be abstracted by the `object_store` using its Path (e.g., storing `42` under `files/42` means file “42” in folder “files” – on local filesystem that’s one dir with many files; we could do `files/42/42` or some scheme). This is an implementation detail; the crate might have a `prefix` or we can manually ensure some structure.
-* **Parallelism vs Memory:** While streaming, we should be careful not to read too far ahead of writing to avoid memory build-up. Using backpressure from the network sink is important. The Rust futures ecosystem typically handles that if we await on writing each chunk. If using frameworks like tokio, one might use `tokio::io::copy_bidirectional` for simplicity. With `object_store`, we likely get a `Stream` of `Bytes` which we can `.try_fold()` into the network sink as shown in their docs.
-* **Updating Metadata performance:** If a user bulk-renames or moves many files (rare via UI, but maybe script), each triggers a DB update. Doing thousands could be slow. One could allow batch updates (not in Hotline UI though). It’s fine given typical usage.
-* **Permission checks overhead:** Our permission check typically involves looking up entries in the Permission table for a given file or its folder. We can optimize by caching resolved permissions per folder for a user session, or by storing an “effective rights” bitmask in the FileNode that combines parent ACL and global for quick check (updated whenever ACLs change). However, computing that on the fly is usually fine (a DB query for Permission where resource\_id = folder or file and principal in {user, any group of user}). We can reduce queries by doing joins in the listing query to fetch an “allowed” flag for each item, but that may be overkill. Simpler: check per operation individually.
-* **Dropping stale uploads:** If a user starts an upload and never finishes (e.g., connection lost), we will have a multipart upload in object store and possibly an incomplete DB entry. We should have a cleanup mechanism: e.g., a background task that finds FileNodes with a temp/incomplete status older than some hours and deletes them and aborts the multipart. Many cloud storages auto-clean multiparts after \~7 days. In our DB, we can either never insert incomplete or insert and then remove. If we inserted, that incomplete entry might appear as a 0-byte file to others (Hotline did show partially uploaded files sometimes, which could be resumed by others if they had permissions, interestingly). But to avoid confusion, better not to show incomplete files except maybe to the uploader. A possible enhancement: mark file as “locked” during upload – others trying to download it might either be blocked or could even download the portion uploaded so far (Hotline’s resume system might allow one user to resume another’s upload? Unlikely, it was per user).
-* **High-Level Performance Trade-off:** Our chosen design trades a bit of complexity (maintaining a DB) for a lot of performance and feature benefits (fast listing, rich metadata, easy moves). The alternative would have been treating the object store as the source of truth (storing files in pseudo-folders and scanning for listings). That would simplify not having a DB, but then implementing aliases, comments, and fine ACL would be extremely hard or impossible because object stores don’t support those things directly. Also, object store listing of large buckets is slower and not as flexible as SQL queries (and often limited to 1000 results per call etc.). So our approach is justified for a feature-rich BBS. The slight risk is the DB and object store must be kept in sync, which we addressed with careful ordering and potential background reconciliation.
+- **Asynchronous I/O and Streaming:** Using async Rust and the `object_store`
+  crate means we handle I/O with minimal threads and high throughput. Large file
+  transfers are streamed directly from the object store to the client (or client
+  to store) without buffering entire files in memory. This reduces memory usage
+  and allows parallel transfers. For example, `object_store.get().into_stream()`
+  lets us pipeline data to the network as it arrives. Similarly, `put_multipart`
+  performs parallel uploads of chunks, exploiting network bandwidth. We can tune
+  the multipart chunk size or concurrency via `PutMultipartOpts` if needed. This
+  ensures even multi-gigabyte files can be handled efficiently and clients on
+  fast connections get good throughput.
+- **Batch and Parallel Operations:** In cases like deleting or moving many
+  files, we can perform object store deletions in parallel batches to speed up
+  cleanup (the `object_store` API could be called concurrently on multiple
+  keys). However, be mindful of API rate limits. Similarly, listing a folder
+  with thousands of entries is just one DB query, which is fine as long as it’s
+  indexed. If a folder has millions of files (not typical in BBS context), we’d
+  implement pagination or lazy loading. The DigitalOcean docs remind that
+  listing too many can be slow and often one might need to filter or page.
+- **Caching Metadata:** For extremely high read frequency (say a very popular
+  file or folder), consider an in-memory cache or using an object cache (like
+  storing the flattened file info in memory to avoid recomposing it every time).
+  However, since DB access is relatively cheap and we have indexes, the
+  bottleneck is usually network I/O, not reading metadata. Still, if needed, one
+  could cache file attributes in a hash map keyed by file_id, invalidated on
+  updates. Given the scale of a typical BBS, this might be premature
+  optimization.
+- **Content Delivery:** Though not asked, it's worth noting: if files are large
+  and many users download them, using a CDN in front of the object store could
+  offload traffic. Our design could integrate with that by generating pre-signed
+  URLs or so, but since Hotline is a direct server model, we keep the server in
+  the loop.
+- **Multipart Tuning:** The `object_store` crate by default might choose a part
+  size (e.g., 10 MiB). For very large files, a smaller part size (e.g. 8 MiB)
+  might improve parallelism; too small and overhead increases. We can adjust as
+  needed. The library automatically coalesces range requests that are close
+  together, improving efficiency if a client oddly asks for multiple ranges.
+- **Mermaid and Schema Efficiency:** (Performance of those isn’t relevant to
+  runtime, they’re design artifacts, so skipping.)
+- **Large Folders and Zip Option:** If a user tries to download an entire huge
+  folder, sequential transfer could be slow to set up each file. As mentioned,
+  one could implement an optimization: compress the folder server-side. But that
+  diverges from Hotline protocol. Alternatively, allow multiple files to be sent
+  in parallel (Hotline did one at a time). To stick to spec, we won’t do
+  parallel in the same request, but a user could manually start separate
+  downloads. If we wanted, we could spawn multiple data connections to download
+  subfolders in parallel. This would complicate the protocol sequence
+  management. So likely not worth it unless in a custom extension.
+- **Indexing and Search:** If needed to search files by name or comment, ensure
+  to add DB indexes (e.g., an index on FileNode.name could help wildcard
+  searches, or use full-text for comments). Not directly asked but something to
+  consider in a real implementation for usability.
+- **Scalability:** The design should handle growth in number of files. The DB
+  approach can manage tens or hundreds of thousands of entries with proper
+  indexing. Object storage can handle virtually unlimited objects. One concern
+  on some object stores (like local filesystem via `object_store`) is having too
+  many files in one directory. If we use ID as key and put all in one flat
+  container, a local FS might slow down if we actually store each file on disk
+  in one folder. For cloud stores, it’s fine. If using local for dev/test, we
+  might incorporate a sharding of keys (like prefix object_key with a few hex of
+  the ID to distribute into subdirectories). This can be abstracted by the
+  `object_store` using its Path (e.g., storing `42` under `files/42` means file
+  “42” in folder “files” – on local filesystem that’s one dir with many files;
+  we could do `files/42/42` or some scheme). This is an implementation detail;
+  the crate might have a `prefix` or we can manually ensure some structure.
+- **Parallelism vs Memory:** While streaming, we should be careful not to read
+  too far ahead of writing to avoid memory build-up. Using backpressure from the
+  network sink is important. The Rust futures ecosystem typically handles that
+  if we await on writing each chunk. If using frameworks like tokio, one might
+  use `tokio::io::copy_bidirectional` for simplicity. With `object_store`, we
+  likely get a `Stream` of `Bytes` which we can `.try_fold()` into the network
+  sink as shown in their docs.
+- **Updating Metadata performance:** If a user bulk-renames or moves many files
+  (rare via UI, but maybe script), each triggers a DB update. Doing thousands
+  could be slow. One could allow batch updates (not in Hotline UI though). It’s
+  fine given typical usage.
+- **Permission checks overhead:** Our permission check typically involves
+  looking up entries in the Permission table for a given file or its folder. We
+  can optimize by caching resolved permissions per folder for a user session, or
+  by storing an “effective rights” bitmask in the FileNode that combines parent
+  ACL and global for quick check (updated whenever ACLs change). However,
+  computing that on the fly is usually fine (a DB query for Permission where
+  resource_id = folder or file and principal in {user, any group of user}). We
+  can reduce queries by doing joins in the listing query to fetch an “allowed”
+  flag for each item, but that may be overkill. Simpler: check per operation
+  individually.
+- **Dropping stale uploads:** If a user starts an upload and never finishes
+  (e.g., connection lost), we will have a multipart upload in object store and
+  possibly an incomplete DB entry. We should have a cleanup mechanism: e.g., a
+  background task that finds FileNodes with a temp/incomplete status older than
+  some hours and deletes them and aborts the multipart. Many cloud storages
+  auto-clean multiparts after ~7 days. In our DB, we can either never insert
+  incomplete or insert and then remove. If we inserted, that incomplete entry
+  might appear as a 0-byte file to others (Hotline did show partially uploaded
+  files sometimes, which could be resumed by others if they had permissions,
+  interestingly). But to avoid confusion, better not to show incomplete files
+  except maybe to the uploader. A possible enhancement: mark file as “locked”
+  during upload – others trying to download it might either be blocked or could
+  even download the portion uploaded so far (Hotline’s resume system might allow
+  one user to resume another’s upload? Unlikely, it was per user).
+- **High-Level Performance Trade-off:** Our chosen design trades a bit of
+  complexity (maintaining a DB) for a lot of performance and feature benefits
+  (fast listing, rich metadata, easy moves). The alternative would have been
+  treating the object store as the source of truth (storing files in
+  pseudo-folders and scanning for listings). That would simplify not having a
+  DB, but then implementing aliases, comments, and fine ACL would be extremely
+  hard or impossible because object stores don’t support those things directly.
+  Also, object store listing of large buckets is slower and not as flexible as
+  SQL queries (and often limited to 1000 results per call etc.). So our approach
+  is justified for a feature-rich BBS. The slight risk is the DB and object
+  store must be kept in sync, which we addressed with careful ordering and
+  potential background reconciliation.
 
 ## Practical Implementation Notes (Rust Backend)
 
 Let’s tie these concepts to actual Rust patterns and code structure:
 
-* We would define data models using an ORM like Diesel or SQLx for the tables above. For example, a `FileNode` struct with Diesel annotations or SQLx queries.
-* For object storage, we configure based on settings. For instance, to initialize:
+- We would define data models using an ORM like Diesel or SQLx for the tables
+  above. For example, a `FileNode` struct with Diesel annotations or SQLx
+  queries.
+
+- For object storage, we configure based on settings. For instance, to
+  initialize:
 
   ```rust
   use object_store::{ObjectStore, path::Path};
@@ -483,33 +1505,85 @@ Let’s tie these concepts to actual Rust patterns and code structure:
   let store: Arc<dyn ObjectStore> = object_store::parse_url(&config.object_store_url)?.0;
   ```
 
-  This uses the `parse_url` helper to create the right store from a URI. Alternatively, use builder with explicit keys if needed. We wrap it in an `Arc<dyn ObjectStore>` to share it across async tasks (cheap clone).
-* For handling requests, each of the above operations would be an async function in our service layer, called by the networking layer when a corresponding client request is received. The functions would use the DB connection (from a pool) and the object\_store (from some global state).
-* Error handling: we’d have to map errors from DB (e.g., unique constraint violation) or object\_store (network errors) into the protocol’s error codes or messages. Hotline had an error transaction with code and text (Field 100 was Error Text). We can send meaningful errors (like “Access Denied” if permission fails, “File Not Found” if not exists, etc.).
-* Logging: Each action can log what user did what (for audit).
-* Testing: We would test with scenarios like:
+  This uses the `parse_url` helper to create the right store from a URI.
+  Alternatively, use builder with explicit keys if needed. We wrap it in an
+  `Arc<dyn ObjectStore>` to share it across async tasks (cheap clone).
 
-  * Upload and then download the same file (with and without resume).
-  * Multi-file operations like folder upload/download.
-  * Permission edge cases (user with/without rights).
-  * Alias functionality (ensure alias download fetches correct content).
-  * Simulated network drop during upload and resume.
-  * Ensure that moves do not trigger expensive copy (maybe verify object keys remain same).
-* Performance testing: try large files (multi-GB) to see that our streaming and multipart works as expected. Possibly adjust multipart part size if needed (some crate versions allow setting the threshold for using multipart, etc.).
-* MermaidJS ER diagram and the DDL provided help developers understand and set up the database. In practice, one would execute those SQL statements to create tables, and likely have a migration system. The relationships help to define foreign key constraints for data integrity (e.g., can’t have a Permission pointing to a non-existent file, thanks to FK).
-* As a Rust implementation detail, make sure to use proper types (e.g., bitmask as i64 or u64 for privileges, date as chrono DateTime, etc.). And ensure thread-safe (Arc for store, connection pool for DB).
-* We also note that by using the `object_store` abstraction, writing unit tests for file logic can be done with the in-memory or local filesystem backend (since the crate supports an in-memory store and local disk store). That’s convenient for testing without real S3. We just need to configure parse\_url with, say, “memory://” or use `object_store::memory::InMemory` directly for tests.
+- For handling requests, each of the above operations would be an async function
+  in our service layer, called by the networking layer when a corresponding
+  client request is received. The functions would use the DB connection (from a
+  pool) and the object_store (from some global state).
+
+- Error handling: we’d have to map errors from DB (e.g., unique constraint
+  violation) or object_store (network errors) into the protocol’s error codes or
+  messages. Hotline had an error transaction with code and text (Field 100 was
+  Error Text). We can send meaningful errors (like “Access Denied” if permission
+  fails, “File Not Found” if not exists, etc.).
+
+- Logging: Each action can log what user did what (for audit).
+
+- Testing: We would test with scenarios like:
+
+  - Upload and then download the same file (with and without resume).
+  - Multi-file operations like folder upload/download.
+  - Permission edge cases (user with/without rights).
+  - Alias functionality (ensure alias download fetches correct content).
+  - Simulated network drop during upload and resume.
+  - Ensure that moves do not trigger expensive copy (maybe verify object keys
+    remain same).
+
+- Performance testing: try large files (multi-GB) to see that our streaming and
+  multipart works as expected. Possibly adjust multipart part size if needed
+  (some crate versions allow setting the threshold for using multipart, etc.).
+
+- MermaidJS ER diagram and the DDL provided help developers understand and set
+  up the database. In practice, one would execute those SQL statements to create
+  tables, and likely have a migration system. The relationships help to define
+  foreign key constraints for data integrity (e.g., can’t have a Permission
+  pointing to a non-existent file, thanks to FK).
+
+- As a Rust implementation detail, make sure to use proper types (e.g., bitmask
+  as i64 or u64 for privileges, date as chrono DateTime, etc.). And ensure
+  thread-safe (Arc for store, connection pool for DB).
+
+- We also note that by using the `object_store` abstraction, writing unit tests
+  for file logic can be done with the in-memory or local filesystem backend
+  (since the crate supports an in-memory store and local disk store). That’s
+  convenient for testing without real S3. We just need to configure parse_url
+  with, say, “memory://” or use `object_store::memory::InMemory` directly for
+  tests.
 
 ## Conclusion
 
-In this implementation guide, we outlined a robust design for a Hotline-inspired file-sharing server component. The solution aligns with Hotline protocol operations 200–213, providing equivalent functionality using modern tech. We leveraged a normalized relational schema to manage the hierarchical namespace, user permissions, and file metadata (including comments and aliases), while delegating binary storage to an `object_store`-backed cloud/object storage for scalability and backend neutrality. We detailed how to handle resumable transfers via range requests and multipart uploads, how to enforce ACLs at every step, and how to maintain consistency between the database and object store. We also discussed performance optimizations to ensure the system can handle large files and many operations efficiently.
+In this implementation guide, we outlined a robust design for a Hotline-inspired
+file-sharing server component. The solution aligns with Hotline protocol
+operations 200–213, providing equivalent functionality using modern tech. We
+leveraged a normalized relational schema to manage the hierarchical namespace,
+user permissions, and file metadata (including comments and aliases), while
+delegating binary storage to an `object_store`-backed cloud/object storage for
+scalability and backend neutrality. We detailed how to handle resumable
+transfers via range requests and multipart uploads, how to enforce ACLs at every
+step, and how to maintain consistency between the database and object store. We
+also discussed performance optimizations to ensure the system can handle large
+files and many operations efficiently.
 
-This guide should enable developers to implement the file-sharing module in a Rust BBS server that feels like the classic Hotline server in behavior, but with the reliability and scalability expected from modern infrastructure. With careful attention to the details above, the resulting system will allow users to seamlessly upload/download files (even large ones with resume), organize them in folders, create aliases and dropboxes for collaboration, all while respecting fine-grained access controls and remaining agnostic to the storage backend used.
+This guide should enable developers to implement the file-sharing module in a
+Rust BBS server that feels like the classic Hotline server in behavior, but with
+the reliability and scalability expected from modern infrastructure. With
+careful attention to the details above, the resulting system will allow users to
+seamlessly upload/download files (even large ones with resume), organize them in
+folders, create aliases and dropboxes for collaboration, all while respecting
+fine-grained access controls and remaining agnostic to the storage backend used.
 
 **Sources:**
 
-* Hotline Protocol Reference (Hotline Wiki) – used for understanding transaction codes and data formats.
-* DigitalOcean Spaces Documentation – explained flat vs hierarchical storage concepts.
-* Rust `object_store` Documentation – demonstrated usage of listing, range reads, and multipart writes in the storage layer.
-* Hotline Access Privileges (Hotline Wiki) – provided details on permission bits for various actions.
-* Download/Upload folder protocol (Hotline Wiki) – informed the implementation of recursive folder transfers and resume mechanics.
+- Hotline Protocol Reference (Hotline Wiki) – used for understanding transaction
+  codes and data formats.
+- DigitalOcean Spaces Documentation – explained flat vs hierarchical storage
+  concepts.
+- Rust `object_store` Documentation – demonstrated usage of listing, range
+  reads, and multipart writes in the storage layer.
+- Hotline Access Privileges (Hotline Wiki) – provided details on permission bits
+  for various actions.
+- Download/Upload folder protocol (Hotline Wiki) – informed the implementation
+  of recursive folder transfers and resume mechanics.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,10 +1,13 @@
 # AFL++ Fuzzing Guide
 
-This document summarizes how to build and run the fuzzing harness for `mxd` and how it integrates with CI.
+This document summarizes how to build and run the fuzzing harness for `mxd` and
+how it integrates with CI.
 
 ## Building the Harness
 
-The fuzzing code lives in `fuzz/` and targets the `parse_transaction` function. Seed inputs are generated using `src/bin/gen_corpus.rs`, which constructs transactions defined in [docs/protocol.md](protocol.md).
+The fuzzing code lives in `fuzz/` and targets the `parse_transaction` function.
+Seed inputs are generated using `src/bin/gen_corpus.rs`, which constructs
+transactions defined in [docs/protocol.md](protocol.md).
 
 ```bash
 # rebuild the seed corpus from the protocol examples
@@ -25,11 +28,16 @@ mkdir -p fuzz/corpus findings
 cargo afl fuzz -i fuzz/corpus -o findings fuzz/target/debug/fuzz
 ```
 
-The harness panics on parsing errors so crashes will be detected. Refer to `file-sharing-design.md` for how file operations interact with the protocol.
+The harness panics on parsing errors so crashes will be detected. Refer to
+`file-sharing-design.md` for how file operations interact with the protocol.
 
 ### Docker
 
-`fuzz/Dockerfile` builds the harness with sanitizers and runs AFL++ inside the official container. Building with sanitizers (for example by setting `RUSTFLAGS="-Zsanitizer=address"`) requires the nightly Rust toolchain, which the Dockerfile installs automatically. Use the container when you want a reproducible environment:
+`fuzz/Dockerfile` builds the harness with sanitizers and runs AFL++ inside the
+official container. Building with sanitizers (for example by setting
+`RUSTFLAGS="-Zsanitizer=address"`) requires the nightly Rust toolchain, which
+the Dockerfile installs automatically. Use the container when you want a
+reproducible environment:
 
 ```bash
 # build the image
@@ -45,7 +53,12 @@ docker run --rm \
 
 ## CI Integration
 
-GitHub Actions runs the fuzzer nightly. The workflow defined in `.github/workflows/fuzz.yml` builds the Docker image, executes AFL++ for several hours and uploads any crashes. Review the artifacts after each run to inspect new findings. This process aligns with the overall architecture outlined in [roadmap.md](roadmap.md) and the storage notes in [file-sharing-design.md](file-sharing-design.md).
+GitHub Actions runs the fuzzer nightly. The workflow defined in
+`.github/workflows/fuzz.yml` builds the Docker image, executes AFL++ for several
+hours and uploads any crashes. Review the artifacts after each run to inspect
+new findings. This process aligns with the overall architecture outlined in
+[roadmap.md](roadmap.md) and the storage notes in
+[file-sharing-design.md](file-sharing-design.md).
 
 ```mermaid
 flowchart TD

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -1,11 +1,15 @@
 # Mermaid Diagram Validation
 
-Mermaid diagrams are rendered client-side, so a small syntax error can leave a broken image in the documentation. To prevent this, every Markdown document that includes a `mermaid` code block must be checked before merging.
+Mermaid diagrams are rendered client-side, so a small syntax error can leave a
+broken image in the documentation. To prevent this, every Markdown document that
+includes a `mermaid` code block must be checked before merging.
 
 ## Requirements
 
 - **Node.js** must be available in your `PATH`.
-- The validator uses `npx` to run the [`@mermaid-js/mermaid-cli`](https://github.com/mermaid-js/mermaid-cli) package. Installing it globally speeds things up:
+- The validator uses `npx` to run the
+  [`@mermaid-js/mermaid-cli`](https://github.com/mermaid-js/mermaid-cli)
+  package. Installing it globally speeds things up:
 
 ```bash
 npm install -g @mermaid-js/mermaid-cli
@@ -27,20 +31,21 @@ nixie docs/*.md
 ```
 
 For machines with many cores, increasing the concurrency can speed up
-validation. By default the script uses the number of CPU cores detected on
-your system. Use the `--concurrency` flag to override the number of diagrams
-rendered in parallel:
+validation. By default the script uses the number of CPU cores detected on your
+system. Use the `--concurrency` flag to override the number of diagrams rendered
+in parallel:
 
 ```bash
 nixie --concurrency 8 docs/*.md
 ```
 
-The script extracts each ```mermaid` block and attempts to render it using
-`mmdc`.
-Any syntax errors will cause the script to exit with a non-zero status. The
-failing diagram's line and a pointer to the error location are printed to help
-you fix the issue.
+The script extracts each
+\`\`\`mermaid`block and attempts to render it using`mmdc\`. Any syntax errors
+will cause the script to exit with a non-zero status. The failing diagram's line
+and a pointer to the error location are printed to help you fix the issue.
 
-If the required tools are missing the validator explains that Node.js and `@mermaid-js/mermaid-cli` must be installed.
+If the required tools are missing the validator explains that Node.js and
+`@mermaid-js/mermaid-cli` must be installed.
 
-Include this step in your workflow whenever you edit Markdown documentation containing Mermaid diagrams.
+Include this step in your workflow whenever you edit Markdown documentation
+containing Mermaid diagrams.

--- a/docs/news-schema.md
+++ b/docs/news-schema.md
@@ -1,8 +1,10 @@
 # Database Schema Design for HXD News Functionality
 
-The following is a compact, evidence-based design that maps Hotline’s hierarchical-news concepts (bundles → categories → articles, with threaded posts) and its granular privilege model into a relational schema.
+The following is a compact, evidence-based design that maps Hotline’s
+hierarchical-news concepts (bundles → categories → articles, with threaded
+posts) and its granular privilege model into a relational schema.
 
----
+______________________________________________________________________
 
 ```mermaid
 erDiagram
@@ -66,7 +68,7 @@ erDiagram
     news_articles   ||--o{ news_articles   : children
 ```
 
----
+______________________________________________________________________
 
 ```sql
 -- Users (given)
@@ -139,12 +141,23 @@ CREATE INDEX idx_categories_bundle      ON news_categories(bundle_id);
 CREATE INDEX idx_articles_category      ON news_articles(category_id);
 ```
 
-### Why these tables?
+## Why these tables?
 
-* **Hierarchical news** – Bundles may contain bundles and categories, matching the server manual’s description of “bundles inside other bundles” and categories that hold posts .
+- **Hierarchical news** – Bundles may contain bundles and categories, matching
+  the server manual’s description of “bundles inside other bundles” and
+  categories that hold posts .
 
-  * Articles inherit Hotline’s thread metadata (parent/prev/next/first-child, flags, poster, date, flavour, data) as specified in the protocol fields list .
-* **Permission model** – The protocol defines 38 distinct access flags (e.g. *News Read Article* code 20, *Broadcast* code 32) .  A lookup table plus an M-N link cleanly represents that bitmap while remaining normalised and queryable.
-* **Users** – The provided `users` table is left intact and linked to permissions via `user_permissions`.
+  - Articles inherit Hotline’s thread metadata (parent/prev/next/first-child,
+    flags, poster, date, flavour, data) as specified in the protocol fields list
+    .
 
-This schema stays portable (pure SQLite 3), enforces referential integrity via `ON DELETE CASCADE`, and leaves room for higher-level abstractions (roles, groups, moderation logs) without breaking existing contracts.
+- **Permission model** – The protocol defines 38 distinct access flags (e.g.
+  *News Read Article* code 20, *Broadcast* code 32) . A lookup table plus an M-N
+  link cleanly represents that bitmap while remaining normalised and queryable.
+
+- **Users** – The provided `users` table is left intact and linked to
+  permissions via `user_permissions`.
+
+This schema stays portable (pure SQLite 3), enforces referential integrity via
+`ON DELETE CASCADE`, and leaves room for higher-level abstractions (roles,
+groups, moderation logs) without breaking existing contracts.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,81 +1,107 @@
 # Hotline Server Protocol v1.8.5: Transactions and Functionality Guide
 
-Hotline is a client/server system providing chat, private messaging, file sharing, and a bulletin-board style news system. Hotline Server v1.8.5 communicates with Hotline clients using a defined set of protocol transactions. This guide describes **every protocol transaction type** in Hotline 1.8.5 and explains how each one correlates with server functionality and what end-users experience. We group transactions by functionality (User Login & Presence, Chat, Private Messaging, File Services, News, Administration) for clarity. For each transaction, we provide its **ID and name**, its **purpose**, **initiator** (client or server), key **parameters** passed and results returned, the **server’s behavior**, and the **user-visible effect**. (Note: Tracker and HTTP tunneling-related transactions are omitted as requested.)
+Hotline is a client/server system providing chat, private messaging, file
+sharing, and a bulletin-board style news system. Hotline Server v1.8.5
+communicates with Hotline clients using a defined set of protocol transactions.
+This guide describes **every protocol transaction type** in Hotline 1.8.5 and
+explains how each one correlates with server functionality and what end-users
+experience. We group transactions by functionality (User Login & Presence, Chat,
+Private Messaging, File Services, News, Administration) for clarity. For each
+transaction, we provide its **ID and name**, its **purpose**, **initiator**
+(client or server), key **parameters** passed and results returned, the
+**server’s behavior**, and the **user-visible effect**. (Note: Tracker and HTTP
+tunneling-related transactions are omitted as requested.)
 
 ## Binary Message Formats (Hotline Protocol v 1.8.5)
 
-All multi-byte integers are transmitted **big-endian (“network byte order”)**. No padding or alignment bytes are used: the fields follow one another exactly as listed.
+All multi-byte integers are transmitted **big-endian (“network byte order”)**.
+No padding or alignment bytes are used: the fields follow one another exactly as
+listed.
 
-### 1  Session-initialisation handshake
+### 1 Session-initialisation handshake
 
-| Offset | Size (bytes) | Field               | Meaning                                                                          |
-| -----: | ------------ | ------------------- | -------------------------------------------------------------------------------- |
-|      0 | 4            | **Protocol ID**     | ASCII **“TRTP”** (0x54 52 54 50). Distinguishes Hotline from other TCP services. |
-|      4 | 4            | **Sub-protocol ID** | Application-specific tag (e.g. “CHAT”, “FILE”). Can be 0.                        |
-|      8 | 2            | **Version**         | Currently **0x0001**. A server should refuse versions it does not understand.    |
-|     10 | 2            | **Sub-version**     | Application-defined; often used for build/revision numbers.                      |
+| Offset | Size (bytes) | Field | Meaning | | -----: | ------------ |
+------------------- |
+\--------------------------------------------------------------------------------
+| | 0 | 4 | **Protocol ID** | ASCII **“TRTP”** (0x54 52 54 50). Distinguishes
+Hotline from other TCP services. | | 4 | 4 | **Sub-protocol ID** |
+Application-specific tag (e.g. “CHAT”, “FILE”). Can be 0. | | 8 | 2 |
+**Version** | Currently **0x0001**. A server should refuse versions it does not
+understand. | | 10 | 2 | **Sub-version** | Application-defined; often used for
+build/revision numbers. |
 
-**Direction:** Client → Server.
-The server replies immediately with:
+**Direction:** Client → Server. The server replies immediately with:
 
-| Offset | Size | Field       | Meaning                                       |
-| -----: | ---- | ----------- | --------------------------------------------- |
-|      0 | 4    | Protocol ID | Must echo “TRTP”.                             |
-|      4 | 4    | Error code  | **0 = OK**. Non-zero → connection is dropped. |
+| Offset | Size | Field | Meaning | | -----: | ---- | ----------- |
+--------------------------------------------- | | 0 | 4 | Protocol ID | Must
+echo “TRTP”. | | 4 | 4 | Error code | **0 = OK**. Non-zero → connection is
+dropped. |
 
-A compliant implementation simply waits for the four-byte error code and aborts if it is non-zero. No further data follow.&#x20;
+A compliant implementation simply waits for the four-byte error code and aborts
+if it is non-zero. No further data follow.
 
----
+______________________________________________________________________
 
-### 2  General transaction frame
+### 2 General transaction frame
 
-Every request **and** reply after the handshake is wrapped in a fixed-length header followed by an optional parameter block.
+Every request **and** reply after the handshake is wrapped in a fixed-length
+header followed by an optional parameter block.
 
-| Offset | Size | Field          | Notes                                                                                                                                                                                         |
-| -----: | ---- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|      0 | 1    | **Flags**      | Reserved – **always 0** for v 1.8.5.                                                                                                                                                          |
-|      1 | 1    | **Is-reply**   | **0 = request**, **1 = reply**.                                                                                                                                                               |
-|      2 | 2    | **Type**       | Transaction ID (see full list in protocol spec – e.g. 0x006B = *Login*).                                                                                                                      |
-|      4 | 4    | **ID**         | Client-chosen non-zero number. Replies **must echo** the same value. Allows out-of-order matching.                                                                                            |
-|      8 | 4    | **Error code** | Meaningful **only when Is-reply = 1** (0 = success).                                                                                                                                          |
-|     12 | 4    | **Total size** | Entire byte count of the transaction’s parameter block **across all fragments**.                                                                                                              |
-|     16 | 4    | **Data size**  | Size of the parameter bytes **in *this* fragment**. If `Data size < Total size`, further fragments with identical header values follow until the accumulated data length equals `Total size`. |
+| Offset | Size | Field | Notes | | -----: | ---- | -------------- |
+\---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| | 0 | 1 | **Flags** | Reserved – **always 0** for v 1.8.5. | | 1 | 1 |
+**Is-reply** | **0 = request**, **1 = reply**. | | 2 | 2 | **Type** |
+Transaction ID (see full list in protocol spec – e.g. 0x006B = *Login*). | | 4 |
+4 | **ID** | Client-chosen non-zero number. Replies **must echo** the same
+value. Allows out-of-order matching. | | 8 | 4 | **Error code** | Meaningful
+**only when Is-reply = 1** (0 = success). | | 12 | 4 | **Total size** | Entire
+byte count of the transaction’s parameter block **across all fragments**. | | 16
+| 4 | **Data size** | Size of the parameter bytes **in *this* fragment**. If
+`Data size < Total size`, further fragments with identical header values follow
+until the accumulated data length equals `Total size`. |
 
 *Header length = 20 bytes.*
 
----
+______________________________________________________________________
 
 #### 2.1 Parameter list (payload block)
 
 If `Data size > 0`, the parameter bytes begin with:
 
-| Offset | Size | Field           | Meaning                                       |
-| -----: | ---- | --------------- | --------------------------------------------- |
-|      0 | 2    | **Param-count** | Number of field/value pairs in this fragment. |
+| Offset | Size | Field | Meaning | | -----: | ---- | --------------- |
+--------------------------------------------- | | 0 | 2 | **Param-count** |
+Number of field/value pairs in this fragment. |
 
 Immediately afterwards, *Param-count* **records** follow:
 
-| Offset | Size         | Field      | Meaning                                                                                   |
-| -----: | ------------ | ---------- | ----------------------------------------------------------------------------------------- |
-|      0 | 2            | Field ID   | See master field-ID table (e.g. 0x0066 = *User Name*).                                    |
-|      2 | 2            | Field size | Length of the data portion in bytes.                                                      |
-|      4 | *Field size* | Field data | Raw value. Interpretation rules: integer (16- or 32-bit), ASCII string, or opaque binary. |
+| Offset | Size | Field | Meaning | | -----: | ------------ | ---------- |
+\-----------------------------------------------------------------------------------------
+| | 0 | 2 | Field ID | See master field-ID table (e.g. 0x0066 = *User Name*). |
+| 2 | 2 | Field size | Length of the data portion in bytes. | | 4 | *Field size*
+| Field data | Raw value. Interpretation rules: integer (16- or 32-bit), ASCII
+string, or opaque binary. |
 
-Field IDs never repeat within a single transaction. Integers are unsigned; the sender may use 16-bit encoding if the value ≤ 0xFFFF, otherwise 32-bit.
+Field IDs never repeat within a single transaction. Integers are unsigned; the
+sender may use 16-bit encoding if the value ≤ 0xFFFF, otherwise 32-bit.
 
 #### 2.2 Date parameters
 
-Several protocol fields store timestamps in an eight‑byte structure, often called *date objects*. The layout is:
+Several protocol fields store timestamps in an eight‑byte structure, often
+called *date objects*. The layout is:
 
-* **Year** – 2 bytes (big-endian)
-* **Milliseconds** – 2 bytes (big-endian)
-* **Seconds** – 4 bytes (big-endian)
+- **Year** – 2 bytes (big-endian)
+- **Milliseconds** – 2 bytes (big-endian)
+- **Seconds** – 4 bytes (big-endian)
 
 All three values use network byte order.
 
-Seconds and milliseconds indicate the elapsed time since **January&nbsp;1** of the given year. For example, a value of 70 seconds and 2,000 milliseconds with year 2010 corresponds to *1&nbsp;January&nbsp;2010&nbsp;00:01:12*. Likewise, 432,010 seconds and 5,000 milliseconds with year 2008 represent *6&nbsp;January&nbsp;2008&nbsp;00:00:15*.
+Seconds and milliseconds indicate the elapsed time since **January 1** of the
+given year. For example, a value of 70 seconds and 2,000 milliseconds with year
+2010 corresponds to *1 January 2010 00:01:12*. Likewise, 432,010 seconds and
+5,000 milliseconds with year 2008 represent *6 January 2008 00:00:15*.
 
-To convert a `SYSTEMTIME` structure to this format, compute the seconds field as:
+To convert a `SYSTEMTIME` structure to this format, compute the seconds field
+as:
 
 ```text
 MONTH_SECS[wMonth - 1] +
@@ -83,806 +109,2017 @@ MONTH_SECS[wMonth - 1] +
 (wSecond + 60 * (wMinute + 60 * (wHour + 24 * (wDay - 1))))
 ```
 
-`MONTH_SECS` is a table containing the cumulative seconds at the start of each month:
+`MONTH_SECS` is a table containing the cumulative seconds at the start of each
+month:
 
-| Month     | Seconds |
-|-----------|--------:|
-| January   | 0 |
-| February  | 2,678,400 |
-| March     | 5,097,600 |
-| April     | 7,776,000 |
-| May       | 10,368,000 |
-| June      | 13,046,400 |
-| July      | 15,638,400 |
-| August    | 18,316,800 |
-| September | 20,995,200 |
-| October   | 23,587,200 |
-| November  | 26,265,600 |
-| December  | 28,857,600 |
+| Month | Seconds | |-----------|--------:| | January | 0 | | February |
+2,678,400 | | March | 5,097,600 | | April | 7,776,000 | | May | 10,368,000 | |
+June | 13,046,400 | | July | 15,638,400 | | August | 18,316,800 | | September |
+20,995,200 | | October | 23,587,200 | | November | 26,265,600 | | December |
+28,857,600 |
 
-The year and milliseconds fields are copied directly from the original timestamp structure.
+The year and milliseconds fields are copied directly from the original timestamp
+structure.
 
----
+______________________________________________________________________
 
-### 3  Fragmentation rules
+### 3 Fragmentation rules
 
-* **Single-part transaction:** `Total size == Data size`; one frame only.
-* **Multi-part transaction:** the first fragment carries part 0. Subsequent fragments repeat the same header (with appropriate `Data size`) and deliver the remaining bytes until the sum of `Data size` values equals `Total size`. The parameter list header (2-byte *Param-count*) appears **only in the first fragment**. The receiver concatenates payloads before decoding parameters.
-* `ID` and `Type` never change across fragments; only the `Data size` field differs.
+- **Single-part transaction:** `Total size == Data size`; one frame only.
+- **Multi-part transaction:** the first fragment carries part 0. Subsequent
+  fragments repeat the same header (with appropriate `Data size`) and deliver
+  the remaining bytes until the sum of `Data size` values equals `Total size`.
+  The parameter list header (2-byte *Param-count*) appears **only in the first
+  fragment**. The receiver concatenates payloads before decoding parameters.
+- `ID` and `Type` never change across fragments; only the `Data size` field
+  differs.
 
----
+______________________________________________________________________
 
-### 4  Reply semantics
+### 4 Reply semantics
 
-* A reply **must** keep the original `ID`, set **Is-reply = 1**, and fill `Error code`.
-* If `Error code ≠ 0`, no parameter list is required; many implementations send an empty payload (`Total size = Data size = 0`).
-* Where a command has no meaningful return data, the server often omits the parameter block entirely.
+- A reply **must** keep the original `ID`, set **Is-reply = 1**, and fill
+  `Error code`.
+- If `Error code ≠ 0`, no parameter list is required; many implementations send
+  an empty payload (`Total size = Data size = 0`).
+- Where a command has no meaningful return data, the server often omits the
+  parameter block entirely.
 
----
+______________________________________________________________________
 
-### 5  Worked example (Login)
+### 5 Worked example (Login)
 
-| Field    | Hex value   | Comment                  |
-| -------- | ----------- | ------------------------ |
-| Flags    | 00          | —                        |
-| Is-reply | 00          | Request                  |
-| Type     | 00 6B       | 107 decimal – *Login*    |
-| ID       | 00 00 01 27 | Arbitrary (295)          |
-| Error    | 00 00 00 00 | Always zero in a request |
-| Total    | 00 00 00 14 | 20 bytes of parameters   |
-| Data     | 00 00 00 14 | All in one fragment      |
+| Field | Hex value | Comment | | -------- | ----------- |
+------------------------ | | Flags | 00 | — | | Is-reply | 00 | Request | | Type
+| 00 6B | 107 decimal – *Login* | | ID | 00 00 01 27 | Arbitrary (295) | | Error
+| 00 00 00 00 | Always zero in a request | | Total | 00 00 00 14 | 20 bytes of
+parameters | | Data | 00 00 00 14 | All in one fragment |
 
 Parameter block:
 
-|             Field ID | Size | Data (hex)     | Meaning      |
-| -------------------: | ---: | -------------- | ------------ |
-|    0069 (User Login) | 0005 | 61 64 6D 69 6E | “admin”      |
-| 006A (User Password) | 0000 | —              | empty        |
-|       00A0 (Version) | 0002 | 00 97          | 0x0097 (151) |
+| Field ID | Size | Data (hex) | Meaning | | -------------------: | ---: |
+-------------- | ------------ | | 0069 (User Login) | 0005 | 61 64 6D 69 6E |
+“admin” | | 006A (User Password) | 0000 | — | empty | | 00A0 (Version) | 0002 |
+00 97 | 0x0097 (151) |
 
-Total frame length: 40 bytes. The server’s reply echoes `ID = 0x00000127`, sets **Is-reply = 1**, inserts its own parameter list, and may set `Error code` if the login fails.&#x20;
+Total frame length: 40 bytes. The server’s reply echoes `ID = 0x00000127`, sets
+**Is-reply = 1**, inserts its own parameter list, and may set `Error code` if
+the login fails.
 
----
+______________________________________________________________________
 
 ### 6 Implementation checklist
 
-1. **Validate before use** – always verify the Protocol ID, `Flags == 0`, and sensible sizes.
-2. **Allocate big-endian helpers** – it is safer to write explicit *readUInt16BE / readUInt32BE* helpers than rely on struct packing.
-3. **Never reuse transaction IDs** until a matching reply arrives or the connection is closed.
-4. **Graceful error path** – on any framing or length anomaly, send a single *Disconnect Message* (111) if possible, then drop the socket.
-5. **Unit-test fragmentation** – many clients send large parameter blocks (e.g. *Upload Folder*) in dozens of fragments.
+1. **Validate before use** – always verify the Protocol ID, `Flags == 0`, and
+   sensible sizes.
+2. **Allocate big-endian helpers** – it is safer to write explicit *readUInt16BE
+   / readUInt32BE* helpers than rely on struct packing.
+3. **Never reuse transaction IDs** until a matching reply arrives or the
+   connection is closed.
+4. **Graceful error path** – on any framing or length anomaly, send a single
+   *Disconnect Message* (111) if possible, then drop the socket.
+5. **Unit-test fragmentation** – many clients send large parameter blocks (e.g.
+   *Upload Folder*) in dozens of fragments.
 
-This guide gives you the precise binary envelope you must generate and parse; pair it with the full transaction catalogue to complete your Hotline server implementation.
+This guide gives you the precise binary envelope you must generate and parse;
+pair it with the full transaction catalogue to complete your Hotline server
+implementation.
 
 ## User Login and Presence
 
 ### Session Handshake (Before Transactions Begin)
 
-When a client first connects to a Hotline server, a handshake occurs to verify protocol versions. The client sends a 12-byte handshake with a protocol ID `'TRTP'` and version info, and the server replies with `'TRTP'` and an error code (0 for success). If the versions or requirements don’t match, the connection is closed (the user cannot log in). This handshake is not a numbered transaction but sets up the session for subsequent transactions.
+When a client first connects to a Hotline server, a handshake occurs to verify
+protocol versions. The client sends a 12-byte handshake with a protocol ID
+`'TRTP'` and version info, and the server replies with `'TRTP'` and an error
+code (0 for success). If the versions or requirements don’t match, the
+connection is closed (the user cannot log in). This handshake is not a numbered
+transaction but sets up the session for subsequent transactions.
 
 ### Login (Transaction 107) – Client Initiates
 
-**ID 107 – Login** (`myTran_Login`) is the first real transaction of a user login sequence. The client initiates it to authenticate and begin login. **Purpose:** To log the user into the server with provided credentials and negotiate client/server capabilities. **Initiator:** Client.
+**ID 107 – Login** (`myTran_Login`) is the first real transaction of a user
+login sequence. The client initiates it to authenticate and begin login.
+**Purpose:** To log the user into the server with provided credentials and
+negotiate client/server capabilities. **Initiator:** Client.
 
-* **Parameters (Client→Server):** The login request includes the user’s login name (field 105), password (field 106), and client version number (field 160). The version field helps the server handle compatibility (Hotline 1.8.5 uses version code 151).
-* **Response (Server→Client):** The server validates the credentials. If successful, it replies with its own version number (field 160). For Hotline 1.8.5 (version ≥151), the server also sends additional info: a **community banner ID** (field 161) and the server’s name (field 162). These are used by the client to fetch and display a banner or server name in the UI. If login fails (bad password or user not allowed), the server will **deny the login** – typically by closing the connection or sending a disconnect message with an error reason (see “Disconnect Message” below), so the user sees a login failure message.
+- **Parameters (Client→Server):** The login request includes the user’s login
+  name (field 105), password (field 106), and client version number (field 160).
+  The version field helps the server handle compatibility (Hotline 1.8.5 uses
+  version code 151).
+- **Response (Server→Client):** The server validates the credentials. If
+  successful, it replies with its own version number (field 160). For Hotline
+  1.8.5 (version ≥151), the server also sends additional info: a **community
+  banner ID** (field 161) and the server’s name (field 162). These are used by
+  the client to fetch and display a banner or server name in the UI. If login
+  fails (bad password or user not allowed), the server will **deny the login** –
+  typically by closing the connection or sending a disconnect message with an
+  error reason (see “Disconnect Message” below), so the user sees a login
+  failure message.
 
-**Server behavior:** On receiving a Login request, the server checks the username/password against its user accounts. If the user is permitted (and not banned or already online if only one session allowed), the server allocates a session. It includes version info in the reply and prepares any welcome materials (like an agreement or banner). If the login is refused (wrong credentials or banned), the server can either drop the connection or send an error/disconnect notice. (The protocol defines a generic **Error (100)** transaction, which may carry an error code or text, but in practice Hotline servers often simply disconnect with a reason string.)
+**Server behavior:** On receiving a Login request, the server checks the
+username/password against its user accounts. If the user is permitted (and not
+banned or already online if only one session allowed), the server allocates a
+session. It includes version info in the reply and prepares any welcome
+materials (like an agreement or banner). If the login is refused (wrong
+credentials or banned), the server can either drop the connection or send an
+error/disconnect notice. (The protocol defines a generic **Error (100)**
+transaction, which may carry an error code or text, but in practice Hotline
+servers often simply disconnect with a reason string.)
 
-**End-user experience:** The user enters their login and password in the Hotline client. If these are correct, the client proceeds to the next login steps (agreement or entering the server). If incorrect, the user sees “Incorrect login or password” (the connection closes or an error message is shown). If the server was full or the user banned, a message like “Server full” or “You have been banned” may be displayed (the server likely uses a disconnect message with that text).
+**End-user experience:** The user enters their login and password in the Hotline
+client. If these are correct, the client proceeds to the next login steps
+(agreement or entering the server). If incorrect, the user sees “Incorrect login
+or password” (the connection closes or an error message is shown). If the server
+was full or the user banned, a message like “Server full” or “You have been
+banned” may be displayed (the server likely uses a disconnect message with that
+text).
 
 ### Server Agreement (Transaction 109) – Server Initiates
 
-**ID 109 – Show Agreement** (`myTran_ShowAgreement`) is sent by the server **immediately after a successful login** if the server requires the user to accept an agreement (terms of service or welcome message). **Purpose:** To present the server’s user agreement and banner info to the client as part of login. **Initiator:** Server (sent to client after login, before finalizing login).
+**ID 109 – Show Agreement** (`myTran_ShowAgreement`) is sent by the server
+**immediately after a successful login** if the server requires the user to
+accept an agreement (terms of service or welcome message). **Purpose:** To
+present the server’s user agreement and banner info to the client as part of
+login. **Initiator:** Server (sent to client after login, before finalizing
+login).
 
-* **Parameters (Server→Client):** The server sends the agreement text string (field 101, “Data”) which the client should display (e.g. in a popup). It also indicates if no agreement is available (field 154 set to 1 if there is no agreement text). Additionally, the server provides banner information: a banner type code (field 152) and either a URL to fetch the banner (field 153, if type indicates URL) or the banner image data itself (field 151, if type indicates an image was included in-line). The banner type could be “URL” or an image format code (e.g. JPEG, GIF).
-* **Response:** No reply is expected from the client for this transaction. Instead, the client will either display the agreement to the user and wait for acceptance, or skip it if `No server agreement` was indicated.
+- **Parameters (Server→Client):** The server sends the agreement text string
+  (field 101, “Data”) which the client should display (e.g. in a popup). It also
+  indicates if no agreement is available (field 154 set to 1 if there is no
+  agreement text). Additionally, the server provides banner information: a
+  banner type code (field 152) and either a URL to fetch the banner (field 153,
+  if type indicates URL) or the banner image data itself (field 151, if type
+  indicates an image was included in-line). The banner type could be “URL” or an
+  image format code (e.g. JPEG, GIF).
+- **Response:** No reply is expected from the client for this transaction.
+  Instead, the client will either display the agreement to the user and wait for
+  acceptance, or skip it if `No server agreement` was indicated.
 
-**Server behavior:** The server pauses the login process and waits for the user’s response. If there is an agreement text configured on the server, it uses this transaction to send it. The user’s client will typically not let them fully join until they accept. The banner info tells the client how to load a server banner (e.g. an image or advertisement) to show in the client UI.
+**Server behavior:** The server pauses the login process and waits for the
+user’s response. If there is an agreement text configured on the server, it uses
+this transaction to send it. The user’s client will typically not let them fully
+join until they accept. The banner info tells the client how to load a server
+banner (e.g. an image or advertisement) to show in the client UI.
 
-**End-user experience:** Right after logging in, the user is presented with the server’s agreement or welcome notice (if the server has one). They must click “Agree/Accept” to proceed. They might also see a banner graphic or link (for example, the server’s logo or ad) displayed in the client. If no agreement is required, this step is skipped (field 154=1 was sent, meaning no agreement).
+**End-user experience:** Right after logging in, the user is presented with the
+server’s agreement or welcome notice (if the server has one). They must click
+“Agree/Accept” to proceed. They might also see a banner graphic or link (for
+example, the server’s logo or ad) displayed in the client. If no agreement is
+required, this step is skipped (field 154=1 was sent, meaning no agreement).
 
 ### Agreement Acceptance (Transaction 121) – Client Initiates
 
-**ID 121 – Agreed** (`myTran_Agreed`) is sent by the client after the user accepts the server’s agreement. **Purpose:** To inform the server that the user agreed to the terms and to provide the user’s chosen settings (like nickname and status flags) for the session. **Initiator:** Client.
+**ID 121 – Agreed** (`myTran_Agreed`) is sent by the client after the user
+accepts the server’s agreement. **Purpose:** To inform the server that the user
+agreed to the terms and to provide the user’s chosen settings (like nickname and
+status flags) for the session. **Initiator:** Client.
 
-* **Parameters (Client→Server):** The client includes the user’s desired display name (field 102) and chosen user icon ID (field 104). It also sends an **Options bitmap** (field 113) representing the user’s preference flags: for example, bit value 1 means “Refuse private messages”, 2 means “Refuse private chat invites”, and 4 means “Automatic response enabled”. If the user enabled an auto-reply message, the client also sends that auto-response text (field 215) in the same request.
-* **Response:** The server doesn’t send a direct reply to `Agreed` (no reply expected). Instead, upon receiving this, the server finalizes the login.
+- **Parameters (Client→Server):** The client includes the user’s desired display
+  name (field 102) and chosen user icon ID (field 104). It also sends an
+  **Options bitmap** (field 113) representing the user’s preference flags: for
+  example, bit value 1 means “Refuse private messages”, 2 means “Refuse private
+  chat invites”, and 4 means “Automatic response enabled”. If the user enabled
+  an auto-reply message, the client also sends that auto-response text (field
+  215\) in the same request.
+- **Response:** The server doesn’t send a direct reply to `Agreed` (no reply
+  expected). Instead, upon receiving this, the server finalizes the login.
 
-**Server behavior:** Once the server gets the Agreed transaction, it knows the user accepted the terms and is ready to fully join. The server records the user’s chosen nickname, icon, and privacy preferences (refusal flags or auto-reply message). At this point, the user is officially “online” on the server. The server will typically respond by sending the user their access privileges and populating their view of the server (user list, etc.).
+**Server behavior:** Once the server gets the Agreed transaction, it knows the
+user accepted the terms and is ready to fully join. The server records the
+user’s chosen nickname, icon, and privacy preferences (refusal flags or
+auto-reply message). At this point, the user is officially “online” on the
+server. The server will typically respond by sending the user their access
+privileges and populating their view of the server (user list, etc.).
 
-* Immediately after this, the server sends a **User Access (354)** transaction to the client (described below) to inform them of their privilege level on the server.
-* The server also considers the user part of the active user list now, and will notify other connected users of this new user (via **Notify Change User (301)**, described shortly).
+- Immediately after this, the server sends a **User Access (354)** transaction
+  to the client (described below) to inform them of their privilege level on the
+  server.
+- The server also considers the user part of the active user list now, and will
+  notify other connected users of this new user (via **Notify Change User
+  (301)**, described shortly).
 
-**End-user experience:** After clicking “Agree”, the user’s chosen nickname and icon are set, and their client transitions into the server’s online environment. They can now see the server contents (like the user list, chat, files, etc. depending on privileges). The client might update some UI based on preferences (e.g. mark them as not accepting private chats/messages if those were chosen).
+**End-user experience:** After clicking “Agree”, the user’s chosen nickname and
+icon are set, and their client transitions into the server’s online environment.
+They can now see the server contents (like the user list, chat, files, etc.
+depending on privileges). The client might update some UI based on preferences
+(e.g. mark them as not accepting private chats/messages if those were chosen).
 
 ### User Access Privileges (Transaction 354) – Server Initiates
 
-**ID 354 – User Access** (`myTran_UserAccess`) is sent by the server typically right after login (after agreement). **Purpose:** To inform the client of the access privileges of the current user’s account. **Initiator:** Server.
+**ID 354 – User Access** (`myTran_UserAccess`) is sent by the server typically
+right after login (after agreement). **Purpose:** To inform the client of the
+access privileges of the current user’s account. **Initiator:** Server.
 
-* **Parameters (Server→Client):** The server sends the user’s access rights as a bitmap (field 110 “User access”). See [Access Privilege Bits](#access-privilege-bits-field-110) for what each bit represents. No other fields are sent.
-* **Response:** The client does not reply to this (one-way notification).
+- **Parameters (Server→Client):** The server sends the user’s access rights as a
+  bitmap (field 110 “User access”). See
+  [Access Privilege Bits](#access-privilege-bits-field-110) for what each bit
+  represents. No other fields are sent.
+- **Response:** The client does not reply to this (one-way notification).
 
-**Server behavior:** The server looks up the privileges associated with the user’s account (e.g. whether they are an admin or a normal user and what permissions they have). It then sends this transaction so the client knows what the user can or cannot do on the server. This could include general privileges (like “Send Chat”, “Download Files”, “Create Folders”) and possibly folder-specific or news-specific rights.
+**Server behavior:** The server looks up the privileges associated with the
+user’s account (e.g. whether they are an admin or a normal user and what
+permissions they have). It then sends this transaction so the client knows what
+the user can or cannot do on the server. This could include general privileges
+(like “Send Chat”, “Download Files”, “Create Folders”) and possibly
+folder-specific or news-specific rights.
 
-**End-user experience:** This transaction itself isn’t visible to the user, but its effects are. The Hotline client will enable or disable interface features based on the privileges. For example, if the user does not have “Upload File” privilege, the upload button might be grayed out; if they have admin rights, admin functions become available. Essentially, the client tailors the UI and available actions according to what the server allowed, immediately after login.
+**End-user experience:** This transaction itself isn’t visible to the user, but
+its effects are. The Hotline client will enable or disable interface features
+based on the privileges. For example, if the user does not have “Upload File”
+privilege, the upload button might be grayed out; if they have admin rights,
+admin functions become available. Essentially, the client tailors the UI and
+available actions according to what the server allowed, immediately after login.
 
 #### Access Privilege Bits (Field 110)
 
-The access bitmap sent in field 110 consists of individual privilege bits. These bits fall into three categories: *general* (user-level), *folder* (per-folder) and *bundle* (logical grouping). The meaning of each bit is listed below so implementations can translate the bitmap into permissions:
+The access bitmap sent in field 110 consists of individual privilege bits. These
+bits fall into three categories: *general* (user-level), *folder* (per-folder)
+and *bundle* (logical grouping). The meaning of each bit is listed below so
+implementations can translate the bitmap into permissions:
 
-| Bit | Privilege |
-| ---:| --------- |
-| 0 | Delete File |
-| 1 | Upload File |
-| 2 | Download File |
-| 3 | Rename File |
-| 4 | Move File |
-| 5 | Create Folder |
-| 6 | Delete Folder |
-| 7 | Rename Folder |
-| 8 | Move Folder |
-| 9 | Read Chat |
-| 10 | Send Chat |
-| 11 | Open Chat |
-| 12 | Close Chat |
-| 13 | Show in List |
-| 14 | Create User |
-| 15 | Delete User |
-| 16 | Open User |
-| 17 | Modify User |
-| 18 | Change Own Password |
-| 19 | Send Private Message |
-| 20 | News Read Article |
-| 21 | News Post Article |
-| 22 | Disconnect User |
-| 23 | Cannot be Disconnected |
-| 24 | Get Client Info |
-| 25 | Upload Anywhere |
-| 26 | Any Name |
-| 27 | No Agreement |
-| 28 | Set File Comment |
-| 29 | Set Folder Comment |
-| 30 | View Drop Boxes |
-| 31 | Make Alias |
-| 32 | Broadcast |
-| 33 | News Delete Article |
-| 34 | News Create Category |
-| 35 | News Delete Category |
-| 36 | News Create Folder |
-| 37 | News Delete Folder |
+| Bit | Privilege | | ---:| --------- | | 0 | Delete File | | 1 | Upload File |
+| 2 | Download File | | 3 | Rename File | | 4 | Move File | | 5 | Create Folder
+| | 6 | Delete Folder | | 7 | Rename Folder | | 8 | Move Folder | | 9 | Read
+Chat | | 10 | Send Chat | | 11 | Open Chat | | 12 | Close Chat | | 13 | Show in
+List | | 14 | Create User | | 15 | Delete User | | 16 | Open User | | 17 |
+Modify User | | 18 | Change Own Password | | 19 | Send Private Message | | 20 |
+News Read Article | | 21 | News Post Article | | 22 | Disconnect User | | 23 |
+Cannot be Disconnected | | 24 | Get Client Info | | 25 | Upload Anywhere | | 26
+| Any Name | | 27 | No Agreement | | 28 | Set File Comment | | 29 | Set Folder
+Comment | | 30 | View Drop Boxes | | 31 | Make Alias | | 32 | Broadcast | | 33 |
+News Delete Article | | 34 | News Create Category | | 35 | News Delete Category
+| | 36 | News Create Folder | | 37 | News Delete Folder |
 
 ### Retrieving the User List (Transaction 300) – Client Initiates
 
-**ID 300 – Get User Name List** (`myTran_GetUserNameList`) is usually the next step in the login sequence. After agreeing and receiving privileges, the client requests the list of currently online users. **Purpose:** To get the roster of all users connected to the server (for display in the client’s user list). **Initiator:** Client.
+**ID 300 – Get User Name List** (`myTran_GetUserNameList`) is usually the next
+step in the login sequence. After agreeing and receiving privileges, the client
+requests the list of currently online users. **Purpose:** To get the roster of
+all users connected to the server (for display in the client’s user list).
+**Initiator:** Client.
 
-* **Parameters (Client→Server):** No fields are required in the request (the server knows to return the full list).
-* **Response (Server→Client):** The server replies with one or more **User Name with Info** entries (field 300, repeated). Each such field is a data structure containing a user’s information: typically their user ID, nickname, icon, status flags (like admin or away), etc. (The protocol documentation defines the exact structure of “User name with info”.) Essentially, the server dumps the current user list.
+- **Parameters (Client→Server):** No fields are required in the request (the
+  server knows to return the full list).
+- **Response (Server→Client):** The server replies with one or more **User Name
+  with Info** entries (field 300, repeated). Each such field is a data structure
+  containing a user’s information: typically their user ID, nickname, icon,
+  status flags (like admin or away), etc. (The protocol documentation defines
+  the exact structure of “User name with info”.) Essentially, the server dumps
+  the current user list.
 
-**Server behavior:** On `GetUserNameList`, the server compiles all connected users’ info. This includes the user IDs (each user gets a unique ID number for this session), their nickname, icon ID, and a flags field that indicates things like whether the user is an admin or has “do not disturb” enabled. It sends all that in a single reply. This snapshot is used by the client to populate the user list UI.
+**Server behavior:** On `GetUserNameList`, the server compiles all connected
+users’ info. This includes the user IDs (each user gets a unique ID number for
+this session), their nickname, icon ID, and a flags field that indicates things
+like whether the user is an admin or has “do not disturb” enabled. It sends all
+that in a single reply. This snapshot is used by the client to populate the user
+list UI.
 
-**End-user experience:** The user sees the “user list” panel populate with all nicknames currently online. Icons or special markers may denote certain statuses (for example, an icon might show if a user is an admin or if they refuse private messages – the client uses the flags from the server to display such icons). At this point, the new user can see who else is online.
+**End-user experience:** The user sees the “user list” panel populate with all
+nicknames currently online. Icons or special markers may denote certain statuses
+(for example, an icon might show if a user is an admin or if they refuse private
+messages – the client uses the flags from the server to display such icons). At
+this point, the new user can see who else is online.
 
 ### User Appearance and Updates (Transaction 301 & 302) – Server Initiates
 
-Once the user is online, the server keeps everyone’s user list updated via notifications:
+Once the user is online, the server keeps everyone’s user list updated via
+notifications:
 
-* **ID 301 – Notify Change User** (`myTran_NotifyChangeUser`) is sent by the server to all clients when a user’s information changes or a new user joins. **Purpose:** To add a new user to the list or update an existing user’s data. **Initiator:** Server. The server uses this whenever *some other user* has either connected or changed their profile.
+- **ID 301 – Notify Change User** (`myTran_NotifyChangeUser`) is sent by the
+  server to all clients when a user’s information changes or a new user joins.
+  **Purpose:** To add a new user to the list or update an existing user’s data.
+  **Initiator:** Server. The server uses this whenever *some other user* has
+  either connected or changed their profile.
 
-  * **Parameters (Server→Client):** It includes the affected user’s ID (field 103), new icon ID (104), flags (112), and name (102). If a new user connected, these fields describe the new user; if an existing user changed something (like their nickname or status), the fields contain the updated info.
-  * **Response:** No reply (clients just update their UI).
+  - **Parameters (Server→Client):** It includes the affected user’s ID (field
+    103), new icon ID (104), flags (112), and name (102). If a new user
+    connected, these fields describe the new user; if an existing user changed
+    something (like their nickname or status), the fields contain the updated
+    info.
+  - **Response:** No reply (clients just update their UI).
 
-  **Server behavior:** For a new login, right after adding the user, the server broadcasts a Notify Change User to everyone *except* that new user (who got the list via 300). This tells other clients “User X has joined” and provides their details. Similarly, if a user uses the **Set Client User Info (304)** transaction to change their nickname, icon, or preference flags (explained next), the server sends Notify Change User to update all clients’ lists with the new nickname/icon/status. In v1.8.x, the server also applies this update to any chat rooms that the user is in (meaning the change is reflected in chat participant lists too).
+  **Server behavior:** For a new login, right after adding the user, the server
+  broadcasts a Notify Change User to everyone *except* that new user (who got
+  the list via 300). This tells other clients “User X has joined” and provides
+  their details. Similarly, if a user uses the **Set Client User Info (304)**
+  transaction to change their nickname, icon, or preference flags (explained
+  next), the server sends Notify Change User to update all clients’ lists with
+  the new nickname/icon/status. In v1.8.x, the server also applies this update
+  to any chat rooms that the user is in (meaning the change is reflected in chat
+  participant lists too).
 
-  **End-user experience:** Other users see one of two things: if a new user connected, they appear in the user list (often with a join message like “User \[name] has connected” in the client’s status area). If an existing user changed their name or icon, the list entry updates (their name changes in real-time, icon updates, and an indicator might flash that the user updated their info). If the user toggled “Refuse chat” or “Refuse messages” or set an auto-reply, those corresponding icons (like a “no messages” icon) might appear or disappear next to the name.
+  **End-user experience:** Other users see one of two things: if a new user
+  connected, they appear in the user list (often with a join message like “User
+  [name] has connected” in the client’s status area). If an existing user
+  changed their name or icon, the list entry updates (their name changes in
+  real-time, icon updates, and an indicator might flash that the user updated
+  their info). If the user toggled “Refuse chat” or “Refuse messages” or set an
+  auto-reply, those corresponding icons (like a “no messages” icon) might appear
+  or disappear next to the name.
 
-* **ID 302 – Notify Delete User** (`myTran_NotifyDeleteUser`) is sent when a user disconnects. **Purpose:** To remove a user from the user list. **Initiator:** Server.
+- **ID 302 – Notify Delete User** (`myTran_NotifyDeleteUser`) is sent when a
+  user disconnects. **Purpose:** To remove a user from the user list.
+  **Initiator:** Server.
 
-  * **Parameters:** The server sends the departing user’s ID (field 103).
-  * **Response:** None (clients will remove the user from their list).
+  - **Parameters:** The server sends the departing user’s ID (field 103).
+  - **Response:** None (clients will remove the user from their list).
 
-  **Server behavior:** As soon as a user disconnects (whether by their own action or being kicked), the server broadcasts a Notify Delete User to all remaining clients. It identifies which user ID is gone so clients can remove it from the roster.
+  **Server behavior:** As soon as a user disconnects (whether by their own
+  action or being kicked), the server broadcasts a Notify Delete User to all
+  remaining clients. It identifies which user ID is gone so clients can remove
+  it from the roster.
 
-  **End-user experience:** All users see that person disappear from the user list. The client typically also shows a message like “User \[name] has disconnected.” Any open private chats with that user would close or indicate that the user left.
+  **End-user experience:** All users see that person disappear from the user
+  list. The client typically also shows a message like “User [name] has
+  disconnected.” Any open private chats with that user would close or indicate
+  that the user left.
 
 ### Viewing User Info (Transaction 303) – Client Initiates
 
-**ID 303 – Get Client Info Text** (`myTran_GetClientInfoText`) is used when one user requests information about another user. **Purpose:** To retrieve a bit of profile or info text about a specific user. **Initiator:** Client (any client with permission can do this, typically by selecting “Get Info” on a user).
+**ID 303 – Get Client Info Text** (`myTran_GetClientInfoText`) is used when one
+user requests information about another user. **Purpose:** To retrieve a bit of
+profile or info text about a specific user. **Initiator:** Client (any client
+with permission can do this, typically by selecting “Get Info” on a user).
 
-* **Parameters (Client→Server):** The requesting client sends the target user’s ID (field 103) in the request. (This action requires the *Get Client Info* privilege (privilege code 24) – by default, regular users likely have it, so they can view each other’s info.)
-* **Response (Server→Client):** The server replies with the user’s name (field 102) and an info text string (field 101, “Data”). The “info text” is a short text that the user or admin configured (for example, a real name, contact info, or any note). If no info text is set, it could be blank.
+- **Parameters (Client→Server):** The requesting client sends the target user’s
+  ID (field 103) in the request. (This action requires the *Get Client Info*
+  privilege (privilege code 24) – by default, regular users likely have it, so
+  they can view each other’s info.)
+- **Response (Server→Client):** The server replies with the user’s name (field
+  102\) and an info text string (field 101, “Data”). The “info text” is a short
+  text that the user or admin configured (for example, a real name, contact
+  info, or any note). If no info text is set, it could be blank.
 
-**Server behavior:** The server looks up the requested user’s account or session info. It fetches the “user info” field associated with that user. On Hotline servers, each account can have an info or real name field, and users themselves can’t change it in 1.8.5 (there is no direct user command to set a profile text aside from auto-reply). Usually, this might contain the full name or a comment an admin set. The server returns that text to the requester.
+**Server behavior:** The server looks up the requested user’s account or session
+info. It fetches the “user info” field associated with that user. On Hotline
+servers, each account can have an info or real name field, and users themselves
+can’t change it in 1.8.5 (there is no direct user command to set a profile text
+aside from auto-reply). Usually, this might contain the full name or a comment
+an admin set. The server returns that text to the requester.
 
-**End-user experience:** When a user selects “Get Info” on someone, a small info window opens showing that user’s nickname and their info text. For example, it might show “User: JohnDoe – Info: John Doe from Support Team.” If the user has no info text, it might just show their name. This is read-only to the viewer.
+**End-user experience:** When a user selects “Get Info” on someone, a small info
+window opens showing that user’s nickname and their info text. For example, it
+might show “User: JohnDoe – Info: John Doe from Support Team.” If the user has
+no info text, it might just show their name. This is read-only to the viewer.
 
 ### Changing User Settings (Transaction 304) – Client Initiates
 
-**ID 304 – Set Client User Info** (`myTran_SetClientUserInfo`) is how a connected user updates their own profile/preferences on the server. **Purpose:** To change the user’s visible name, icon, or privacy options on the server. **Initiator:** Client (only for the current user themselves).
+**ID 304 – Set Client User Info** (`myTran_SetClientUserInfo`) is how a
+connected user updates their own profile/preferences on the server. **Purpose:**
+To change the user’s visible name, icon, or privacy options on the server.
+**Initiator:** Client (only for the current user themselves).
 
-* **Parameters (Client→Server):** The client sends any of the following that are being changed: new user name (field 102) to change their display nickname, new icon ID (field 104) to change their icon, and an updated Options bitmap (field 113) to change their privacy settings. The Options bits are the same as during login: bit 1 = refuse private messages, bit 2 = refuse private chat invites, bit 4 = enable automatic response. If bit 4 (auto-response) is set, an Automatic Response string (field 215) can be provided with the message to auto-send. The client includes only the fields it wants to change (e.g. to just toggle “no private messages”, it might send just the options field).
-* **Response:** There is no direct reply expected. The server will acknowledge the changes implicitly by broadcasting an update to others.
+- **Parameters (Client→Server):** The client sends any of the following that are
+  being changed: new user name (field 102) to change their display nickname, new
+  icon ID (field 104) to change their icon, and an updated Options bitmap (field
+  113\) to change their privacy settings. The Options bits are the same as during
+  login: bit 1 = refuse private messages, bit 2 = refuse private chat invites,
+  bit 4 = enable automatic response. If bit 4 (auto-response) is set, an
+  Automatic Response string (field 215) can be provided with the message to
+  auto-send. The client includes only the fields it wants to change (e.g. to
+  just toggle “no private messages”, it might send just the options field).
+- **Response:** There is no direct reply expected. The server will acknowledge
+  the changes implicitly by broadcasting an update to others.
 
-**Server behavior:** When the server receives SetClientUserInfo, it updates that user’s info in memory: their name (for the session), icon, and flags. It then notifies all clients (including in any chats) via **Notify Change User (301)** so that everyone sees the new name/icon/status. This is essentially how nickname changes or “do not disturb” status is propagated. The server does not persist these changes to the account database (except possibly the user icon and name might be session-only if the account name is fixed; in Hotline the nickname can be different from login and can change per session). Automatic response text is stored so the server (or the client) can use it if someone messages this user.
+**Server behavior:** When the server receives SetClientUserInfo, it updates that
+user’s info in memory: their name (for the session), icon, and flags. It then
+notifies all clients (including in any chats) via **Notify Change User (301)**
+so that everyone sees the new name/icon/status. This is essentially how nickname
+changes or “do not disturb” status is propagated. The server does not persist
+these changes to the account database (except possibly the user icon and name
+might be session-only if the account name is fixed; in Hotline the nickname can
+be different from login and can change per session). Automatic response text is
+stored so the server (or the client) can use it if someone messages this user.
 
-**End-user experience:** When the user changes their nickname or icon, they immediately see it change in their own client. Everyone else online sees the user’s entry update (the new name appears in the user list, possibly with a notification). If the user toggles “Refuse Private Messages” or “Refuse Chat”, an icon (like a no-entry sign) might appear next to their name in others’ user lists indicating they are not open to PMs or chat invites. If they set an auto-reply, others won’t see that directly, but it will be sent back when someone tries to message them (as we’ll see in **Private Messaging** below).
+**End-user experience:** When the user changes their nickname or icon, they
+immediately see it change in their own client. Everyone else online sees the
+user’s entry update (the new name appears in the user list, possibly with a
+notification). If the user toggles “Refuse Private Messages” or “Refuse Chat”,
+an icon (like a no-entry sign) might appear next to their name in others’ user
+lists indicating they are not open to PMs or chat invites. If they set an
+auto-reply, others won’t see that directly, but it will be sent back when
+someone tries to message them (as we’ll see in **Private Messaging** below).
 
-**Summary:** At this point in the login flow, the user is fully online, can see others, and others see them. The client has possibly also automatically issued either a **Get File List (200)** or **Get News Category List (370)** request, depending on user preferences, to load either the file browser or news as the default view. (Hotline clients let users choose whether to start in the Files or News section after login.) The next sections describe how file browsing and news retrieval work, as well as chat and messaging.
+**Summary:** At this point in the login flow, the user is fully online, can see
+others, and others see them. The client has possibly also automatically issued
+either a **Get File List (200)** or **Get News Category List (370)** request,
+depending on user preferences, to load either the file browser or news as the
+default view. (Hotline clients let users choose whether to start in the Files or
+News section after login.) The next sections describe how file browsing and news
+retrieval work, as well as chat and messaging.
 
 ## Chat (Public and Private Chat Rooms)
 
-Hotline servers support a main public chat room and additional private chat rooms. Chat messages are broadcast to all users in the same chat room. The following transactions handle sending and receiving chat text, joining/leaving chats, and managing chat invitations and subjects.
+Hotline servers support a main public chat room and additional private chat
+rooms. Chat messages are broadcast to all users in the same chat room. The
+following transactions handle sending and receiving chat text, joining/leaving
+chats, and managing chat invitations and subjects.
 
 ### Sending a Chat Message (Transaction 105) – Client Initiates
 
-**ID 105 – Send Chat** (`myTran_ChatSend`) is used whenever a user sends a message to a chat room. **Purpose:** To transmit a chat message (text line) from a client to the server (to be distributed to all chat participants). **Initiator:** Client.
+**ID 105 – Send Chat** (`myTran_ChatSend`) is used whenever a user sends a
+message to a chat room. **Purpose:** To transmit a chat message (text line) from
+a client to the server (to be distributed to all chat participants).
+**Initiator:** Client.
 
-* **Parameters (Client→Server):** The client provides the chat message text (field 101, containing the message string). It also may include a **Chat ID** (field 114) if the message is intended for a specific chat room other than the main/default chat. If no Chat ID is given, it implies the main public chat. There’s also an optional “Chat options” field (109) which can indicate a “normal” or “alternate” chat message. (In practice, this might differentiate between standard chat lines vs. actions or colored text, depending on the client UI. By default 0 = normal text, 1 = alternate style.)
-* **Response:** The server does not send a direct reply to the sender. Instead, the server will echo/distribute the message to all appropriate users via the **Chat Message** transaction.
+- **Parameters (Client→Server):** The client provides the chat message text
+  (field 101, containing the message string). It also may include a **Chat ID**
+  (field 114) if the message is intended for a specific chat room other than the
+  main/default chat. If no Chat ID is given, it implies the main public chat.
+  There’s also an optional “Chat options” field (109) which can indicate a
+  “normal” or “alternate” chat message. (In practice, this might differentiate
+  between standard chat lines vs. actions or colored text, depending on the
+  client UI. By default 0 = normal text, 1 = alternate style.)
+- **Response:** The server does not send a direct reply to the sender. Instead,
+  the server will echo/distribute the message to all appropriate users via the
+  **Chat Message** transaction.
 
-**Server behavior:** Upon receiving a ChatSend from a user, the server checks that the user has the privilege to send chat (the user needs *Send Chat* privilege). If yes, the server takes the text and prepares a **Chat Message (106)** to all users in that chat room (including the sender, typically, so they see their message appear). If the user is not in the specified chat (e.g. they haven’t joined a private chat they’re trying to send to), the server might ignore the message or send an error. If the server has any chat moderation, it could filter or format the message (but normally it just relays it).
+**Server behavior:** Upon receiving a ChatSend from a user, the server checks
+that the user has the privilege to send chat (the user needs *Send Chat*
+privilege). If yes, the server takes the text and prepares a **Chat Message
+(106)** to all users in that chat room (including the sender, typically, so they
+see their message appear). If the user is not in the specified chat (e.g. they
+haven’t joined a private chat they’re trying to send to), the server might
+ignore the message or send an error. If the server has any chat moderation, it
+could filter or format the message (but normally it just relays it).
 
-**End-user experience:** The user types a line in the chat input and hits send. Immediately (round-trip to server), the message appears in the chat window for them and everyone else present. The client will display it with the user’s name or icon next to it. If there was a problem (for instance, user muted or no privilege), the message wouldn’t show and the user might get a notice that they cannot speak in chat.
+**End-user experience:** The user types a line in the chat input and hits send.
+Immediately (round-trip to server), the message appears in the chat window for
+them and everyone else present. The client will display it with the user’s name
+or icon next to it. If there was a problem (for instance, user muted or no
+privilege), the message wouldn’t show and the user might get a notice that they
+cannot speak in chat.
 
 ### Receiving a Chat Message (Transaction 106) – Server Initiates
 
-**ID 106 – Chat Message** (`myTran_ChatMsg`) is how the server delivers a chat line to clients in a chat room. **Purpose:** To broadcast a chat message to chat participants. **Initiator:** Server (sent to each client in the chat).
+**ID 106 – Chat Message** (`myTran_ChatMsg`) is how the server delivers a chat
+line to clients in a chat room. **Purpose:** To broadcast a chat message to chat
+participants. **Initiator:** Server (sent to each client in the chat).
 
-* **Parameters (Server→Client):** The server includes the chat identifier (field 114) to specify which chat room the message belongs to, and the chat text (field 101) which is the content of the message. If the Chat ID is not provided in the message (perhaps in older contexts or main chat), the protocol notes that the Data field might contain a “special chat message” – possibly system messages or actions.
-* **Response:** Clients do not reply to chat messages.
+- **Parameters (Server→Client):** The server includes the chat identifier (field
+  114\) to specify which chat room the message belongs to, and the chat text
+  (field 101) which is the content of the message. If the Chat ID is not
+  provided in the message (perhaps in older contexts or main chat), the protocol
+  notes that the Data field might contain a “special chat message” – possibly
+  system messages or actions.
+- **Response:** Clients do not reply to chat messages.
 
-**Server behavior:** For every incoming chat message, the server sends out a ChatMsg transaction to each user currently in that chat room (except possibly the sender if the client is designed to echo locally, but generally the sender gets it too for consistency). The server may also generate ChatMsg on its own for server notices (for example, “Admin has muted the room” could be sent as a chat message by the server software). If chat rooms have IDs (the main chat might be ID 0 or omitted), the server ensures to tag the message with the correct chat context so clients only display it in the correct window.
+**Server behavior:** For every incoming chat message, the server sends out a
+ChatMsg transaction to each user currently in that chat room (except possibly
+the sender if the client is designed to echo locally, but generally the sender
+gets it too for consistency). The server may also generate ChatMsg on its own
+for server notices (for example, “Admin has muted the room” could be sent as a
+chat message by the server software). If chat rooms have IDs (the main chat
+might be ID 0 or omitted), the server ensures to tag the message with the
+correct chat context so clients only display it in the correct window.
 
-**End-user experience:** The user sees new chat lines appearing in the chat window. Each ChatMsg usually appears with the sender’s name (the client knows user ID to name mapping from the user list). If the message was a special type (e.g. an emote or system message), it might appear in italic or a different style as handled by the client. All participants in the chat see the same messages at roughly the same time.
+**End-user experience:** The user sees new chat lines appearing in the chat
+window. Each ChatMsg usually appears with the sender’s name (the client knows
+user ID to name mapping from the user list). If the message was a special type
+(e.g. an emote or system message), it might appear in italic or a different
+style as handled by the client. All participants in the chat see the same
+messages at roughly the same time.
 
 ### Joining a Chat Room (Transaction 115) – Client Initiates
 
-**ID 115 – Join Chat** (`myTran_JoinChat`) is used when a client wants to enter a chat room (either the main chat or a private chat). **Purpose:** To join an existing chat channel and retrieve its current state (participants and topic). **Initiator:** Client.
+**ID 115 – Join Chat** (`myTran_JoinChat`) is used when a client wants to enter
+a chat room (either the main chat or a private chat). **Purpose:** To join an
+existing chat channel and retrieve its current state (participants and topic).
+**Initiator:** Client.
 
-* **Parameters (Client→Server):** The client sends the Chat ID of the chat it wishes to join (field 114). For the main public chat, there may be a well-known ID (often 0 or omitted; Hotline main chat might not require an explicit join in some implementations, but if it does, the ID would be known or obtained via an invite mechanism).
-* **Response (Server→Client):** The server replies with the current **Chat subject** (field 115) – the topic/title of that chat room – and a list of current users in the chat. The user list is given by one or more **User name with info** entries (field 300, repeated) listing each user currently in that chat. This is similar to the main user list but scoped to that chat room.
+- **Parameters (Client→Server):** The client sends the Chat ID of the chat it
+  wishes to join (field 114). For the main public chat, there may be a
+  well-known ID (often 0 or omitted; Hotline main chat might not require an
+  explicit join in some implementations, but if it does, the ID would be known
+  or obtained via an invite mechanism).
+- **Response (Server→Client):** The server replies with the current **Chat
+  subject** (field 115) – the topic/title of that chat room – and a list of
+  current users in the chat. The user list is given by one or more **User name
+  with info** entries (field 300, repeated) listing each user currently in that
+  chat. This is similar to the main user list but scoped to that chat room.
 
-**Server behavior:** When a user requests to join a chat, the server checks if the chat exists and if the user is allowed (if it’s a private chat, perhaps an invite is required or a password, but Hotline’s private chats are usually by invitation only). Assuming they have access (for main chat, if they have *Read Chat* privilege they can join; for private, if they were invited or it’s open), the server adds that user to the chat’s participant list. It then sends back the chat’s current subject (topic) and all users currently there. The server also notifies *other members of that chat* that this user has joined via a **Notify Chat Change User (117)** transaction (described next).
+**Server behavior:** When a user requests to join a chat, the server checks if
+the chat exists and if the user is allowed (if it’s a private chat, perhaps an
+invite is required or a password, but Hotline’s private chats are usually by
+invitation only). Assuming they have access (for main chat, if they have *Read
+Chat* privilege they can join; for private, if they were invited or it’s open),
+the server adds that user to the chat’s participant list. It then sends back the
+chat’s current subject (topic) and all users currently there. The server also
+notifies *other members of that chat* that this user has joined via a **Notify
+Chat Change User (117)** transaction (described next).
 
-**End-user experience:** When the user opens a chat window (main or a private chat), the client sends JoinChat. The user then sees the chat room interface populate: the chat topic (subject) is displayed (e.g. “Topic: General Discussion”), and the list of users currently in that chat appears (often on the side of the chat window). They can now participate and see messages in that chat. Other people in the room will see a notification that this user has joined (often as a system message like “\[User] has joined the chat”).
+**End-user experience:** When the user opens a chat window (main or a private
+chat), the client sends JoinChat. The user then sees the chat room interface
+populate: the chat topic (subject) is displayed (e.g. “Topic: General
+Discussion”), and the list of users currently in that chat appears (often on the
+side of the chat window). They can now participate and see messages in that
+chat. Other people in the room will see a notification that this user has joined
+(often as a system message like “[User] has joined the chat”).
 
 ### Leaving a Chat Room (Transaction 116) – Client Initiates
 
-**ID 116 – Leave Chat** (`myTran_LeaveChat`) is sent when a user leaves a chat room. **Purpose:** To exit a chat and inform the server (so the server can update the participant list). **Initiator:** Client.
+**ID 116 – Leave Chat** (`myTran_LeaveChat`) is sent when a user leaves a chat
+room. **Purpose:** To exit a chat and inform the server (so the server can
+update the participant list). **Initiator:** Client.
 
-* **Parameters:** The client specifies the Chat ID of the chat to leave (field 114).
-* **Response:** None expected directly.
+- **Parameters:** The client specifies the Chat ID of the chat to leave (field
+  114).
+- **Response:** None expected directly.
 
-**Server behavior:** The server removes the user from that chat’s participant list. It then sends a **Notify Chat Delete User (118)** to the remaining participants to tell them this user left. The server might also clear any state for that chat for the user (they will no longer receive messages from it).
+**Server behavior:** The server removes the user from that chat’s participant
+list. It then sends a **Notify Chat Delete User (118)** to the remaining
+participants to tell them this user left. The server might also clear any state
+for that chat for the user (they will no longer receive messages from it).
 
-**End-user experience:** The user closing a chat window or leaving a chat causes them to no longer see messages from that chat. On their side, the chat window closes. The other users in the chat see that “\[User] has left the chat” and that user’s name disappears from the chat’s user list.
+**End-user experience:** The user closing a chat window or leaving a chat causes
+them to no longer see messages from that chat. On their side, the chat window
+closes. The other users in the chat see that “[User] has left the chat” and that
+user’s name disappears from the chat’s user list.
 
 ### Chat Room Notifications (Transactions 117 & 118) – Server Initiates
 
 These keep track of who is in the chat:
 
-* **ID 117 – Notify Chat Change User** (`myTran_NotifyChatChangeUser`) is sent by the server to users in a chat room when *someone joins the chat or changes their info while in that chat*. **Purpose:** To add a user to the chat’s user list or update their icon/name in that chat. **Initiator:** Server.
+- **ID 117 – Notify Chat Change User** (`myTran_NotifyChatChangeUser`) is sent
+  by the server to users in a chat room when *someone joins the chat or changes
+  their info while in that chat*. **Purpose:** To add a user to the chat’s user
+  list or update their icon/name in that chat. **Initiator:** Server.
 
-  * **Parameters:** Includes the Chat ID (field 114), the user’s ID (103), icon ID (104), flags (112), and name (102). Essentially the same data as a 301 NotifyChangeUser, but scoped to a chat.
-  * **Response:** None.
+  - **Parameters:** Includes the Chat ID (field 114), the user’s ID (103), icon
+    ID (104), flags (112), and name (102). Essentially the same data as a 301
+    NotifyChangeUser, but scoped to a chat.
+  - **Response:** None.
 
-  **Server behavior:** When a user joins, the server sends this to existing members so the new user appears in their chat roster. If a user already in the chat changes their nickname or icon (via 304), the global NotifyChangeUser (301) is sent to all clients, and **Hotline 1.8.x applies that update to chat rooms as well**. So 117 is actually mainly used for the join event (the documentation notes in 1.8.x it’s effectively only used for new joiners, since general info changes are covered by 301 in all contexts).
+  **Server behavior:** When a user joins, the server sends this to existing
+  members so the new user appears in their chat roster. If a user already in the
+  chat changes their nickname or icon (via 304), the global NotifyChangeUser
+  (301) is sent to all clients, and **Hotline 1.8.x applies that update to chat
+  rooms as well**. So 117 is actually mainly used for the join event (the
+  documentation notes in 1.8.x it’s effectively only used for new joiners, since
+  general info changes are covered by 301 in all contexts).
 
-  **End-user experience:** In the chat’s user list pane, a new name appears when someone joins. If someone already in the chat changed their name/icon, it updates there too (often instant since 301 handles it globally). The chat text area might also show a system line “User \[Name] has joined the chat.” This makes it clear who just came in.
+  **End-user experience:** In the chat’s user list pane, a new name appears when
+  someone joins. If someone already in the chat changed their name/icon, it
+  updates there too (often instant since 301 handles it globally). The chat text
+  area might also show a system line “User [Name] has joined the chat.” This
+  makes it clear who just came in.
 
-* **ID 118 – Notify Chat Delete User** (`myTran_NotifyChatDeleteUser`) is sent when someone leaves a chat. **Purpose:** To remove a user from the chat’s participant list. **Initiator:** Server.
+- **ID 118 – Notify Chat Delete User** (`myTran_NotifyChatDeleteUser`) is sent
+  when someone leaves a chat. **Purpose:** To remove a user from the chat’s
+  participant list. **Initiator:** Server.
 
-  * **Parameters:** Chat ID (114) and User ID (103) of the user who left.
-  * **Response:** None.
+  - **Parameters:** Chat ID (114) and User ID (103) of the user who left.
+  - **Response:** None.
 
-  **Server behavior:** On a user’s departure (or if they are kicked from the chat), the server sends this to remaining chat members. They will remove that user’s name from the list.
+  **Server behavior:** On a user’s departure (or if they are kicked from the
+  chat), the server sends this to remaining chat members. They will remove that
+  user’s name from the list.
 
-  **End-user experience:** The users in the chat see that user disappear from the user list. Often a message like “User \[Name] has left the chat” is shown. The chat continues for others; the leaving user is no longer in that room (and if it was a private chat and they were the last to leave, the chat room might cease to exist entirely).
+  **End-user experience:** The users in the chat see that user disappear from
+  the user list. Often a message like “User [Name] has left the chat” is shown.
+  The chat continues for others; the leaving user is no longer in that room (and
+  if it was a private chat and they were the last to leave, the chat room might
+  cease to exist entirely).
 
 ### Chat Invitations (Transactions 112, 113, 114) – Private Chats
 
-Hotline allows private chats: one user can invite others into a new chat room. These transactions handle inviting and accepting/declining chat invitations.
+Hotline allows private chats: one user can invite others into a new chat room.
+These transactions handle inviting and accepting/declining chat invitations.
 
-* **ID 112 – Invite to New Chat** (`myTran_InviteNewChat`) is used to start a brand new private chat with one or more users. **Purpose:** Client A invites selected users to a new chat room. **Initiator:** Client.
+- **ID 112 – Invite to New Chat** (`myTran_InviteNewChat`) is used to start a
+  brand new private chat with one or more users. **Purpose:** Client A invites
+  selected users to a new chat room. **Initiator:** Client.
 
-  * **Parameters (Client→Server):** It can include one or multiple user IDs to invite. Field 103 holds a User ID, and it can be repeated (103, 103, … multiple times) to invite several people at once. If no user ID is given, it likely means invite none (which wouldn’t make sense, so usually at least one).
-  * **Response (Server→Client):** The server responds with a set of fields that effectively *create the new chat*: it returns the list of initial participants and the new chat’s ID. Specifically, the reply includes the User ID (103), User icon ID (104), User flags (112), and User name (102) for **each user invited who joins**, as well as the new Chat ID (114) for this chat room. Essentially the server is confirming the chat creation and listing who is in it (likely echoing back the inviter and any invitees who are immediately in the chat, which initially might be just the inviter until others accept).
+  - **Parameters (Client→Server):** It can include one or multiple user IDs to
+    invite. Field 103 holds a User ID, and it can be repeated (103, 103, …
+    multiple times) to invite several people at once. If no user ID is given, it
+    likely means invite none (which wouldn’t make sense, so usually at least
+    one).
+  - **Response (Server→Client):** The server responds with a set of fields that
+    effectively *create the new chat*: it returns the list of initial
+    participants and the new chat’s ID. Specifically, the reply includes the
+    User ID (103), User icon ID (104), User flags (112), and User name (102) for
+    **each user invited who joins**, as well as the new Chat ID (114) for this
+    chat room. Essentially the server is confirming the chat creation and
+    listing who is in it (likely echoing back the inviter and any invitees who
+    are immediately in the chat, which initially might be just the inviter until
+    others accept).
 
-  **Server behavior:** When a user invites others to a new chat, the server creates a new chat room (assigning a unique Chat ID). The server adds the inviter to it immediately (they initiated it, so they are in that chat by default). It then sends out invitations to each user specified via **Invite to Chat (113)** transactions (see below). The reply to the inviter contains the Chat ID and currently present users (initially just themselves). As invitees join, the inviter will receive NotifyChatChangeUser events as those people come in.
+  **Server behavior:** When a user invites others to a new chat, the server
+  creates a new chat room (assigning a unique Chat ID). The server adds the
+  inviter to it immediately (they initiated it, so they are in that chat by
+  default). It then sends out invitations to each user specified via **Invite to
+  Chat (113)** transactions (see below). The reply to the inviter contains the
+  Chat ID and currently present users (initially just themselves). As invitees
+  join, the inviter will receive NotifyChatChangeUser events as those people
+  come in.
 
-  **End-user experience:** The inviting user will see a new chat window open (or a prompt) representing the private chat. Initially it might just show themselves until others join. The chat’s participant list is populated with those who accept. The invitee(s) on their side will receive an invite notification.
+  **End-user experience:** The inviting user will see a new chat window open (or
+  a prompt) representing the private chat. Initially it might just show
+  themselves until others join. The chat’s participant list is populated with
+  those who accept. The invitee(s) on their side will receive an invite
+  notification.
 
-* **ID 113 – Invite to Chat** (`myTran_InviteToChat`) covers two cases: the server sending an invite to a user, and a client inviting a user to an *existing* chat room.
+- **ID 113 – Invite to Chat** (`myTran_InviteToChat`) covers two cases: the
+  server sending an invite to a user, and a client inviting a user to an
+  *existing* chat room.
 
-  * **Client-initiated (optional case):** A client already in a chat can invite another user to *that existing chat* (not creating a new one). In that case, **Initiator: Client**, and the client sends the User ID to invite (103) and the Chat ID of the chat room (114). There is no reply expected from the server for this form. The server will then send an invite notification to the target user (using the server form below).
-  * **Server-initiated (common case for private chat invites):** **Initiator: Server.** The server sends this to a user to notify them that they are invited to join a chat.
+  - **Client-initiated (optional case):** A client already in a chat can invite
+    another user to *that existing chat* (not creating a new one). In that case,
+    **Initiator: Client**, and the client sends the User ID to invite (103) and
+    the Chat ID of the chat room (114). There is no reply expected from the
+    server for this form. The server will then send an invite notification to
+    the target user (using the server form below).
 
-    * **Parameters (Server→Client):** The server provides the Chat ID (114) and the ID of the user who invited them (103), plus that inviter’s name (102). This lets the receiving client know “User \[Name] is inviting you to Chat \[ID]”. The client typically will prompt “So-and-so invites you to a private chat. Accept?”.
-    * **Response:** The invited user does not reply to the InviteToChat directly. They will either join (via sending `Join Chat (115)`) or reject (via `Reject Chat Invite (114)` transaction).
+  - **Server-initiated (common case for private chat invites):** **Initiator:
+    Server.** The server sends this to a user to notify them that they are
+    invited to join a chat.
 
-  **Server behavior:** For a new chat (triggered by 112) or an existing chat invite, the server sends InviteToChat to each targeted user. If the server version is older (<1.5) and the invitee had auto-response or reject flags set, the doc notes the client will auto-send a RejectChatInvite (114) immediately without prompting. In modern case, the client likely prompts the user unless “auto-refuse chat invites” is enabled, in which case it automatically declines. The server awaits either a join or reject from each invitee.
+    - **Parameters (Server→Client):** The server provides the Chat ID (114) and
+      the ID of the user who invited them (103), plus that inviter’s name (102).
+      This lets the receiving client know “User [Name] is inviting you to Chat
+      [ID]”. The client typically will prompt “So-and-so invites you to a
+      private chat. Accept?”.
+    - **Response:** The invited user does not reply to the InviteToChat
+      directly. They will either join (via sending `Join Chat (115)`) or reject
+      (via `Reject Chat Invite (114)` transaction).
 
-  **End-user experience:** The user receiving this sees a pop-up or notification: “User X invites you to a private chat.” They can choose to accept or decline. If their client is set to auto-refuse chats (do not disturb), they might not even be prompted; it will auto-decline on their behalf, possibly with an auto message if set.
+  **Server behavior:** For a new chat (triggered by 112) or an existing chat
+  invite, the server sends InviteToChat to each targeted user. If the server
+  version is older (\<1.5) and the invitee had auto-response or reject flags
+  set, the doc notes the client will auto-send a RejectChatInvite (114)
+  immediately without prompting. In modern case, the client likely prompts the
+  user unless “auto-refuse chat invites” is enabled, in which case it
+  automatically declines. The server awaits either a join or reject from each
+  invitee.
 
-* **ID 114 – Reject Chat Invite** (`myTran_RejectChatInvite`) is sent by a client to refuse a chat invitation. **Purpose:** To let the server (and indirectly the inviter) know that the invitation was declined. **Initiator:** Client (invitee).
+  **End-user experience:** The user receiving this sees a pop-up or
+  notification: “User X invites you to a private chat.” They can choose to
+  accept or decline. If their client is set to auto-refuse chats (do not
+  disturb), they might not even be prompted; it will auto-decline on their
+  behalf, possibly with an auto message if set.
 
-  * **Parameters:** Chat ID (114) of the invite being rejected. That’s all that’s needed (the server knows who is rejecting by the session).
-  * **Response:** None.
+- **ID 114 – Reject Chat Invite** (`myTran_RejectChatInvite`) is sent by a
+  client to refuse a chat invitation. **Purpose:** To let the server (and
+  indirectly the inviter) know that the invitation was declined. **Initiator:**
+  Client (invitee).
 
-  **Server behavior:** On receiving a rejection, the server will not add that user to the chat. It may inform the inviter in some fashion (Hotline may send the inviter a system message like “User X declined the chat invite” – likely implemented as a **Server Message** to the inviter with a flag indicating refusal, or simply not adding the user, which implicitly shows they aren’t coming). The chat room, if empty (e.g. everyone declined), might be destroyed. There isn’t a specific protocol message to the inviter for rejection in the spec except possibly a server message with an option flag for admin vs user message.
+  - **Parameters:** Chat ID (114) of the invite being rejected. That’s all
+    that’s needed (the server knows who is rejecting by the session).
+  - **Response:** None.
 
-  **End-user experience:** The inviter sees that the person didn’t join – possibly they get a message “\[User] refused to join” or they simply never show up in the chat. The invitee simply closes the invite dialog or clicks “No,” and nothing more happens – they remain out of that chat.
+  **Server behavior:** On receiving a rejection, the server will not add that
+  user to the chat. It may inform the inviter in some fashion (Hotline may send
+  the inviter a system message like “User X declined the chat invite” – likely
+  implemented as a **Server Message** to the inviter with a flag indicating
+  refusal, or simply not adding the user, which implicitly shows they aren’t
+  coming). The chat room, if empty (e.g. everyone declined), might be destroyed.
+  There isn’t a specific protocol message to the inviter for rejection in the
+  spec except possibly a server message with an option flag for admin vs user
+  message.
+
+  **End-user experience:** The inviter sees that the person didn’t join –
+  possibly they get a message “[User] refused to join” or they simply never show
+  up in the chat. The invitee simply closes the invite dialog or clicks “No,”
+  and nothing more happens – they remain out of that chat.
 
 ### Chat Subject Management (Transactions 119 & 120)
 
-Chat rooms in Hotline have a “subject” or topic line that can be set, usually visible at the top of the chat window.
+Chat rooms in Hotline have a “subject” or topic line that can be set, usually
+visible at the top of the chat window.
 
-* **ID 120 – Set Chat Subject** (`myTran_SetChatSubject`) is used to change a chat’s topic. **Purpose:** To allow a user (often the admin or the one who created the chat) to set a new subject line for the chat room. **Initiator:** Client.
+- **ID 120 – Set Chat Subject** (`myTran_SetChatSubject`) is used to change a
+  chat’s topic. **Purpose:** To allow a user (often the admin or the one who
+  created the chat) to set a new subject line for the chat room. **Initiator:**
+  Client.
 
-  * **Parameters (Client→Server):** The client sends the Chat ID (field 114) of the room and the new subject string (field 115). The subject text is typically a short string.
-  * **Response:** No reply expected (the server will notify others).
+  - **Parameters (Client→Server):** The client sends the Chat ID (field 114) of
+    the room and the new subject string (field 115). The subject text is
+    typically a short string.
+  - **Response:** No reply expected (the server will notify others).
 
-  **Server behavior:** The server updates the chat room’s subject in its state. It then sends a **Notify Chat Subject (119)** to all participants to broadcast the new topic.
+  **Server behavior:** The server updates the chat room’s subject in its state.
+  It then sends a **Notify Chat Subject (119)** to all participants to broadcast
+  the new topic.
 
-  **End-user experience:** The user setting the topic might see their chat window update immediately. All users in the chat will see the topic change (often the client displays something like “Chat topic is now: <new subject>”). The topic field at the top of the chat window updates for everyone.
+  **End-user experience:** The user setting the topic might see their chat
+  window update immediately. All users in the chat will see the topic change
+  (often the client displays something like "Chat topic is now: `new subject`").
+  The topic field at the top of the chat window updates for everyone.
 
-* **ID 119 – Notify Chat Subject** (`myTran_NotifyChatSubject`) is the server’s message to all chat members that the subject changed. **Purpose:** To distribute the new chat topic. **Initiator:** Server.
+- **ID 119 – Notify Chat Subject** (`myTran_NotifyChatSubject`) is the server’s
+  message to all chat members that the subject changed. **Purpose:** To
+  distribute the new chat topic. **Initiator:** Server.
 
-  * **Parameters:** Chat ID (114) and the new Subject string (115).
-  * **Response:** None.
+  - **Parameters:** Chat ID (114) and the new Subject string (115).
+  - **Response:** None.
 
-  **Server behavior:** This is triggered when someone uses SetChatSubject. The server sends the new subject to every client in the specified chat so they can update their display.
+  **Server behavior:** This is triggered when someone uses SetChatSubject. The
+  server sends the new subject to every client in the specified chat so they can
+  update their display.
 
-  **End-user experience:** As mentioned, the chat’s topic line refreshes to the new text. Many clients also print a line in the chat log like “**Topic**: <new subject>” to ensure everyone notices the change.
+  **End-user experience:** As mentioned, the chat’s topic line refreshes to the
+  new text. Many clients also print a line in the chat log like "**Topic**:
+  `new subject`" to ensure everyone notices the change.
 
 ## Private Messaging (Instant Messages)
 
-Aside from group chat, Hotline supports one-to-one direct messages often called “private messages” or “instant messages.” These do not open a chat room; instead, they are like sending a direct note to one user (which may open a small private message window). The transactions for private messaging are separate from chat transactions.
+Aside from group chat, Hotline supports one-to-one direct messages often called
+“private messages” or “instant messages.” These do not open a chat room;
+instead, they are like sending a direct note to one user (which may open a small
+private message window). The transactions for private messaging are separate
+from chat transactions.
 
 ### Sending an Instant Message (Transaction 108) – Client Initiates
 
-**ID 108 – Send Instant Message** (`myTran_SendInstantMsg`) is used when a user sends a direct private message to another user on the server. **Purpose:** To deliver a private message (which could be text, or a refusal/auto-response) from one client to another via the server. **Initiator:** Client.
+**ID 108 – Send Instant Message** (`myTran_SendInstantMsg`) is used when a user
+sends a direct private message to another user on the server. **Purpose:** To
+deliver a private message (which could be text, or a refusal/auto-response) from
+one client to another via the server. **Initiator:** Client.
 
-* **Parameters (Client→Server):** The sender specifies the target user’s ID (field 103). An **Options** field (113) is included to indicate the nature of this message. Options can be:
+- **Parameters (Client→Server):** The sender specifies the target user’s ID
+  (field 103). An **Options** field (113) is included to indicate the nature of
+  this message. Options can be:
 
-  * `1` for a normal user message,
-  * `2` for a “Refuse message” (meaning this is actually a notice that the sender is refusing a prior message),
-  * `3` for “Refuse chat” (similar concept for chat invites),
-  * `4` for an “Automatic response” message.
+  - `1` for a normal user message,
+  - `2` for a “Refuse message” (meaning this is actually a notice that the
+    sender is refusing a prior message),
+  - `3` for “Refuse chat” (similar concept for chat invites),
+  - `4` for an “Automatic response” message.
 
-  In a typical scenario, a user sending a new message will set Options = 1 (User message). If the user is replying with an auto-response or refusal, their client will use the appropriate code. The message text itself goes in field 101 (Data) if there is a text message to send. Optionally, field 214 (Quoting message) can carry a quoted text (for example, if auto-responding to a specific message, it might quote it). In a normal initial message, quoting is not used.
-* **Response:** There is no direct reply back to the sender for this transaction. The server will route the message to the intended recipient via a **Server Message (104)** transaction.
+  In a typical scenario, a user sending a new message will set Options = 1 (User
+  message). If the user is replying with an auto-response or refusal, their
+  client will use the appropriate code. The message text itself goes in field
+  101 (Data) if there is a text message to send. Optionally, field 214 (Quoting
+  message) can carry a quoted text (for example, if auto-responding to a
+  specific message, it might quote it). In a normal initial message, quoting is
+  not used.
 
-**Server behavior:** When the server receives SendInstantMsg, it checks that the target user is online and that the sender has *Send Private Message* privilege (privilege code 19). If allowed, the server will forward the message. It translates the incoming data into a **Server Message** to the target user (see below). The Options field tells the server if this is a normal message or some kind of automated reply/refusal:
+- **Response:** There is no direct reply back to the sender for this
+  transaction. The server will route the message to the intended recipient via a
+  **Server Message (104)** transaction.
 
-* If it’s a normal user message (1), the server simply delivers it.
-* If the sender set it to “Refuse message” or “Refuse chat,” it likely means the sender is notifying the other person that their previous attempt was refused. In practice, the *receiving* user’s client, when set to refuse messages, doesn’t literally send a refusal code; instead the server or client on the other side might handle it. (Hotline protocol allows a user to actively send a refuse code – possibly used when someone tries to open a private chat and you hit “refuse” manually, your client might send an InstantMsg with option 2 or 3 as a signal.)
-* If it’s an “Automatic response” (4), the content will be the auto-reply text the user set. Typically this is triggered when a user is away; their client, upon receiving a message, might automatically send an InstantMsg with option 4 back to the original sender (including the original message quoted in field 214). The server then relays that auto-reply to the original sender as a Server Message (104).
+**Server behavior:** When the server receives SendInstantMsg, it checks that the
+target user is online and that the sender has *Send Private Message* privilege
+(privilege code 19). If allowed, the server will forward the message. It
+translates the incoming data into a **Server Message** to the target user (see
+below). The Options field tells the server if this is a normal message or some
+kind of automated reply/refusal:
 
-If the target user is offline (which on a Hotline server shouldn’t happen – you can only SendInstantMsg to connected users, since it’s not store-and-forward email), the server might return an error or ignore it. If the target has “Refuse Private Messages” enabled, one of two things can happen: either the server blocks the message and sends back a refusal on their behalf, or the target’s client immediately responds with a refusal message. In older versions, the server might auto-reply using the user’s auto-response string if present. In 1.8.5, since the auto-response is known to the server (from transaction 304), the server could potentially handle it. However, the design suggests the client does the auto-reply by sending an InstantMsg with option 4.
+- If it’s a normal user message (1), the server simply delivers it.
+- If the sender set it to “Refuse message” or “Refuse chat,” it likely means the
+  sender is notifying the other person that their previous attempt was refused.
+  In practice, the *receiving* user’s client, when set to refuse messages,
+  doesn’t literally send a refusal code; instead the server or client on the
+  other side might handle it. (Hotline protocol allows a user to actively send a
+  refuse code – possibly used when someone tries to open a private chat and you
+  hit “refuse” manually, your client might send an InstantMsg with option 2 or 3
+  as a signal.)
+- If it’s an “Automatic response” (4), the content will be the auto-reply text
+  the user set. Typically this is triggered when a user is away; their client,
+  upon receiving a message, might automatically send an InstantMsg with option 4
+  back to the original sender (including the original message quoted in field
+  214). The server then relays that auto-reply to the original sender as a
+  Server Message (104).
 
-**End-user experience:** When user A sends a private message to user B, user A will see the message appear in a private chat-style window or message window labeled with user B’s name (the Hotline client opens a small window for the conversation). They won’t get an explicit “delivered” response, but if user B replies, it will appear. If user B has auto-response on or is refusing messages, user A might instantly receive a message back saying e.g. “User B is not accepting private messages” or whatever auto-reply text B set. From user B’s perspective, if not blocking, a window pops up with A’s message. If B has “Refuse private messages” on, their client might not show anything, and either nothing happens on A’s side (message ignored) or A receives a generic refusal message. Typically, the Hotline client indicates with an icon that the user cannot be messaged (so the user A would know not to even try, ideally). If A does try, often nothing happens or A gets a system message from the server: the **Server Message** could be used to inform them that user B isn’t accepting messages.
+If the target user is offline (which on a Hotline server shouldn’t happen – you
+can only SendInstantMsg to connected users, since it’s not store-and-forward
+email), the server might return an error or ignore it. If the target has “Refuse
+Private Messages” enabled, one of two things can happen: either the server
+blocks the message and sends back a refusal on their behalf, or the target’s
+client immediately responds with a refusal message. In older versions, the
+server might auto-reply using the user’s auto-response string if present. In
+1.8.5, since the auto-response is known to the server (from transaction 304),
+the server could potentially handle it. However, the design suggests the client
+does the auto-reply by sending an InstantMsg with option 4.
+
+**End-user experience:** When user A sends a private message to user B, user A
+will see the message appear in a private chat-style window or message window
+labeled with user B’s name (the Hotline client opens a small window for the
+conversation). They won’t get an explicit “delivered” response, but if user B
+replies, it will appear. If user B has auto-response on or is refusing messages,
+user A might instantly receive a message back saying e.g. “User B is not
+accepting private messages” or whatever auto-reply text B set. From user B’s
+perspective, if not blocking, a window pops up with A’s message. If B has
+“Refuse private messages” on, their client might not show anything, and either
+nothing happens on A’s side (message ignored) or A receives a generic refusal
+message. Typically, the Hotline client indicates with an icon that the user
+cannot be messaged (so the user A would know not to even try, ideally). If A
+does try, often nothing happens or A gets a system message from the server: the
+**Server Message** could be used to inform them that user B isn’t accepting
+messages.
 
 ### Receiving a Private Message (Transaction 104) – Server Initiates
 
-**ID 104 – Server Message** (`myTran_ServerMsg`) is the mechanism by which a user actually receives a private message or certain admin messages. Despite the name “Server Message,” it generally carries messages from another user (routed through the server) or from the server/admin to the user. **Purpose:** Deliver a one-to-one message or notice to a client. **Initiator:** Server (whenever a message or certain alerts need to be delivered).
+**ID 104 – Server Message** (`myTran_ServerMsg`) is the mechanism by which a
+user actually receives a private message or certain admin messages. Despite the
+name “Server Message,” it generally carries messages from another user (routed
+through the server) or from the server/admin to the user. **Purpose:** Deliver a
+one-to-one message or notice to a client. **Initiator:** Server (whenever a
+message or certain alerts need to be delivered).
 
-* **Parameters (Server→Client):** In the common case of a user-to-user message, the server includes:
+- **Parameters (Server→Client):** In the common case of a user-to-user message,
+  the server includes:
 
-  * The sender’s user ID (field 103) and user name (field 102), so the recipient knows who it’s from.
-  * An Options bitmap (field 113) indicating if this is an automatic response, or if the sender refuses chat/messages, etc., similar to before. For a normal incoming message, this is usually 0 or 1 (the bits might all be zero meaning a regular message). If it’s an auto-reply or a system/admin message, the flags differ.
-  * The message text (field 101) which is the content to display.
-  * If the message is quoting a previous one (like an auto-response quoting what you said), field 214 “Quoting message” contains the quoted text.
+  - The sender’s user ID (field 103) and user name (field 102), so the recipient
+    knows who it’s from.
+  - An Options bitmap (field 113) indicating if this is an automatic response,
+    or if the sender refuses chat/messages, etc., similar to before. For a
+    normal incoming message, this is usually 0 or 1 (the bits might all be zero
+    meaning a regular message). If it’s an auto-reply or a system/admin message,
+    the flags differ.
+  - The message text (field 101) which is the content to display.
+  - If the message is quoting a previous one (like an auto-response quoting what
+    you said), field 214 “Quoting message” contains the quoted text.
 
-  If the server itself or an admin is sending a message, the protocol can omit the User ID field. The documentation says: if User ID (103) is not sent, the receiver should interpret the message as coming from the “server or admin” context, using the alternative fields. In that case, the server provides:
+  If the server itself or an admin is sending a message, the protocol can omit
+  the User ID field. The documentation says: if User ID (103) is not sent, the
+  receiver should interpret the message as coming from the “server or admin”
+  context, using the alternative fields. In that case, the server provides:
 
-  * The message text (101) as usual.
-  * A Chat options field (109) used here to signal message type: if Chat options = 1, it’s a “Server message”; if any other value, it’s an “Admin message”. This distinction might change how the client displays it (perhaps server messages are labeled as from “Server” or shown as system notifications).
-* **Response:** Clients do not reply to ServerMsg transactions.
+  - The message text (101) as usual.
+  - A Chat options field (109) used here to signal message type: if Chat options
+    = 1, it’s a “Server message”; if any other value, it’s an “Admin message”.
+    This distinction might change how the client displays it (perhaps server
+    messages are labeled as from “Server” or shown as system notifications).
 
-**Server behavior:** For a user-to-user PM, the server constructs a ServerMsg containing the original sender’s info and text. It sets the Options field based on the context (for example, if the sender had “automatic response” flag active on their account, it might set the corresponding bit so the recipient’s client can display an “Auto-Reply” tag). If the message is a **broadcast from an admin** or a **server notice**, the server sends a ServerMsg without a user ID, and uses the Chat options field to mark it. This is how things like an administrator’s broadcast (which we’ll cover in Administration) or system notifications (like “Server is restarting in 5 minutes”) are delivered to users – they appear as a special message, often italicized or in a separate system message window.
+- **Response:** Clients do not reply to ServerMsg transactions.
 
-**End-user experience:** When a user receives a private message, a private message window opens (or if one already exists for that correspondent, the new message appears in it). It will show the sender’s name and the message text. If it was an automatic response from the other side, it might say something like “Auto-response from \[Name]: I am away from my desk” – many clients visually indicate auto-replies or refusals (maybe by prefixing “\[Auto-Reply]”). If the message was from the server or an admin (with no user ID), it might appear either in a dedicated “News/Log window” or as a pop-up: for example, an admin broadcast might show up as “**Admin Message**: Please note the server rules...” to all users, or a server message might say “Welcome to the server!” when you log in. In any case, the client treats these ServerMsg accordingly (knowing whether there was a user ID or not).
+**Server behavior:** For a user-to-user PM, the server constructs a ServerMsg
+containing the original sender’s info and text. It sets the Options field based
+on the context (for example, if the sender had “automatic response” flag active
+on their account, it might set the corresponding bit so the recipient’s client
+can display an “Auto-Reply” tag). If the message is a **broadcast from an
+admin** or a **server notice**, the server sends a ServerMsg without a user ID,
+and uses the Chat options field to mark it. This is how things like an
+administrator’s broadcast (which we’ll cover in Administration) or system
+notifications (like “Server is restarting in 5 minutes”) are delivered to users
+– they appear as a special message, often italicized or in a separate system
+message window.
 
-**Note:** Hotline also had the concept of offline messages or news in older versions, which used **Get Messages (101)** and **New Message (102)** transactions. In 1.8.5, those are largely superseded by the News system (see next section). For completeness: **Get Messages (101)** was a client request to retrieve stored messages (server would reply with field 101 containing message text for each message), and **New Message (102)** was a server push of a new message (with field 101 text). These were used in older versions to implement something like a bulletin board or message of the day. In modern use, they are legacy and not commonly used since the News (bulletin board) transactions replaced them. Implementers should be aware these exist but can be considered deprecated in the context of 1.8.5.
+**End-user experience:** When a user receives a private message, a private
+message window opens (or if one already exists for that correspondent, the new
+message appears in it). It will show the sender’s name and the message text. If
+it was an automatic response from the other side, it might say something like
+“Auto-response from \[Name\]: I am away from my desk” – many clients visually
+indicate auto-replies or refusals (maybe by prefixing “[Auto-Reply]”). If the
+message was from the server or an admin (with no user ID), it might appear
+either in a dedicated “News/Log window” or as a pop-up: for example, an admin
+broadcast might show up as “**Admin Message**: Please note the server rules...”
+to all users, or a server message might say “Welcome to the server!” when you
+log in. In any case, the client treats these ServerMsg accordingly (knowing
+whether there was a user ID or not).
+
+**Note:** Hotline also had the concept of offline messages or news in older
+versions, which used **Get Messages (101)** and **New Message (102)**
+transactions. In 1.8.5, those are largely superseded by the News system (see
+next section). For completeness: **Get Messages (101)** was a client request to
+retrieve stored messages (server would reply with field 101 containing message
+text for each message), and **New Message (102)** was a server push of a new
+message (with field 101 text). These were used in older versions to implement
+something like a bulletin board or message of the day. In modern use, they are
+legacy and not commonly used since the News (bulletin board) transactions
+replaced them. Implementers should be aware these exist but can be considered
+deprecated in the context of 1.8.5.
 
 ## File Services (Files and Folders)
 
-Hotline servers provide a shared file repository where users can browse folders, download files, upload files, etc. The protocol uses a base port for transactions and a separate data port for file transfers (by default, if the server’s base port is N, file data connections use port N+1 for standard TCP transfers). Below are the transactions for file system navigation and transfer:
+Hotline servers provide a shared file repository where users can browse folders,
+download files, upload files, etc. The protocol uses a base port for
+transactions and a separate data port for file transfers (by default, if the
+server’s base port is N, file data connections use port N+1 for standard TCP
+transfers). Below are the transactions for file system navigation and transfer:
 
 ### Listing Files in a Folder (Transaction 200) – Client Initiates
 
-**ID 200 – Get File Name List** (`myTran_GetFileNameList`) is how a client asks for the contents (files and subfolders) of a directory on the server. **Purpose:** Retrieve a directory listing. **Initiator:** Client.
+**ID 200 – Get File Name List** (`myTran_GetFileNameList`) is how a client asks
+for the contents (files and subfolders) of a directory on the server.
+**Purpose:** Retrieve a directory listing. **Initiator:** Client.
 
-* **Parameters (Client→Server):** The client may send the path of the folder it wants to list (field 202 “File path”). If this field is not provided, the server assumes the root folder of the server’s file area. The path format is a binary structure in Hotline (not just a string – typically it’s a sequence of folder IDs or names). But the client takes care of that; the server just needs the provided path. No other fields are needed.
-* **Response (Server→Client):** The server replies with one or more **File name with info** entries (field 200, repeated). Each entry contains a file or folder name along with metadata. According to the protocol, “File name with info” includes details like whether it’s a folder or file, size, possibly creation date, etc., plus the name. Essentially, the server is sending a directory listing of that folder. Each entry is optional in the sense the server can send as many as there are items.
+- **Parameters (Client→Server):** The client may send the path of the folder it
+  wants to list (field 202 “File path”). If this field is not provided, the
+  server assumes the root folder of the server’s file area. The path format is a
+  binary structure in Hotline (not just a string – typically it’s a sequence of
+  folder IDs or names). But the client takes care of that; the server just needs
+  the provided path. No other fields are needed.
+- **Response (Server→Client):** The server replies with one or more **File name
+  with info** entries (field 200, repeated). Each entry contains a file or
+  folder name along with metadata. According to the protocol, “File name with
+  info” includes details like whether it’s a folder or file, size, possibly
+  creation date, etc., plus the name. Essentially, the server is sending a
+  directory listing of that folder. Each entry is optional in the sense the
+  server can send as many as there are items.
 
-**Server behavior:** Upon receiving the request, the server checks if the user has permission to view that folder (there are folder-level privileges like “View Drop Boxes” that might hide some folders) – in general, normal files are visible if the user has *Download File* or *View* rights. Then it gathers all items in the specified folder. For each file or subfolder, it creates a “file name with info” record including the item’s name, size (if file), type/creator codes (for Mac files), etc. If the listing is large, it might send multiple transactions parts, but typically it can fit many entries in one response. The server sends the list.
+**Server behavior:** Upon receiving the request, the server checks if the user
+has permission to view that folder (there are folder-level privileges like “View
+Drop Boxes” that might hide some folders) – in general, normal files are visible
+if the user has *Download File* or *View* rights. Then it gathers all items in
+the specified folder. For each file or subfolder, it creates a “file name with
+info” record including the item’s name, size (if file), type/creator codes (for
+Mac files), etc. If the listing is large, it might send multiple transactions
+parts, but typically it can fit many entries in one response. The server sends
+the list.
 
-**End-user experience:** The user navigates in the client’s file browser (for example, double-clicking a folder or choosing the Files view after login). The client sends this request, and then the file list appears: you see filenames, sizes, possibly icons indicating file vs folder. The user can now choose to download files or enter subfolders (which would trigger more 200 requests for deeper folders). If the folder was empty or not accessible, the user might see nothing or an error (if no permission, the server might have sent an empty list or possibly an error message).
+**End-user experience:** The user navigates in the client’s file browser (for
+example, double-clicking a folder or choosing the Files view after login). The
+client sends this request, and then the file list appears: you see filenames,
+sizes, possibly icons indicating file vs folder. The user can now choose to
+download files or enter subfolders (which would trigger more 200 requests for
+deeper folders). If the folder was empty or not accessible, the user might see
+nothing or an error (if no permission, the server might have sent an empty list
+or possibly an error message).
 
 ### Downloading a File (Transaction 202) – Client Initiates
 
-**ID 202 – Download File** (`myTran_DownloadFile`) is used when a client wants to download a single file from the server. **Purpose:** Initiate a file download. **Initiator:** Client.
+**ID 202 – Download File** (`myTran_DownloadFile`) is used when a client wants
+to download a single file from the server. **Purpose:** Initiate a file
+download. **Initiator:** Client.
 
-* **Parameters (Client→Server):** The client provides the name of the file (field 201) and the path of the file (field 202) so the server knows which file to send. If the client is resuming a partial download, it can include a **File resume data** field (203) with resume information (Hotline supports resuming downloads; this data tells the server how much the client already has). There’s also an optional **File transfer options** (field 204) which in practice is used for specifying if the client wants a specific fork or format of the file. In Hotline 1.8.x, this is set to 2 for certain file types (TEXT, image files) to possibly indicate a preview or specific handling. For most downloads, the default value is 2.
-* **Response (Server→Client):** The server responds with some fields indicating it’s ready to send. Specifically:
+- **Parameters (Client→Server):** The client provides the name of the file
+  (field 201) and the path of the file (field 202) so the server knows which
+  file to send. If the client is resuming a partial download, it can include a
+  **File resume data** field (203) with resume information (Hotline supports
+  resuming downloads; this data tells the server how much the client already
+  has). There’s also an optional **File transfer options** (field 204) which in
+  practice is used for specifying if the client wants a specific fork or format
+  of the file. In Hotline 1.8.x, this is set to 2 for certain file types (TEXT,
+  image files) to possibly indicate a preview or specific handling. For most
+  downloads, the default value is 2.
 
-  * A **Transfer size** (field 108) which is the total size in bytes that will be sent (for this file).
-  * The **File size** (field 207) of the file (could be same as transfer size, unless maybe a specific fork or conversion is happening; usually they match).
-  * A **Reference number** (field 107) which is an identifier for this transfer.
-  * A **Waiting count** (field 116) which tells how many downloads are in queue ahead of this one (if the server has limited slots). Usually if the server can start sending immediately, waiting count is 0. If all download slots are full, waiting count might be >0 and the server might not send data until a slot frees up.
+- **Response (Server→Client):** The server responds with some fields indicating
+  it’s ready to send. Specifically:
 
-**Server behavior:** When a download request comes in, the server first checks the user’s privileges. The user must have *Download File* privilege for that folder or file. If allowed, the server locks one of its download “slots” for this transfer (Hotline servers often limit how many concurrent downloads they serve per user or in total). If the slots are full, the server might queue the request. In such a case, the server could respond with a **Download Info (211)** transaction to indicate the user’s position in queue. (Transaction **211 – Download Info** is a server-initiated message: it includes the reference number and a waiting position count, basically telling the client “I’ve queued your download, you are #N in line” – the client would typically display a “Waiting…” status). In our scenario, assume either immediately or eventually a slot is free:
+  - A **Transfer size** (field 108) which is the total size in bytes that will
+    be sent (for this file).
+  - The **File size** (field 207) of the file (could be same as transfer size,
+    unless maybe a specific fork or conversion is happening; usually they
+    match).
+  - A **Reference number** (field 107) which is an identifier for this transfer.
+  - A **Waiting count** (field 116) which tells how many downloads are in queue
+    ahead of this one (if the server has limited slots). Usually if the server
+    can start sending immediately, waiting count is 0. If all download slots are
+    full, waiting count might be >0 and the server might not send data until a
+    slot frees up.
 
-* The server sends back the reply with reference number, file size, etc..
-* Then the file transfer proper begins: The client is now expected to open a separate TCP connection to the server’s data port (base port + 1). The client sends a small handshake over that new connection containing `'HTXF'` (Hotline Transfer) and the reference number. The server uses that reference to match the transfer request.
-* If the connection is established and handshake done, the server transmits the file’s data over that connection. Specifically, Hotline uses a “flattened file object” format which can include file forks and metadata for Mac files. For a simple file, it’s essentially the raw bytes preceded by a header.
-* If the download was queued, once it’s this user’s turn the server will initiate the data connection handshake at that time (the client might keep trying to connect until allowed).
-* If the client had provided resume info, the server will skip ahead and only send the remaining bytes (or instruct the client to resume from a point via a **Resume** action – though in Hotline’s case the resume was indicated by field 203, so likely the server just starts from that offset).
+**Server behavior:** When a download request comes in, the server first checks
+the user’s privileges. The user must have *Download File* privilege for that
+folder or file. If allowed, the server locks one of its download “slots” for
+this transfer (Hotline servers often limit how many concurrent downloads they
+serve per user or in total). If the slots are full, the server might queue the
+request. In such a case, the server could respond with a **Download Info (211)**
+transaction to indicate the user’s position in queue. (Transaction **211 –
+Download Info** is a server-initiated message: it includes the reference number
+and a waiting position count, basically telling the client “I’ve queued your
+download, you are #N in line” – the client would typically display a “Waiting…”
+status). In our scenario, assume either immediately or eventually a slot is
+free:
 
-The details of the actual data stream are complex, but the main point is the transaction workflow sets it up. After sending data, the server closes the data connection.
+- The server sends back the reply with reference number, file size, etc..
+- Then the file transfer proper begins: The client is now expected to open a
+  separate TCP connection to the server’s data port (base port + 1). The client
+  sends a small handshake over that new connection containing `'HTXF'` (Hotline
+  Transfer) and the reference number. The server uses that reference to match
+  the transfer request.
+- If the connection is established and handshake done, the server transmits the
+  file’s data over that connection. Specifically, Hotline uses a “flattened file
+  object” format which can include file forks and metadata for Mac files. For a
+  simple file, it’s essentially the raw bytes preceded by a header.
+- If the download was queued, once it’s this user’s turn the server will
+  initiate the data connection handshake at that time (the client might keep
+  trying to connect until allowed).
+- If the client had provided resume info, the server will skip ahead and only
+  send the remaining bytes (or instruct the client to resume from a point via a
+  **Resume** action – though in Hotline’s case the resume was indicated by field
+  203, so likely the server just starts from that offset).
 
-**End-user experience:** The user selects a file and clicks “Download”. Immediately, an entry appears in their Transfers window. If the download starts immediately, it shows progress (the client now downloading from the server). If the server had too many concurrent downloads, the user might see a “Waiting in queue (position X)” status – Hotline clients show the queue position, thanks to the server’s Download Info (211) message which includes `Waiting count`. Once it’s their turn, the transfer begins. If the transfer is interrupted, the user can resume it later; the client will send the same 202 with a resume token and the server will continue where left off. When complete, the user has the file saved on their machine.
+The details of the actual data stream are complex, but the main point is the
+transaction workflow sets it up. After sending data, the server closes the data
+connection.
+
+**End-user experience:** The user selects a file and clicks “Download”.
+Immediately, an entry appears in their Transfers window. If the download starts
+immediately, it shows progress (the client now downloading from the server). If
+the server had too many concurrent downloads, the user might see a “Waiting in
+queue (position X)” status – Hotline clients show the queue position, thanks to
+the server’s Download Info (211) message which includes `Waiting count`. Once
+it’s their turn, the transfer begins. If the transfer is interrupted, the user
+can resume it later; the client will send the same 202 with a resume token and
+the server will continue where left off. When complete, the user has the file
+saved on their machine.
 
 ### Uploading a File (Transaction 203) – Client Initiates
 
-**ID 203 – Upload File** (`myTran_UploadFile`) handles sending a file from the client to the server. **Purpose:** Initiate an upload of a single file to the specified server folder. **Initiator:** Client.
+**ID 203 – Upload File** (`myTran_UploadFile`) handles sending a file from the
+client to the server. **Purpose:** Initiate an upload of a single file to the
+specified server folder. **Initiator:** Client.
 
-* **Parameters (Client→Server):** The client specifies the file name (field 201) and the destination path on the server (field 202). If the client is resuming an interrupted upload, it might include **File transfer options** (field 204) set to indicate resume (the spec notes it’s used to resume downloads, but in upload context it may be unused or set to a default). It also can provide the total file size upfront in field 108 (File transfer size) if not resuming. This helps the server know how much to expect.
-* **Response (Server→Client):** The server replies with a **Reference number** (field 107) to identify this transfer, and optionally **File resume data** (field 203) if the upload is to be resumed. The resume data would be used if an upload was partial; it tells the client where to continue. Often for fresh uploads, resume data is not sent, meaning start from scratch.
+- **Parameters (Client→Server):** The client specifies the file name (field 201)
+  and the destination path on the server (field 202). If the client is resuming
+  an interrupted upload, it might include **File transfer options** (field 204)
+  set to indicate resume (the spec notes it’s used to resume downloads, but in
+  upload context it may be unused or set to a default). It also can provide the
+  total file size upfront in field 108 (File transfer size) if not resuming.
+  This helps the server know how much to expect.
+- **Response (Server→Client):** The server replies with a **Reference number**
+  (field 107) to identify this transfer, and optionally **File resume data**
+  (field 203) if the upload is to be resumed. The resume data would be used if
+  an upload was partial; it tells the client where to continue. Often for fresh
+  uploads, resume data is not sent, meaning start from scratch.
 
-**Server behavior:** When an upload request arrives, the server checks privileges – the user must have *Upload File* rights for that folder. If allowed and if there’s space/quotas okay, the server will allocate a transfer slot. The reply gives a reference number like with downloads. Then the client is expected to open a new connection to the server’s upload port (which is the same as download port, base port+1, in non-HTTP mode). The client then sends the `'HTXF'` handshake with the reference and the total data size to send. After that, the client transmits the file data in the same “flattened file” format over that connection. The server receives the bytes and writes the file to the specified folder.
+**Server behavior:** When an upload request arrives, the server checks
+privileges – the user must have *Upload File* rights for that folder. If allowed
+and if there’s space/quotas okay, the server will allocate a transfer slot. The
+reply gives a reference number like with downloads. Then the client is expected
+to open a new connection to the server’s upload port (which is the same as
+download port, base port+1, in non-HTTP mode). The client then sends the
+`'HTXF'` handshake with the reference and the total data size to send. After
+that, the client transmits the file data in the same “flattened file” format
+over that connection. The server receives the bytes and writes the file to the
+specified folder.
 
-If the client had crashed and is resuming an upload, the server might have a partial file and it can provide resume info: typically, Hotline supported resuming of uploads, though it was less common. The `File resume data` field in the reply, if present, would tell the client from which point to continue. The client then would only send the missing portion, presumably after a negotiation on the data connection (similar to how folder download resumes are done with a small handshake, although specifics for upload resume aren’t detailed, likely simpler: it sends reference and offset).
+If the client had crashed and is resuming an upload, the server might have a
+partial file and it can provide resume info: typically, Hotline supported
+resuming of uploads, though it was less common. The `File resume data` field in
+the reply, if present, would tell the client from which point to continue. The
+client then would only send the missing portion, presumably after a negotiation
+on the data connection (similar to how folder download resumes are done with a
+small handshake, although specifics for upload resume aren’t detailed, likely
+simpler: it sends reference and offset).
 
-If upload slots are full, Hotline may queue the upload similar to downloads, but the protocol does not specify a distinct “Upload Info” transaction. Possibly the server could delay the reply until a slot frees or send an error indicating busy. More likely, it just limits per-user or total and the client has to try later.
+If upload slots are full, Hotline may queue the upload similar to downloads, but
+the protocol does not specify a distinct “Upload Info” transaction. Possibly the
+server could delay the reply until a slot frees or send an error indicating
+busy. More likely, it just limits per-user or total and the client has to try
+later.
 
-**End-user experience:** The user selects a file to upload (via the client’s interface, typically dragging a file into the server’s folder or using an “Upload” command). The upload appears in their Transfers window. If it starts, they see progress as data is sent. If the server was busy or they lacked permission, the client would show an error (e.g., “Upload not allowed” or “Server busy”). With appropriate permissions, the file will appear on the server (other users might see it pop up in the file list as soon as it’s done, or if the server lists incomplete uploads, maybe they see it appear mid-transfer but usually not until complete). If connection breaks, the user can resume the upload; the client will automatically try to resume when reinitiating, and the server will append the rest.
+**End-user experience:** The user selects a file to upload (via the client’s
+interface, typically dragging a file into the server’s folder or using an
+“Upload” command). The upload appears in their Transfers window. If it starts,
+they see progress as data is sent. If the server was busy or they lacked
+permission, the client would show an error (e.g., “Upload not allowed” or
+“Server busy”). With appropriate permissions, the file will appear on the server
+(other users might see it pop up in the file list as soon as it’s done, or if
+the server lists incomplete uploads, maybe they see it appear mid-transfer but
+usually not until complete). If connection breaks, the user can resume the
+upload; the client will automatically try to resume when reinitiating, and the
+server will append the rest.
 
 ### Deleting a File (Transaction 204) – Client Initiates
 
-**ID 204 – Delete File** (`myTran_DeleteFile`) is used to remove a file from the server’s filesystem. **Purpose:** Delete a specified file (or possibly an empty folder) on the server. **Initiator:** Client.
+**ID 204 – Delete File** (`myTran_DeleteFile`) is used to remove a file from the
+server’s filesystem. **Purpose:** Delete a specified file (or possibly an empty
+folder) on the server. **Initiator:** Client.
 
-* **Parameters:** The client provides the file name (field 201) and its path (field 202) to identify the item to delete.
-* **Response:** None (if successful, the server just does it; if failure, the server might send an error or simply not remove it).
+- **Parameters:** The client provides the file name (field 201) and its path
+  (field 202) to identify the item to delete.
+- **Response:** None (if successful, the server just does it; if failure, the
+  server might send an error or simply not remove it).
 
-**Server behavior:** The server checks that the user has the right to delete that item. There are separate privileges for deleting files and folders: *Delete File* (privilege 0) for files and *Delete Folder* (privilege 6) for folders. If the target is a file and the user has Delete File privilege in that folder (or globally), the server deletes it from disk. If it’s a folder, the user would need Delete Folder privilege and typically the folder must be empty (unless the server also deletes contents recursively, which it likely does not for safety). No reply is needed, but if an error occurs (like no permission or file not found), the server could send an Error (100) with a message or use a Server Message to inform the client.
+**Server behavior:** The server checks that the user has the right to delete
+that item. There are separate privileges for deleting files and folders: *Delete
+File* (privilege 0) for files and *Delete Folder* (privilege 6) for folders. If
+the target is a file and the user has Delete File privilege in that folder (or
+globally), the server deletes it from disk. If it’s a folder, the user would
+need Delete Folder privilege and typically the folder must be empty (unless the
+server also deletes contents recursively, which it likely does not for safety).
+No reply is needed, but if an error occurs (like no permission or file not
+found), the server could send an Error (100) with a message or use a Server
+Message to inform the client.
 
-**End-user experience:** The user triggers a delete (e.g., pressing delete key on a highlighted file or using a context menu). If they have permission, the file disappears from the file list on their client. Other users browsing that folder might also see it disappear (the client would refresh the file list). If the user lacked permission, they would get a notice “You are not allowed to delete that file” (likely the server sends an error text, which the client shows as a dialog or status message). If the file was successfully deleted, on most clients there’s no specific success message – it just is gone.
+**End-user experience:** The user triggers a delete (e.g., pressing delete key
+on a highlighted file or using a context menu). If they have permission, the
+file disappears from the file list on their client. Other users browsing that
+folder might also see it disappear (the client would refresh the file list). If
+the user lacked permission, they would get a notice “You are not allowed to
+delete that file” (likely the server sends an error text, which the client shows
+as a dialog or status message). If the file was successfully deleted, on most
+clients there’s no specific success message – it just is gone.
 
 ### Creating a New Folder (Transaction 205) – Client Initiates
 
-**ID 205 – New Folder** (`myTran_NewFolder`) lets a user create a new directory on the server. **Purpose:** Create a new folder in the specified directory. **Initiator:** Client.
+**ID 205 – New Folder** (`myTran_NewFolder`) lets a user create a new directory
+on the server. **Purpose:** Create a new folder in the specified directory.
+**Initiator:** Client.
 
-* **Parameters:** The client supplies the desired name for the new folder (field 201) and the path of where to create it (field 202) (if path is not given, maybe create in root, but typically you specify the parent folder).
-* **Response:** None (if creation succeeds, the server will likely send an update via the file list mechanism if needed).
+- **Parameters:** The client supplies the desired name for the new folder (field
+  201\) and the path of where to create it (field 202) (if path is not given,
+  maybe create in root, but typically you specify the parent folder).
+- **Response:** None (if creation succeeds, the server will likely send an
+  update via the file list mechanism if needed).
 
-**Server behavior:** The server checks the *Create Folder* privilege (privilege 5) for that location. If allowed, it creates the directory on the server’s filesystem. No direct reply is sent, but the client will usually follow up by listing the folder’s contents (or the parent folder’s contents). Often the client might automatically refresh the view by calling GetFileNameList again to show the new folder.
+**Server behavior:** The server checks the *Create Folder* privilege (privilege
+5\) for that location. If allowed, it creates the directory on the server’s
+filesystem. No direct reply is sent, but the client will usually follow up by
+listing the folder’s contents (or the parent folder’s contents). Often the
+client might automatically refresh the view by calling GetFileNameList again to
+show the new folder.
 
-**End-user experience:** The user hits “New Folder” in the client, enters a folder name. The new folder then appears in the file list if creation was successful. If they lacked rights, they’d see an error message. After creation, they can navigate into that folder or upload files to it.
+**End-user experience:** The user hits “New Folder” in the client, enters a
+folder name. The new folder then appears in the file list if creation was
+successful. If they lacked rights, they’d see an error message. After creation,
+they can navigate into that folder or upload files to it.
 
 ### Getting File/Folder Info (Transaction 206) – Client Initiates
 
-**ID 206 – Get File Info** (`myTran_GetFileInfo`) retrieves metadata about a file or folder. **Purpose:** To get detailed information such as file type, dates, comments, etc., usually for a “Get Info” dialog. **Initiator:** Client.
+**ID 206 – Get File Info** (`myTran_GetFileInfo`) retrieves metadata about a
+file or folder. **Purpose:** To get detailed information such as file type,
+dates, comments, etc., usually for a “Get Info” dialog. **Initiator:** Client.
 
-* **Parameters:** The client specifies the target file/folder name (field 201) and its path (field 202). The path is optional if it’s in current directory.
-* **Response:** The server replies with a set of fields describing the file/folder:
+- **Parameters:** The client specifies the target file/folder name (field 201)
+  and its path (field 202). The path is optional if it’s in current directory.
 
-  * **Name** (field 201) – the file name again (possibly to confirm or in case of any encoding),
-  * **File type string** (205) and **File creator string** (206) – these are 4-character codes used on classic Mac OS to identify file type/creator. They might be blank for non-Mac files.
-  * **File comment** (210) – a user-editable comment or description. Hotline allowed comments on files/folders (like a description visible to users).
-  * **File type** (213) – likely an integer or flag indicating file vs folder (or type code numeric).
-  * **Creation date** (208) and **Modification date** (209) – timestamps for the file.
-  * **File size** (207) – size in bytes (for a folder, size might be 0 or cumulative size if server calculates it).
+- **Response:** The server replies with a set of fields describing the
+  file/folder:
+
+  - **Name** (field 201) – the file name again (possibly to confirm or in case
+    of any encoding),
+  - **File type string** (205) and **File creator string** (206) – these are
+    4-character codes used on classic Mac OS to identify file type/creator. They
+    might be blank for non-Mac files.
+  - **File comment** (210) – a user-editable comment or description. Hotline
+    allowed comments on files/folders (like a description visible to users).
+  - **File type** (213) – likely an integer or flag indicating file vs folder
+    (or type code numeric).
+  - **Creation date** (208) and **Modification date** (209) – timestamps for the
+    file.
+  - **File size** (207) – size in bytes (for a folder, size might be 0 or
+    cumulative size if server calculates it).
 
   This info covers all basic properties.
 
-**Server behavior:** On GetFileInfo, the server reads the file’s metadata from the filesystem. For files, on Mac it might store type/creator codes and comments as extended attributes (Hotline servers on Windows might not have those, but protocol still sends blanks). Comments are stored in the server’s data (Hotline server maintains a database of comments for files/folders). The server checks if the user has rights to see info (possibly *Get File Info* privilege, which is likely general since all can usually get info – indeed there is privilege 24 “Get Client Info” but that’s for user info, not file; file info typically anyone can view if they can see the file). It then populates the reply fields and sends them.
+**Server behavior:** On GetFileInfo, the server reads the file’s metadata from
+the filesystem. For files, on Mac it might store type/creator codes and comments
+as extended attributes (Hotline servers on Windows might not have those, but
+protocol still sends blanks). Comments are stored in the server’s data (Hotline
+server maintains a database of comments for files/folders). The server checks if
+the user has rights to see info (possibly *Get File Info* privilege, which is
+likely general since all can usually get info – indeed there is privilege 24
+“Get Client Info” but that’s for user info, not file; file info typically anyone
+can view if they can see the file). It then populates the reply fields and sends
+them.
 
-**End-user experience:** The user selects a file and chooses “Get Info” (or right-click Properties). A dialog appears showing details: file name, size, type (perhaps showing the Mac type/creator or an icon for file type), creation and modification dates, and the “Comment” field. The comment is often editable if they have permission (in Hotline, file comments can be edited if you have appropriate rights). So they might see a description or be able to add one.
+**End-user experience:** The user selects a file and chooses “Get Info” (or
+right-click Properties). A dialog appears showing details: file name, size, type
+(perhaps showing the Mac type/creator or an icon for file type), creation and
+modification dates, and the “Comment” field. The comment is often editable if
+they have permission (in Hotline, file comments can be edited if you have
+appropriate rights). So they might see a description or be able to add one.
 
 ### Setting File/Folder Info (Transaction 207) – Client Initiates
 
-**ID 207 – Set File Info** (`myTran_SetFileInfo`) is used to change metadata of a file or folder, such as renaming it or editing its comment. **Purpose:** Modify file attributes on the server. **Initiator:** Client.
+**ID 207 – Set File Info** (`myTran_SetFileInfo`) is used to change metadata of
+a file or folder, such as renaming it or editing its comment. **Purpose:**
+Modify file attributes on the server. **Initiator:** Client.
 
-* **Parameters:** The client sends the target file’s current name (201) and path (202). It can include a new name (field 211 “File new name”) if renaming, and/or a new comment string (field 210) to set a comment/description. Either or both can be provided. (If the client only wants to edit the comment, it leaves new name blank; if only renaming, it leaves comment blank.)
-* **Response:** None (the server performs the change and doesn’t explicitly confirm except by the effects).
+- **Parameters:** The client sends the target file’s current name (201) and path
+  (202). It can include a new name (field 211 “File new name”) if renaming,
+  and/or a new comment string (field 210) to set a comment/description. Either
+  or both can be provided. (If the client only wants to edit the comment, it
+  leaves new name blank; if only renaming, it leaves comment blank.)
+- **Response:** None (the server performs the change and doesn’t explicitly
+  confirm except by the effects).
 
-**Server behavior:** The server checks privileges: to rename a file, the user likely needs *Rename File* privilege (priv 3) or *Rename Folder* (7) if it’s a folder; to set a comment, perhaps the same privilege or a specific one like *Set File Comment* (28) / *Set Folder Comment* (29). Indeed, the protocol notes access for SetFileInfo as requiring either Set File Comment or Set Folder Comment privilege (priv 28 or 29). If the user only has comment privilege but not rename, presumably they can change the comment but the server will ignore any new name field. Conversely, if they have rename rights but not comment, they can rename but not set comment. The server will apply the changes to the file system: if renaming, it changes the file/folder name. If updating comment, it stores the new comment in its database. The server does not send a direct reply, but it might internally trigger an update: for example, if a folder name changed, clients viewing the parent directory might need to refresh (the server might rely on the client to refresh manually or could broadcast a file list update via some mechanism, but Hotline protocol doesn’t have an explicit “file list changed” push except maybe through the same channel as file events for admin actions).
+**Server behavior:** The server checks privileges: to rename a file, the user
+likely needs *Rename File* privilege (priv 3) or *Rename Folder* (7) if it’s a
+folder; to set a comment, perhaps the same privilege or a specific one like *Set
+File Comment* (28) / *Set Folder Comment* (29). Indeed, the protocol notes
+access for SetFileInfo as requiring either Set File Comment or Set Folder
+Comment privilege (priv 28 or 29). If the user only has comment privilege but
+not rename, presumably they can change the comment but the server will ignore
+any new name field. Conversely, if they have rename rights but not comment, they
+can rename but not set comment. The server will apply the changes to the file
+system: if renaming, it changes the file/folder name. If updating comment, it
+stores the new comment in its database. The server does not send a direct reply,
+but it might internally trigger an update: for example, if a folder name
+changed, clients viewing the parent directory might need to refresh (the server
+might rely on the client to refresh manually or could broadcast a file list
+update via some mechanism, but Hotline protocol doesn’t have an explicit “file
+list changed” push except maybe through the same channel as file events for
+admin actions).
 
-**End-user experience:** If the user has permission, after they rename a file or edit its comment in the client’s Info dialog, the changes take effect. The file will show the new name in the list. Others browsing that directory might or might not see it update immediately — typically they would see it when they refresh or when they next open the folder (Hotline doesn’t actively push file list changes on renames, except the user who did it sees it immediately). If the user lacks rights to rename or comment, their attempt will result in an error or simply nothing happens. For instance, trying to rename a file without privilege might cause the client to pop up “You do not have permission to rename files.” If comment editing is not allowed, the comment field might be grayed out or the server might reject the SetFileInfo silently.
+**End-user experience:** If the user has permission, after they rename a file or
+edit its comment in the client’s Info dialog, the changes take effect. The file
+will show the new name in the list. Others browsing that directory might or
+might not see it update immediately — typically they would see it when they
+refresh or when they next open the folder (Hotline doesn’t actively push file
+list changes on renames, except the user who did it sees it immediately). If the
+user lacks rights to rename or comment, their attempt will result in an error or
+simply nothing happens. For instance, trying to rename a file without privilege
+might cause the client to pop up “You do not have permission to rename files.”
+If comment editing is not allowed, the comment field might be grayed out or the
+server might reject the SetFileInfo silently.
 
 ### Moving Files/Folders (Transaction 208) – Client Initiates
 
-**ID 208 – Move File** (`myTran_MoveFile`) is used to move or relocate a file/folder from one directory to another on the server. **Purpose:** Cut-paste a file or folder to a new location. **Initiator:** Client.
+**ID 208 – Move File** (`myTran_MoveFile`) is used to move or relocate a
+file/folder from one directory to another on the server. **Purpose:** Cut-paste
+a file or folder to a new location. **Initiator:** Client.
 
-* **Parameters:** The client specifies the item’s name (201) and current path (202), and the destination path (field 212 “File new path”). Essentially, “move \[this name] from \[old path] to \[new path]”.
-* **Response:** None.
+- **Parameters:** The client specifies the item’s name (201) and current path
+  (202), and the destination path (field 212 “File new path”). Essentially,
+  “move [this name] from [old path] to [new path]”.
+- **Response:** None.
 
-**Server behavior:** The server checks *Move File* privilege (priv 4) if it’s a file, or *Move Folder* (8) for folders. If allowed, the server will remove the item from the old directory and add it to the new directory (on the filesystem this is a rename operation or file system move). This includes adjusting any internal records (like comments might move with it; since it’s the same file just in a new place, it’s straightforward). If the destination has a file with the same name, the server might either overwrite (if allowed) or fail the move – the protocol doesn’t specify, but typically it might fail to avoid overwriting unless the user also has delete rights. The client is not explicitly told the result, but if successful, the file will disappear from the old folder listing and should appear in the new one.
+**Server behavior:** The server checks *Move File* privilege (priv 4) if it’s a
+file, or *Move Folder* (8) for folders. If allowed, the server will remove the
+item from the old directory and add it to the new directory (on the filesystem
+this is a rename operation or file system move). This includes adjusting any
+internal records (like comments might move with it; since it’s the same file
+just in a new place, it’s straightforward). If the destination has a file with
+the same name, the server might either overwrite (if allowed) or fail the move –
+the protocol doesn’t specify, but typically it might fail to avoid overwriting
+unless the user also has delete rights. The client is not explicitly told the
+result, but if successful, the file will disappear from the old folder listing
+and should appear in the new one.
 
-**End-user experience:** The user can drag and drop a file from one folder to another in the client interface. If they have permission, it will vanish from the source folder view and show up in the target folder view (the client likely issues a GetFileNameList on both source and destination to update them). If not permitted, the client will pop up a message or just snap the file back, indicating they can’t move it. Essentially it works like moving files in a file explorer.
+**End-user experience:** The user can drag and drop a file from one folder to
+another in the client interface. If they have permission, it will vanish from
+the source folder view and show up in the target folder view (the client likely
+issues a GetFileNameList on both source and destination to update them). If not
+permitted, the client will pop up a message or just snap the file back,
+indicating they can’t move it. Essentially it works like moving files in a file
+explorer.
 
 ### Creating an Alias (Shortcut) (Transaction 209) – Client Initiates
 
-**ID 209 – Make File Alias** (`myTran_MakeFileAlias`) creates an alias/shortcut of a file on the server. **Purpose:** To create a reference to an existing file in another folder (so one file can appear in two places). **Initiator:** Client.
+**ID 209 – Make File Alias** (`myTran_MakeFileAlias`) creates an alias/shortcut
+of a file on the server. **Purpose:** To create a reference to an existing file
+in another folder (so one file can appear in two places). **Initiator:** Client.
 
-* **Parameters:** The client specifies the source file name (201) and its current path (202), and a destination path where the alias should be created (212). The alias itself will typically have the same name or maybe a .alias extension depending on server, but the protocol doesn’t require a new name – it likely uses the same name in the new location.
-* **Response:** None.
+- **Parameters:** The client specifies the source file name (201) and its
+  current path (202), and a destination path where the alias should be created
+  (212). The alias itself will typically have the same name or maybe a .alias
+  extension depending on server, but the protocol doesn’t require a new name –
+  it likely uses the same name in the new location.
+- **Response:** None.
 
-**Server behavior:** The user needs *Make Alias* privilege (priv 31) to do this. The server will create an alias entry in the destination. On classic Mac HFS servers, this could literally be a Finder alias file. In cross-platform context, it might be a logical reference stored by the server. But from a Hotline perspective, it shows up as a file that, when downloaded, actually gives the original file’s content or points to it. The server likely treats an alias as a special file type that when accessed, redirects to the original. No direct feedback except the alias appears in listings.
+**Server behavior:** The user needs *Make Alias* privilege (priv 31) to do this.
+The server will create an alias entry in the destination. On classic Mac HFS
+servers, this could literally be a Finder alias file. In cross-platform context,
+it might be a logical reference stored by the server. But from a Hotline
+perspective, it shows up as a file that, when downloaded, actually gives the
+original file’s content or points to it. The server likely treats an alias as a
+special file type that when accessed, redirects to the original. No direct
+feedback except the alias appears in listings.
 
-**End-user experience:** The user might select “Make Alias” on a file, then choose a destination folder. The alias appears as a new item in the target folder, typically with an alias icon (a curved arrow or such). Other users see it too. If a user tries to download the alias, the server will serve the original file’s data (so it acts as a pointer). For the user who created it, they effectively made a shortcut so the file is accessible from multiple locations on the server (useful for organization). If permission lacked, they’d get an error.
+**End-user experience:** The user might select “Make Alias” on a file, then
+choose a destination folder. The alias appears as a new item in the target
+folder, typically with an alias icon (a curved arrow or such). Other users see
+it too. If a user tries to download the alias, the server will serve the
+original file’s data (so it acts as a pointer). For the user who created it,
+they effectively made a shortcut so the file is accessible from multiple
+locations on the server (useful for organization). If permission lacked, they’d
+get an error.
 
 ### Downloading an Entire Folder (Transaction 210) – Client Initiates
 
-**ID 210 – Download Folder** (`myTran_DownloadFldr`) allows a user to download a folder and all its contents in one go. **Purpose:** To retrieve a folder recursively (the server will bundle files and subfolders). **Initiator:** Client.
+**ID 210 – Download Folder** (`myTran_DownloadFldr`) allows a user to download a
+folder and all its contents in one go. **Purpose:** To retrieve a folder
+recursively (the server will bundle files and subfolders). **Initiator:**
+Client.
 
-* **Parameters:** The client specifies the folder name (201) and its path (202) to identify the folder to download.
-* **Response:** The server responds with:
+- **Parameters:** The client specifies the folder name (201) and its path (202)
+  to identify the folder to download.
 
-  * **Folder item count** (220) – how many items (files) are going to be transferred in total,
-  * **Reference number** (107) for this multi-file transfer,
-  * **Transfer size** (108) which is the total size in bytes of all files in the folder (and subfolders),
-  * **Waiting count** (116) if queued, similar concept to single file download.
+- **Response:** The server responds with:
 
-**Server behavior:** Downloading a folder is more complex. The server again checks *Download File* privilege (since it essentially is downloading multiple files). If allowed, and if not too many concurrent transfers, it sets up a reference number and calculates how many files and total bytes are involved in that folder (this can take time if folder is large; it likely counts up front). Then the client connects to the data port with the reference (just like a file transfer). The protocol then goes into a *folder download loop*:
+  - **Folder item count** (220) – how many items (files) are going to be
+    transferred in total,
+  - **Reference number** (107) for this multi-file transfer,
+  - **Transfer size** (108) which is the total size in bytes of all files in the
+    folder (and subfolders),
+  - **Waiting count** (116) if queued, similar concept to single file download.
 
-* The server will not just blast data, but rather coordinate file-by-file. As documented, once the data connection is open, the server sends a header indicating the next file’s path and type. The client then must respond with what action to take (next file, resume, or send file).
-* Essentially, for each file in the folder, the server says “I have file X ready” and the client says “send it” (or “skip/resume this one” if it had some of it). This is done with small control messages over the data connection: the **Download folder action** codes: `3` = proceed to next file, `2` = resume from offset, `1` = send file now.
-* The server then sends the file’s data (with size header). Then moves to next item.
-* This continues for all files (and likely subfolders are traversed; the server likely organizes them into some flat sequence with path info).
-* The folder’s directory structure is preserved by the path info each file’s header contains, so the client can reconstruct the hierarchy when saving.
+**Server behavior:** Downloading a folder is more complex. The server again
+checks *Download File* privilege (since it essentially is downloading multiple
+files). If allowed, and if not too many concurrent transfers, it sets up a
+reference number and calculates how many files and total bytes are involved in
+that folder (this can take time if folder is large; it likely counts up front).
+Then the client connects to the data port with the reference (just like a file
+transfer). The protocol then goes into a *folder download loop*:
 
-If at any point all download slots were busy, the initial response would have indicated a waiting count (like single file). The queue mechanism is similar. Resuming a folder download is also possible: the client can say “resume” for a particular file in the sequence if partially done.
+- The server will not just blast data, but rather coordinate file-by-file. As
+  documented, once the data connection is open, the server sends a header
+  indicating the next file’s path and type. The client then must respond with
+  what action to take (next file, resume, or send file).
+- Essentially, for each file in the folder, the server says “I have file X
+  ready” and the client says “send it” (or “skip/resume this one” if it had some
+  of it). This is done with small control messages over the data connection: the
+  **Download folder action** codes: `3` = proceed to next file, `2` = resume
+  from offset, `1` = send file now.
+- The server then sends the file’s data (with size header). Then moves to next
+  item.
+- This continues for all files (and likely subfolders are traversed; the server
+  likely organizes them into some flat sequence with path info).
+- The folder’s directory structure is preserved by the path info each file’s
+  header contains, so the client can reconstruct the hierarchy when saving.
 
-**End-user experience:** The user requests to download a folder (some clients allow dragging a folder to your computer or a “Download Folder” option). The client likely asks where to save this folder, then initiates the transaction. The experience is that multiple files start downloading as part of one job. The client might show a single aggregate progress bar for the whole folder, or it might show each file being downloaded sequentially. The user doesn’t have to manually download each file – it’s automated. If the folder is large, it could take a while; the user just sees progress. If interrupted, the client can later resume the folder download, and it will skip files already done. This is very convenient for batch transfers (like grabbing an entire directory of files at once).
+If at any point all download slots were busy, the initial response would have
+indicated a waiting count (like single file). The queue mechanism is similar.
+Resuming a folder download is also possible: the client can say “resume” for a
+particular file in the sequence if partially done.
+
+**End-user experience:** The user requests to download a folder (some clients
+allow dragging a folder to your computer or a “Download Folder” option). The
+client likely asks where to save this folder, then initiates the transaction.
+The experience is that multiple files start downloading as part of one job. The
+client might show a single aggregate progress bar for the whole folder, or it
+might show each file being downloaded sequentially. The user doesn’t have to
+manually download each file – it’s automated. If the folder is large, it could
+take a while; the user just sees progress. If interrupted, the client can later
+resume the folder download, and it will skip files already done. This is very
+convenient for batch transfers (like grabbing an entire directory of files at
+once).
 
 ### Uploading an Entire Folder (Transaction 213) – Client Initiates
 
-**ID 213 – Upload Folder** (`myTran_UploadFldr`) allows uploading a folder (with subfolders) to the server in one operation. **Purpose:** Send multiple files (and directory structure) to the server. **Initiator:** Client.
+**ID 213 – Upload Folder** (`myTran_UploadFldr`) allows uploading a folder (with
+subfolders) to the server in one operation. **Purpose:** Send multiple files
+(and directory structure) to the server. **Initiator:** Client.
 
-* **Parameters:** The client specifies the folder name it’s uploading as (201) and the destination path on server (202). It also sends the total size of all files in the folder (field 108) and the count of items (files) in the folder (220). `File transfer options` (204) may be present (set to 1 as per spec, possibly indicating “folder upload” mode).
-* **Response:** The server returns a Reference number (107) for the transfer. No need to send resume data here (if resuming, likely handled in-band).
+- **Parameters:** The client specifies the folder name it’s uploading as (201)
+  and the destination path on server (202). It also sends the total size of all
+  files in the folder (field 108) and the count of items (files) in the folder
+  (220). `File transfer options` (204) may be present (set to 1 as per spec,
+  possibly indicating “folder upload” mode).
+- **Response:** The server returns a Reference number (107) for the transfer. No
+  need to send resume data here (if resuming, likely handled in-band).
 
-**Server behavior:** Privilege required is *Upload File* (1) since it’s essentially many file uploads. After the handshake, the client connects to the data port (as usual). The protocol for folder upload is essentially the inverse of folder download: the client will send files one by one, with headers indicating path, etc., and the server will respond with small control codes to request next file, confirm receipt, or to handle resumes. The documentation suggests the server can reply with a **Download folder action** code `3` (Next file) to prompt the client to send the next item, or `2` to request resume data if needed. The client then proceeds to send each file’s flattened data preceded by a header (with path info). This continues until all files are sent.
+**Server behavior:** Privilege required is *Upload File* (1) since it’s
+essentially many file uploads. After the handshake, the client connects to the
+data port (as usual). The protocol for folder upload is essentially the inverse
+of folder download: the client will send files one by one, with headers
+indicating path, etc., and the server will respond with small control codes to
+request next file, confirm receipt, or to handle resumes. The documentation
+suggests the server can reply with a **Download folder action** code `3` (Next
+file) to prompt the client to send the next item, or `2` to request resume data
+if needed. The client then proceeds to send each file’s flattened data preceded
+by a header (with path info). This continues until all files are sent.
 
-Essentially, the server is reconstructing the folder on its side. It creates the root folder (with the name given in 201) in the destination path, then as each file entry comes in, it creates files and subdirectories accordingly.
+Essentially, the server is reconstructing the folder on its side. It creates the
+root folder (with the name given in 201) in the destination path, then as each
+file entry comes in, it creates files and subdirectories accordingly.
 
-If an error occurs mid-way (network drop), the server may have partial data; resuming would involve the server telling the client which files were received and which to continue. But implementing resume for multi-file upload is complex; not sure if the official client supported it heavily. The protocol has provisions though (resume codes).
+If an error occurs mid-way (network drop), the server may have partial data;
+resuming would involve the server telling the client which files were received
+and which to continue. But implementing resume for multi-file upload is complex;
+not sure if the official client supported it heavily. The protocol has
+provisions though (resume codes).
 
-**End-user experience:** The user uploads a folder (some clients allow dragging a folder onto the server). The client will enumerate all files and maybe compress them or just send structure. Typically, the user sees one composite progress or a sequence of uploads happening automatically. On the server, the folder with all its files appears. If they lack permission, none of it will start (and they’ll get an error). If partially through the connection breaks, some files might have uploaded; the user may need to re-upload the folder, which might skip already uploaded files (depending on client sophistication). The experience is akin to an FTP folder upload – the structure is preserved.
+**End-user experience:** The user uploads a folder (some clients allow dragging
+a folder onto the server). The client will enumerate all files and maybe
+compress them or just send structure. Typically, the user sees one composite
+progress or a sequence of uploads happening automatically. On the server, the
+folder with all its files appears. If they lack permission, none of it will
+start (and they’ll get an error). If partially through the connection breaks,
+some files might have uploaded; the user may need to re-upload the folder, which
+might skip already uploaded files (depending on client sophistication). The
+experience is akin to an FTP folder upload – the structure is preserved.
 
 ### Banner Download (Transaction 212) – Client Initiates
 
-**ID 212 – Download Banner** (`myTran_DownloadBanner`) is a special-case transaction to fetch the server’s banner image via the file transfer port. **Purpose:** Retrieve the server’s banner graphic (if the server uses an image banner instead of a URL). **Initiator:** Client.
+**ID 212 – Download Banner** (`myTran_DownloadBanner`) is a special-case
+transaction to fetch the server’s banner image via the file transfer port.
+**Purpose:** Retrieve the server’s banner graphic (if the server uses an image
+banner instead of a URL). **Initiator:** Client.
 
-* **Parameters:** None in the request. The client just says “give me the banner now.”
-* **Response:** The server replies with a Reference number (107) and Transfer size (108) for the banner data.
+- **Parameters:** None in the request. The client just says “give me the banner
+  now.”
+- **Response:** The server replies with a Reference number (107) and Transfer
+  size (108) for the banner data.
 
-**When/Why:** This occurs typically right after login. In the login sequence, the server’s Show Agreement (109) message would have told the client if a banner image is available by providing a Banner ID and possibly by setting banner type to something like JPEG/GIF and not providing a URL. In that case, the client knows it must perform DownloadBanner to actually get the image bytes to display. Alternatively, if the banner type was URL, the client would just fetch from that URL instead.
+**When/Why:** This occurs typically right after login. In the login sequence,
+the server’s Show Agreement (109) message would have told the client if a banner
+image is available by providing a Banner ID and possibly by setting banner type
+to something like JPEG/GIF and not providing a URL. In that case, the client
+knows it must perform DownloadBanner to actually get the image bytes to display.
+Alternatively, if the banner type was URL, the client would just fetch from that
+URL instead.
 
-**Server behavior:** On DownloadBanner request, the server essentially treats the banner file like a normal file transfer. It might have the banner image stored on disk. It gives a reference and size, and then the client opens a data connection (port+1) with the reference. The server sends the banner image data over that connection (the Type field in the handshake is `2` meaning banner, as the snippet suggests). The client receives it and displays it.
+**Server behavior:** On DownloadBanner request, the server essentially treats
+the banner file like a normal file transfer. It might have the banner image
+stored on disk. It gives a reference and size, and then the client opens a data
+connection (port+1) with the reference. The server sends the banner image data
+over that connection (the Type field in the handshake is `2` meaning banner, as
+the snippet suggests). The client receives it and displays it.
 
-**End-user experience:** The user doesn’t explicitly do this; it’s automatic after login. They might notice a small delay and then a banner image (maybe an advertisement or server logo) appears in the client’s banner area. If the server uses an external URL banner, the client loads it from the internet directly. If an image was provided via this transaction, the effect is the same: a banner is shown. If the user has banners disabled or none exists, nothing is fetched/shown.
+**End-user experience:** The user doesn’t explicitly do this; it’s automatic
+after login. They might notice a small delay and then a banner image (maybe an
+advertisement or server logo) appears in the client’s banner area. If the server
+uses an external URL banner, the client loads it from the internet directly. If
+an image was provided via this transaction, the effect is the same: a banner is
+shown. If the user has banners disabled or none exists, nothing is
+fetched/shown.
 
 ## News (Bulletin Board System)
 
-Hotline servers include a “News” or bulletin board system where users can read and post articles organized into bundles and categories (similar to forums or newsgroups). In Hotline 1.8.5, the news system is hierarchical: **Bundles** (top-level groupings, sometimes called “news folders”), containing **Categories**, which can contain sub-categories or posts (articles). Each article can have replies (forming threads). The protocol provides transactions to navigate and manipulate this structure. (Note: older clients had a simpler “messages” board, but 1.8.x uses the advanced news; we include the old **Old Post News (103)** for legacy completeness.)
+Hotline servers include a “News” or bulletin board system where users can read
+and post articles organized into bundles and categories (similar to forums or
+newsgroups). In Hotline 1.8.5, the news system is hierarchical: **Bundles**
+(top-level groupings, sometimes called “news folders”), containing
+**Categories**, which can contain sub-categories or posts (articles). Each
+article can have replies (forming threads). The protocol provides transactions
+to navigate and manipulate this structure. (Note: older clients had a simpler
+“messages” board, but 1.8.x uses the advanced news; we include the old **Old
+Post News (103)** for legacy completeness.)
 
 ### News Hierarchy
 
-Hotline implements its news as a four-tier hierarchy similar to a modern forum. At the top are **bundles**, each identified by a path on the server. Inside a bundle are **categories** that further divide the discussion. Users post **articles** within a category, and each article may have **replies** forming a threaded conversation. Articles expose metadata such as ID, title, poster, date and data flavour (typically `"text/plain"` but extensible to formats like `"text/markdown"`), plus the article body. Replies carry the same data fields and additionally track the parent and first child article IDs to maintain the thread structure.
+Hotline implements its news as a four-tier hierarchy similar to a modern forum.
+At the top are **bundles**, each identified by a path on the server. Inside a
+bundle are **categories** that further divide the discussion. Users post
+**articles** within a category, and each article may have **replies** forming a
+threaded conversation. Articles expose metadata such as ID, title, poster, date
+and data flavour (typically `"text/plain"` but extensible to formats like
+`"text/markdown"`), plus the article body. Replies carry the same data fields
+and additionally track the parent and first child article IDs to maintain the
+thread structure.
 
 ### Listing News Categories (Transaction 370) – Client Initiates
 
-**ID 370 – Get News Category Name List** (`myTran_GetNewsCatNameList`) is used to retrieve the list of sub-categories (or top-level bundles) at a given news path. **Purpose:** To list news groups or categories within a bundle. **Initiator:** Client.
+**ID 370 – Get News Category Name List** (`myTran_GetNewsCatNameList`) is used
+to retrieve the list of sub-categories (or top-level bundles) at a given news
+path. **Purpose:** To list news groups or categories within a bundle.
+**Initiator:** Client.
 
-* **Parameters:** The client can specify a **News path** (field 325) indicating which part of the news hierarchy to list. If this is omitted, the server might return the top-level bundles. The news path is a structured reference (like “/” for root, or a bundle/category identifier).
-* **Response:** The server replies with one or more **News category list data** entries (field 323, repeated). Each entry represents a bundle or category name (and possibly some encoded info like number of posts, etc., depending on implementation). Essentially, this is the list of category names at that level.
+- **Parameters:** The client can specify a **News path** (field 325) indicating
+  which part of the news hierarchy to list. If this is omitted, the server might
+  return the top-level bundles. The news path is a structured reference (like
+  “/” for root, or a bundle/category identifier).
 
-  *Compatibility:* The protocol notes that if the client/server version is older than 1.5, it would use field 320 instead of 323 for these entries (so field 320 was the old identifier for category list data). But in 1.8.5 we use 323.
+- **Response:** The server replies with one or more **News category list data**
+  entries (field 323, repeated). Each entry represents a bundle or category name
+  (and possibly some encoded info like number of posts, etc., depending on
+  implementation). Essentially, this is the list of category names at that
+  level.
 
-**Server behavior:** The server, upon request, looks at the specified path in the news database:
+  *Compatibility:* The protocol notes that if the client/server version is older
+  than 1.5, it would use field 320 instead of 323 for these entries (so field
+  320 was the old identifier for category list data). But in 1.8.5 we use 323.
 
-* If the path is root or a bundle, it finds all immediate sub-categories (which could be bundles or actual categories containing articles, depending on level) and sends their names. For top-level, these entries are “Bundles” (top-level news groupings). Each entry likely includes the category’s name and maybe an ID or flag in the binary data, but from the client perspective just a name. The server sends them all.
-* The server might require *News Read Article* privilege (priv 20) to access news at all, but typically reading news is allowed for all logged-in users by default.
-* If no path given, return top-level bundles. If a path to a specific bundle, return its categories.
+**Server behavior:** The server, upon request, looks at the specified path in
+the news database:
 
-**End-user experience:** When the user goes to the News section in the client, the client will first fetch the top-level list (by calling GetNewsCatNameList with no path). The user then sees a list of news bundles (for example, “Announcements”, “Discussion Board”, etc.). These appear kind of like folders. If the user clicks a bundle to expand it, the client calls GetNewsCatNameList with that bundle’s path, and then receives the categories inside (say, “Rules”, “Q\&A” categories, etc.), which then display. The user navigates these like directories to find posts.
+- If the path is root or a bundle, it finds all immediate sub-categories (which
+  could be bundles or actual categories containing articles, depending on level)
+  and sends their names. For top-level, these entries are “Bundles” (top-level
+  news groupings). Each entry likely includes the category’s name and maybe an
+  ID or flag in the binary data, but from the client perspective just a name.
+  The server sends them all.
+- The server might require *News Read Article* privilege (priv 20) to access
+  news at all, but typically reading news is allowed for all logged-in users by
+  default.
+- If no path given, return top-level bundles. If a path to a specific bundle,
+  return its categories.
+
+**End-user experience:** When the user goes to the News section in the client,
+the client will first fetch the top-level list (by calling GetNewsCatNameList
+with no path). The user then sees a list of news bundles (for example,
+“Announcements”, “Discussion Board”, etc.). These appear kind of like folders.
+If the user clicks a bundle to expand it, the client calls GetNewsCatNameList
+with that bundle’s path, and then receives the categories inside (say, “Rules”,
+“Q&A” categories, etc.), which then display. The user navigates these like
+directories to find posts.
 
 ### Listing News Articles (Transaction 371) – Client Initiates
 
-**ID 371 – Get News Article Name List** (`myTran_GetNewsArtNameList`) retrieves the list of article titles under a given news category. **Purpose:** To list the actual posts/articles (and possibly sub-threads) in a category. **Initiator:** Client.
+**ID 371 – Get News Article Name List** (`myTran_GetNewsArtNameList`) retrieves
+the list of article titles under a given news category. **Purpose:** To list the
+actual posts/articles (and possibly sub-threads) in a category. **Initiator:**
+Client.
 
-* **Parameters:** The client sends the News path (325) identifying which category (or sub-category) it wants the article list for.
-* **Response:** The server replies with one or more **News article list data** entries (field 321, repeated). Each entry corresponds to an article (post) title in that category. It likely includes the article’s title and some identifier (like an ID and maybe author or date snippet). The client will typically display the list of post titles.
+- **Parameters:** The client sends the News path (325) identifying which
+  category (or sub-category) it wants the article list for.
+- **Response:** The server replies with one or more **News article list data**
+  entries (field 321, repeated). Each entry corresponds to an article (post)
+  title in that category. It likely includes the article’s title and some
+  identifier (like an ID and maybe author or date snippet). The client will
+  typically display the list of post titles.
 
-**Server behavior:** The server looks up all articles in the specified category (if the category has sub-categories, the client would use 370 for those; 371 is specifically used when reaching a level where actual articles exist). It then sends each article’s info. This probably includes an article ID internally, which the client will use to fetch the full content later (the protocol suggests that field 321 contains necessary data, possibly including the article’s subject and an ID). The server requires *News Read Article* privilege (priv 20) to read posts, which if the user lacks, might return nothing or error.
+**Server behavior:** The server looks up all articles in the specified category
+(if the category has sub-categories, the client would use 370 for those; 371 is
+specifically used when reaching a level where actual articles exist). It then
+sends each article’s info. This probably includes an article ID internally,
+which the client will use to fetch the full content later (the protocol suggests
+that field 321 contains necessary data, possibly including the article’s subject
+and an ID). The server requires *News Read Article* privilege (priv 20) to read
+posts, which if the user lacks, might return nothing or error.
 
-**End-user experience:** When the user opens a news category (for example “Announcements”), the client requests the list of articles there. The user then sees a list of post titles, possibly with some indicator (unread/read). They can select a post to read it. If the category had sub-categories instead of articles, the client would have used 370 again rather than 371, so 371 results indicate that this is actually a list of posts (the final level of browsing).
+**End-user experience:** When the user opens a news category (for example
+“Announcements”), the client requests the list of articles there. The user then
+sees a list of post titles, possibly with some indicator (unread/read). They can
+select a post to read it. If the category had sub-categories instead of
+articles, the client would have used 370 again rather than 371, so 371 results
+indicate that this is actually a list of posts (the final level of browsing).
 
 ### Reading a News Article (Transaction 400) – Client Initiates
 
-**ID 400 – Get News Article Data** (`myTran_GetNewsArtData`) is used to retrieve the full content of a specific news article (post). **Purpose:** Download the text (and metadata) of a news article so it can be read. **Initiator:** Client.
+**ID 400 – Get News Article Data** (`myTran_GetNewsArtData`) is used to retrieve
+the full content of a specific news article (post). **Purpose:** Download the
+text (and metadata) of a news article so it can be read. **Initiator:** Client.
 
-* **Parameters:** The client specifies the category path (field 325) where the article resides, the Article ID (field 326) of the desired post, and a **Data flavor** (field 327) indicating what format of the article it wants. In Hotline, the data flavor is typically `"text/plain"` (meaning we want the text content). The Article ID is an identifier the server assigns to each post (likely gotten from the list data).
-* **Response:** The server replies with the article’s details:
+- **Parameters:** The client specifies the category path (field 325) where the
+  article resides, the Article ID (field 326) of the desired post, and a **Data
+  flavor** (field 327) indicating what format of the article it wants. In
+  Hotline, the data flavor is typically `"text/plain"` (meaning we want the text
+  content). The Article ID is an identifier the server assigns to each post
+  (likely gotten from the list data).
 
-  * **Title** (328) – the article’s title string.
-  * **Poster** (329) – the username of who posted it.
-  * **Date** (330) – the date/time it was posted.
-  * **Previous article ID** (331) and **Next article ID** (332) – references to navigate threads (the previous and next article at the same level).
-  * **Parent article ID** (335) and **First child article ID** (336) – references for threading (i.e., if this post is a reply, parent ID points to the post it replied to; first child ID points to the first reply to this post, if any).
-  * **Data flavor** (327) echoing what is provided (should be `"text/plain"`).
-  * **Article data** (333) – the actual content of the article, i.e., the body text. This field is optional in case the flavor is not text, but in our case it will contain the post’s text.
+- **Response:** The server replies with the article’s details:
 
-**Server behavior:** On request, the server loads the specified article from its database. It ensures the user can read it (*News Read Article* priv required, as above). It then sends all the metadata and the content. If the content is plain text, it’s all in field 333. If there were other flavors (like attachments or HTML), the protocol could handle but currently it’s plain text only and others are ignored. The article IDs (previous/next/parent/child) allow the client to implement “threaded” reading (like next/prev buttons or hierarchical view).
+  - **Title** (328) – the article’s title string.
+  - **Poster** (329) – the username of who posted it.
+  - **Date** (330) – the date/time it was posted.
+  - **Previous article ID** (331) and **Next article ID** (332) – references to
+    navigate threads (the previous and next article at the same level).
+  - **Parent article ID** (335) and **First child article ID** (336) –
+    references for threading (i.e., if this post is a reply, parent ID points to
+    the post it replied to; first child ID points to the first reply to this
+    post, if any).
+  - **Data flavor** (327) echoing what is provided (should be `"text/plain"`).
+  - **Article data** (333) – the actual content of the article, i.e., the body
+    text. This field is optional in case the flavor is not text, but in our case
+    it will contain the post’s text.
 
-**End-user experience:** The user selects a post from the list. The content of that post is then displayed in the client’s news reader pane: they see the title, author, date, and the body text. The client might also provide buttons to go to next or previous posts (which use the IDs provided) or to go “up” to the list again. If the post is part of a threaded conversation, the client might allow viewing replies (it could automatically fetch the first child, etc., or just list replies as separate articles under the same category if the server organizes them that way – implementations vary). The key is the user can now read the full text of the article.
+**Server behavior:** On request, the server loads the specified article from its
+database. It ensures the user can read it (*News Read Article* priv required, as
+above). It then sends all the metadata and the content. If the content is plain
+text, it’s all in field 333. If there were other flavors (like attachments or
+HTML), the protocol could handle but currently it’s plain text only and others
+are ignored. The article IDs (previous/next/parent/child) allow the client to
+implement “threaded” reading (like next/prev buttons or hierarchical view).
+
+**End-user experience:** The user selects a post from the list. The content of
+that post is then displayed in the client’s news reader pane: they see the
+title, author, date, and the body text. The client might also provide buttons to
+go to next or previous posts (which use the IDs provided) or to go “up” to the
+list again. If the post is part of a threaded conversation, the client might
+allow viewing replies (it could automatically fetch the first child, etc., or
+just list replies as separate articles under the same category if the server
+organizes them that way – implementations vary). The key is the user can now
+read the full text of the article.
 
 ### Posting a News Article (Transaction 410) – Client Initiates
 
-**ID 410 – Post News Article** (`myTran_PostNewsArt`) is used when a user submits a new post (either a new thread or a reply) to the server’s news system. **Purpose:** To create a new article in a given category (or as a reply to an existing article). **Initiator:** Client.
+**ID 410 – Post News Article** (`myTran_PostNewsArt`) is used when a user
+submits a new post (either a new thread or a reply) to the server’s news system.
+**Purpose:** To create a new article in a given category (or as a reply to an
+existing article). **Initiator:** Client.
 
-* **Parameters:** The client sends:
+- **Parameters:** The client sends:
 
-  * The category path where to post (325).
-  * An Article ID (326) that represents the parent article if this is a reply (the spec notes “ID of the parent article?”). If this is a new thread (posting at top of category), this might be 0 or omitted.
-  * The article’s title (328).
-  * Article flags (334) – possibly indicating if the post is locked, or announcement type, etc. Typically 0 for normal posts.
-  * Data flavor (327) – usually `"text/plain"` indicating the content is plain text.
-  * The article content (333) – the body text of the post.
+  - The category path where to post (325).
+  - An Article ID (326) that represents the parent article if this is a reply
+    (the spec notes “ID of the parent article?”). If this is a new thread
+    (posting at top of category), this might be 0 or omitted.
+  - The article’s title (328).
+  - Article flags (334) – possibly indicating if the post is locked, or
+    announcement type, etc. Typically 0 for normal posts.
+  - Data flavor (327) – usually `"text/plain"` indicating the content is plain
+    text.
+  - The article content (333) – the body text of the post.
 
-* **Response:** None (the server either accepts and will notify others, or returns an error if something’s wrong).
+- **Response:** None (the server either accepts and will notify others, or
+  returns an error if something’s wrong).
 
-**Server behavior:** The server checks *News Post Article* privilege (priv 21) to see if the user can post in that category. If allowed, it creates the new article entry in its database. It assigns a new Article ID to it. The parent ID provided tells it if it’s a reply (if so, it will link the new post under the parent’s thread). The server sets any flags (maybe not used much; possibly for admin posts). Since there’s no direct reply, the client doesn’t automatically get the new post’s ID from this transaction. Instead, the server will make it visible to clients in that category on next refresh. In some implementations, the server might immediately push a **New Message (102)** or some notification to alert clients of the new post, but Hotline’s approach is often that clients periodically refresh or the user will see it upon next check. The protocol does define **New Message (102)** which could serve as “server pushes new news post”, but it’s not clearly documented if 1.8.5 uses it for news. Many clients simply refresh the list after posting.
+**Server behavior:** The server checks *News Post Article* privilege (priv 21)
+to see if the user can post in that category. If allowed, it creates the new
+article entry in its database. It assigns a new Article ID to it. The parent ID
+provided tells it if it’s a reply (if so, it will link the new post under the
+parent’s thread). The server sets any flags (maybe not used much; possibly for
+admin posts). Since there’s no direct reply, the client doesn’t automatically
+get the new post’s ID from this transaction. Instead, the server will make it
+visible to clients in that category on next refresh. In some implementations,
+the server might immediately push a **New Message (102)** or some notification
+to alert clients of the new post, but Hotline’s approach is often that clients
+periodically refresh or the user will see it upon next check. The protocol does
+define **New Message (102)** which could serve as “server pushes new news post”,
+but it’s not clearly documented if 1.8.5 uses it for news. Many clients simply
+refresh the list after posting.
 
-**End-user experience:** The user writes a post via the client’s interface (usually a text editor that pops up when you choose “Post News” or “Reply”). Upon sending, if successful, their post appears in the category. Often the client will refresh the article list, so the user sees their new post title in the list of articles. Others currently viewing that category might have to refresh manually or might also automatically see the new title pop in (some clients auto-refresh every few seconds or when a new post transaction is detected). If the user lacked permission to post (like a read-only forum), the client would show an error message like “You do not have permission to post in this category” (the server would have denied the transaction, possibly via an error code). With success, the article is now stored, and other users can read it.
+**End-user experience:** The user writes a post via the client’s interface
+(usually a text editor that pops up when you choose “Post News” or “Reply”).
+Upon sending, if successful, their post appears in the category. Often the
+client will refresh the article list, so the user sees their new post title in
+the list of articles. Others currently viewing that category might have to
+refresh manually or might also automatically see the new title pop in (some
+clients auto-refresh every few seconds or when a new post transaction is
+detected). If the user lacked permission to post (like a read-only forum), the
+client would show an error message like “You do not have permission to post in
+this category” (the server would have denied the transaction, possibly via an
+error code). With success, the article is now stored, and other users can read
+it.
 
 ### Deleting a News Article (Transaction 411) – Client Initiates
 
-**ID 411 – Delete News Article** (`myTran_DelNewsArt`) is used to remove a specific article (or thread) from the news board. **Purpose:** Delete a news post. **Initiator:** Client.
+**ID 411 – Delete News Article** (`myTran_DelNewsArt`) is used to remove a
+specific article (or thread) from the news board. **Purpose:** Delete a news
+post. **Initiator:** Client.
 
-* **Parameters:** The client provides the category path (325) and the Article ID (326) of the post to delete. There is also a flag (337, “News article – recursive delete”) indicating whether to delete child articles (replies) as well. This flag is 1 for deleting the post and all its replies (the entire thread), or 0 to delete just the single article (if 0, and there are replies, those might become orphan or perhaps the server disallows non-recursive deletion if replies exist).
-* **Response:** None (server performs deletion).
+- **Parameters:** The client provides the category path (325) and the Article ID
+  (326) of the post to delete. There is also a flag (337, “News article –
+  recursive delete”) indicating whether to delete child articles (replies) as
+  well. This flag is 1 for deleting the post and all its replies (the entire
+  thread), or 0 to delete just the single article (if 0, and there are replies,
+  those might become orphan or perhaps the server disallows non-recursive
+  deletion if replies exist).
+- **Response:** None (server performs deletion).
 
-**Server behavior:** The server checks *News Delete Article* privilege (priv 33). Typically only admins or moderators have this. If allowed, and if the article exists, the server will remove it. If recursive flag is 1, it deletes all replies recursively. If 0 and replies exist, the behavior might be to only delete that post’s content (maybe leaving a placeholder saying removed), or it might refuse unless no replies. The protocol allows specifying it, so presumably if 0 and thread has children, it might just delete that one and leave children as orphan (maybe shifting them up under the parent’s parent). The server likely also updates indexes, etc.
+**Server behavior:** The server checks *News Delete Article* privilege (priv
+33). Typically only admins or moderators have this. If allowed, and if the
+article exists, the server will remove it. If recursive flag is 1, it deletes
+all replies recursively. If 0 and replies exist, the behavior might be to only
+delete that post’s content (maybe leaving a placeholder saying removed), or it
+might refuse unless no replies. The protocol allows specifying it, so presumably
+if 0 and thread has children, it might just delete that one and leave children
+as orphan (maybe shifting them up under the parent’s parent). The server likely
+also updates indexes, etc.
 
-There’s no specific “notification” to other users that a post was deleted except that it will disappear from the list. The server might not push that info; clients might find out on next refresh or if they attempt to read it and get an error. Possibly an admin delete could be accompanied by a broadcast or not.
+There’s no specific “notification” to other users that a post was deleted except
+that it will disappear from the list. The server might not push that info;
+clients might find out on next refresh or if they attempt to read it and get an
+error. Possibly an admin delete could be accompanied by a broadcast or not.
 
-**End-user experience:** Only authorized users (admin or moderator) can delete posts. If a user deletes their own post (if the server allowed that – often not unless they have privilege or maybe the server allows authors to remove their own within some timeframe), the post will vanish from the category listing. If others have the list open, they might not see it gone until refresh. If someone tries to read a deleted post, they might get “Article not found” error if not refreshed. So essentially, the post and its replies (if chosen) are gone as if they never were there. Users might just notice that something disappeared. There is no “undo” – it’s a permanent removal from the server’s perspective.
+**End-user experience:** Only authorized users (admin or moderator) can delete
+posts. If a user deletes their own post (if the server allowed that – often not
+unless they have privilege or maybe the server allows authors to remove their
+own within some timeframe), the post will vanish from the category listing. If
+others have the list open, they might not see it gone until refresh. If someone
+tries to read a deleted post, they might get “Article not found” error if not
+refreshed. So essentially, the post and its replies (if chosen) are gone as if
+they never were there. Users might just notice that something disappeared. There
+is no “undo” – it’s a permanent removal from the server’s perspective.
 
 ### Managing News Structure (Transactions 380, 381, 382) – Client Initiates (Admin/Mods)
 
-These transactions let privileged users manage the news hierarchy (creating or deleting bundles/categories):
+These transactions let privileged users manage the news hierarchy (creating or
+deleting bundles/categories):
 
-* **ID 381 – New News Folder** (`myTran_NewNewsFldr`) is for creating a new **News Bundle** (top-level folder). **Purpose:** Create a new bundle in the news system. **Initiator:** Client (admin). Requires privilege *News Create Folder* (priv 36).
+- **ID 381 – New News Folder** (`myTran_NewNewsFldr`) is for creating a new
+  **News Bundle** (top-level folder). **Purpose:** Create a new bundle in the
+  news system. **Initiator:** Client (admin). Requires privilege *News Create
+  Folder* (priv 36).
 
-  * **Parameters:** The client sends a name for the new bundle (201) and the news path (325) under which to create it. For a top-level bundle, the path might be empty or some root reference.
-  * **Response:** None.
+  - **Parameters:** The client sends a name for the new bundle (201) and the
+    news path (325) under which to create it. For a top-level bundle, the path
+    might be empty or some root reference.
+  - **Response:** None.
 
-  **Effect:** The server creates a new bundle (a container that can hold categories). In practice, top-level news bundles might just be created at root (so path blank, name provided). If path is given (like specifying an existing bundle), it might create a sub-bundle, but typically there are only two levels: bundles and categories. The user who created it (admin) and others will see this new bundle appear in the news list (probably next time they refresh or maybe immediately if the client refreshes on creation).
+  **Effect:** The server creates a new bundle (a container that can hold
+  categories). In practice, top-level news bundles might just be created at root
+  (so path blank, name provided). If path is given (like specifying an existing
+  bundle), it might create a sub-bundle, but typically there are only two
+  levels: bundles and categories. The user who created it (admin) and others
+  will see this new bundle appear in the news list (probably next time they
+  refresh or maybe immediately if the client refreshes on creation).
 
-  **End-user experience:** The admin uses an option “Create Bundle” in their client (which might be enabled for admins). They name the new bundle. Users will see a new top-level entry in the news section by that name, which can then be expanded (initially empty). If normal users are not allowed to create bundles, they won’t have that option.
+  **End-user experience:** The admin uses an option “Create Bundle” in their
+  client (which might be enabled for admins). They name the new bundle. Users
+  will see a new top-level entry in the news section by that name, which can
+  then be expanded (initially empty). If normal users are not allowed to create
+  bundles, they won’t have that option.
 
-* **ID 382 – New News Category** (`myTran_NewNewsCat`) creates a new **Category** under an existing bundle. **Purpose:** Add a sub-category (forum) under a news bundle. **Initiator:** Client (admin or privileged user). Requires *News Create Category* privilege (priv 34).
+- **ID 382 – New News Category** (`myTran_NewNewsCat`) creates a new
+  **Category** under an existing bundle. **Purpose:** Add a sub-category (forum)
+  under a news bundle. **Initiator:** Client (admin or privileged user).
+  Requires *News Create Category* privilege (priv 34).
 
-  * **Parameters:** The client provides the category name (field 322) and the news path (325) where to create it. The path would be the bundle (or parent category) under which to make this new category.
-  * **Response:** None.
+  - **Parameters:** The client provides the category name (field 322) and the
+    news path (325) where to create it. The path would be the bundle (or parent
+    category) under which to make this new category.
+  - **Response:** None.
 
-  **Effect:** The server creates a new category node. Users will see it when viewing that bundle.
+  **Effect:** The server creates a new category node. Users will see it when
+  viewing that bundle.
 
-  **End-user experience:** The admin (or user with rights) chooses “Create Category” (if allowed) and names it. It appears as a folder under the selected bundle in the news list. For example, under “Announcements” bundle, an admin might add a category “Server Updates”. Regular users typically cannot create new categories unless the server admin specifically grants certain accounts that privilege.
+  **End-user experience:** The admin (or user with rights) chooses “Create
+  Category” (if allowed) and names it. It appears as a folder under the selected
+  bundle in the news list. For example, under “Announcements” bundle, an admin
+  might add a category “Server Updates”. Regular users typically cannot create
+  new categories unless the server admin specifically grants certain accounts
+  that privilege.
 
-* **ID 380 – Delete News Item** (`myTran_DelNewsItem`) deletes a **Bundle or Category** (an organizational item). **Purpose:** Remove a news folder (either a top-level bundle or a sub-category). **Initiator:** Client (admin). Requires either *News Delete Folder* (priv 37) or *News Delete Category* (35) depending on target.
+- **ID 380 – Delete News Item** (`myTran_DelNewsItem`) deletes a **Bundle or
+  Category** (an organizational item). **Purpose:** Remove a news folder (either
+  a top-level bundle or a sub-category). **Initiator:** Client (admin). Requires
+  either *News Delete Folder* (priv 37) or *News Delete Category* (35) depending
+  on target.
 
-  * **Parameters:** The client sends the path (325) of the news item to delete. This path would point to a bundle or category. There is no explicit field to distinguish bundle vs category; the server can infer from internal data or privileges used.
-  * **Response:** None.
+  - **Parameters:** The client sends the path (325) of the news item to delete.
+    This path would point to a bundle or category. There is no explicit field to
+    distinguish bundle vs category; the server can infer from internal data or
+    privileges used.
+  - **Response:** None.
 
-  **Effect:** The server will remove that entire bundle or category and all articles within it. This is a destructive operation. If it’s a bundle, all categories and posts under it are gone. If it’s a sub-category, its posts are gone. The server would likely not allow deletion of a bundle if the user only has category deletion privilege or vice versa. It might require the appropriate one or both privileges.
+  **Effect:** The server will remove that entire bundle or category and all
+  articles within it. This is a destructive operation. If it’s a bundle, all
+  categories and posts under it are gone. If it’s a sub-category, its posts are
+  gone. The server would likely not allow deletion of a bundle if the user only
+  has category deletion privilege or vice versa. It might require the
+  appropriate one or both privileges.
 
-  **End-user experience:** The admin might click “Delete Category” or “Delete Bundle” on an item in the news list (these options probably only appear for those with rights). Once confirmed, that item disappears from everyone’s view. All posts in it become inaccessible. Essentially, an entire section of the board is removed. Normal users wouldn’t have this ability, so they would just notice that a forum is gone if an admin removed it (maybe accompanied by an announcement or not).
+  **End-user experience:** The admin might click “Delete Category” or “Delete
+  Bundle” on an item in the news list (these options probably only appear for
+  those with rights). Once confirmed, that item disappears from everyone’s view.
+  All posts in it become inaccessible. Essentially, an entire section of the
+  board is removed. Normal users wouldn’t have this ability, so they would just
+  notice that a forum is gone if an admin removed it (maybe accompanied by an
+  announcement or not).
 
-**Legacy Note:** **ID 103 – Old Post News** (`myTran_OldPostNews`) is a legacy transaction from older Hotline versions. It allowed posting a news message in the old single “News” window system (pre-1.5). It takes just a Data field (101) for the message text, with no category since older servers didn’t have multiple categories, just one stream of messages. It required *News Post Article* privilege (21). In 1.8.5, this is not used for the new system but might still be supported for backward compatibility with very old clients. Essentially, if an old client sends OldPostNews, the server might stuff the message into a default category or ignore it. Modern implementations can mostly ignore 103, focusing on the new news transactions above.
+**Legacy Note:** **ID 103 – Old Post News** (`myTran_OldPostNews`) is a legacy
+transaction from older Hotline versions. It allowed posting a news message in
+the old single “News” window system (pre-1.5). It takes just a Data field (101)
+for the message text, with no category since older servers didn’t have multiple
+categories, just one stream of messages. It required *News Post Article*
+privilege (21). In 1.8.5, this is not used for the new system but might still be
+supported for backward compatibility with very old clients. Essentially, if an
+old client sends OldPostNews, the server might stuff the message into a default
+category or ignore it. Modern implementations can mostly ignore 103, focusing on
+the new news transactions above.
 
 ## Administrative Functions
 
-Finally, Hotline protocol includes transactions reserved for administrative control of the server and user accounts. These are typically only usable by the admin or users with specific privileges. They allow remote management of user accounts (adding or removing allowed users), broadcasting messages to all users, and forcibly disconnecting users.
+Finally, Hotline protocol includes transactions reserved for administrative
+control of the server and user accounts. These are typically only usable by the
+admin or users with specific privileges. They allow remote management of user
+accounts (adding or removing allowed users), broadcasting messages to all users,
+and forcibly disconnecting users.
 
-### User Account Management (Transactions 350, 351, 352, 353) – Client Initiates (Admin)
+### User Account Management – Client Initiates (Admin) (Tx 350–353)
 
-These let an admin manage the server’s user database (the list of login accounts allowed on the server). They correspond to features in the Hotline Admin client interface for adding/editing accounts.
+These let an admin manage the server’s user database (the list of login accounts
+allowed on the server). They correspond to features in the Hotline Admin client
+interface for adding/editing accounts.
 
-* **ID 350 – New User** (`myTran_NewUser`) allows the admin to create a new user account on the server. **Purpose:** Add a login account to the server’s list of allowed users. **Initiator:** Client (Admin).
+- **ID 350 – New User** (`myTran_NewUser`) allows the admin to create a new user
+  account on the server. **Purpose:** Add a login account to the server’s list
+  of allowed users. **Initiator:** Client (Admin).
 
-  * **Parameters:** The admin supplies the new account’s login name (105), password (106), full user name (102), and an **access privileges bitmap** (110). The login is the username used to log in; password will be stored (Hotline may store it plaintext or hashed – in protocol it’s likely plaintext or simply negated bytes in older style, but as far as the transaction, it’s provided). The user name (102) is the display name (often initially set the same as login or a more descriptive name). The access bitmap is crucial: it defines what privileges the account will have (e.g. admin, file access, etc.). Privileges are assigned by setting bits according to [Access Privilege Bits](#access-privilege-bits-field-110). In the admin UI, this corresponds to checking boxes for privileges, which then form this bitmap.
-  * **Response:** None direct.
+  - **Parameters:** The admin supplies the new account’s login name (105),
+    password (106), full user name (102), and an **access privileges bitmap**
+    (110). The login is the username used to log in; password will be stored
+    (Hotline may store it plaintext or hashed – in protocol it’s likely
+    plaintext or simply negated bytes in older style, but as far as the
+    transaction, it’s provided). The user name (102) is the display name (often
+    initially set the same as login or a more descriptive name). The access
+    bitmap is crucial: it defines what privileges the account will have (e.g.
+    admin, file access, etc.). Privileges are assigned by setting bits according
+    to [Access Privilege Bits](#access-privilege-bits-field-110). In the admin
+    UI, this corresponds to checking boxes for privileges, which then form this
+    bitmap.
+  - **Response:** None direct.
 
-  **Server behavior:** The server creates a new account entry in its user database (or memory if runtime). It will store the login, (likely hash the password internally or store it in config), the display name, and the privileges. If an account with that login already exists, the server would likely either overwrite or (more likely) not create and possibly return an error (maybe via an error transaction). But typically the admin client would prevent duplicates by checking the list first. No specific success message is sent; the admin client knows it succeeded if no error and the account appears in the list when fetched again.
+  **Server behavior:** The server creates a new account entry in its user
+  database (or memory if runtime). It will store the login, (likely hash the
+  password internally or store it in config), the display name, and the
+  privileges. If an account with that login already exists, the server would
+  likely either overwrite or (more likely) not create and possibly return an
+  error (maybe via an error transaction). But typically the admin client would
+  prevent duplicates by checking the list first. No specific success message is
+  sent; the admin client knows it succeeded if no error and the account appears
+  in the list when fetched again.
 
-  **End-user experience:** Only admins do this. In the admin’s Hotline client or Admin tool, when they add a user account and set privileges, behind the scenes it sends NewUser. The admin sees the new account appear in the server’s account list UI. Regular users don’t see anything – this is purely administrative (it doesn’t broadcast to all users that an account was added or anything).
+  **End-user experience:** Only admins do this. In the admin’s Hotline client or
+  Admin tool, when they add a user account and set privileges, behind the scenes
+  it sends NewUser. The admin sees the new account appear in the server’s
+  account list UI. Regular users don’t see anything – this is purely
+  administrative (it doesn’t broadcast to all users that an account was added or
+  anything).
 
-* **ID 351 – Delete User** (`myTran_DeleteUser`) removes an existing user account from the server’s allowed list. **Purpose:** Delete a user’s account (they will no longer be able to log in). **Initiator:** Client (Admin).
+- **ID 351 – Delete User** (`myTran_DeleteUser`) removes an existing user
+  account from the server’s allowed list. **Purpose:** Delete a user’s account
+  (they will no longer be able to log in). **Initiator:** Client (Admin).
 
-  * **Parameters:** The admin provides the login name (105) of the account to delete. That identifies which account to remove.
-  * **Response:** None (if success, the account is gone; if the account didn’t exist, server may ignore or error).
+  - **Parameters:** The admin provides the login name (105) of the account to
+    delete. That identifies which account to remove.
+  - **Response:** None (if success, the account is gone; if the account didn’t
+    exist, server may ignore or error).
 
-  **Server behavior:** The server will remove that user from its stored list. If that user is currently online at the time, an admin would typically kick them separately if desired – deleting an account doesn’t automatically disconnect them (but it does prevent re-login). There’s no broadcast or notification to regular users. If the admin accidentally tries to delete a non-existent user, likely nothing happens or an error is returned. The admin’s account list will update (the entry disappears).
+  **Server behavior:** The server will remove that user from its stored list. If
+  that user is currently online at the time, an admin would typically kick them
+  separately if desired – deleting an account doesn’t automatically disconnect
+  them (but it does prevent re-login). There’s no broadcast or notification to
+  regular users. If the admin accidentally tries to delete a non-existent user,
+  likely nothing happens or an error is returned. The admin’s account list will
+  update (the entry disappears).
 
-  **End-user experience:** For the admin, the account disappears from the list in the admin tool. For the user whose account was deleted: if they are online, nothing immediate might happen (they could continue their session until disconnected manually or by leaving). However, once they log out, they can’t log back in. If an admin deletes an account and wants to kick the user off now, they would use Disconnect User (110) as well. There is one special case: the server might protect deletion of the built-in Admin account via privileges (so you can’t delete the last admin or yourself while logged in – just caution, but at protocol level, nothing stops sending 351 for any login).
+  **End-user experience:** For the admin, the account disappears from the list
+  in the admin tool. For the user whose account was deleted: if they are online,
+  nothing immediate might happen (they could continue their session until
+  disconnected manually or by leaving). However, once they log out, they can’t
+  log back in. If an admin deletes an account and wants to kick the user off
+  now, they would use Disconnect User (110) as well. There is one special case:
+  the server might protect deletion of the built-in Admin account via privileges
+  (so you can’t delete the last admin or yourself while logged in – just
+  caution, but at protocol level, nothing stops sending 351 for any login).
 
-* **ID 352 – Get User** (`myTran_GetUser`) retrieves information about an existing user account. **Purpose:** To fetch the details of a specific user account (used when editing an account). **Initiator:** Client (Admin).
+- **ID 352 – Get User** (`myTran_GetUser`) retrieves information about an
+  existing user account. **Purpose:** To fetch the details of a specific user
+  account (used when editing an account). **Initiator:** Client (Admin).
 
-  * **Parameters:** The admin sends the login name (105) of the account they want to view.
-  * **Response:** The server replies with that account’s info: it returns the user’s full display name (102), the login (105) (interestingly, the protocol notes each character is bitwise negated in this field in the reply – an old obscure practice possibly for not sending plain text; the admin client will invert the bits again to get actual login), the password (106) (likely also negated or hashed similarly), and the access privileges bitmap (110). Refer to [Access Privilege Bits](#access-privilege-bits-field-110) to decode the bitmap.
+  - **Parameters:** The admin sends the login name (105) of the account they
+    want to view.
+  - **Response:** The server replies with that account’s info: it returns the
+    user’s full display name (102), the login (105) (interestingly, the protocol
+    notes each character is bitwise negated in this field in the reply – an old
+    obscure practice possibly for not sending plain text; the admin client will
+    invert the bits again to get actual login), the password (106) (likely also
+    negated or hashed similarly), and the access privileges bitmap (110). Refer
+    to [Access Privilege Bits](#access-privilege-bits-field-110) to decode the
+    bitmap.
 
-  **Server behavior:** When an admin wants to edit an account, their client issues GetUser. The server looks up that account in its list and sends back the current stored values for name, login, (maybe an encoded password), and privileges. The weird negation (\~) of each character for login (and possibly password) is probably done so that if someone is sniffing the connection, they don’t see the literal credentials easily. (It’s not true encryption but a simple obfuscation – historically Hotline did that). The admin client will invert those bits to display the actual login and password in the UI.
+  **Server behavior:** When an admin wants to edit an account, their client
+  issues GetUser. The server looks up that account in its list and sends back
+  the current stored values for name, login, (maybe an encoded password), and
+  privileges. The weird negation (~) of each character for login (and possibly
+  password) is probably done so that if someone is sniffing the connection, they
+  don’t see the literal credentials easily. (It’s not true encryption but a
+  simple obfuscation – historically Hotline did that). The admin client will
+  invert those bits to display the actual login and password in the UI.
 
-  **End-user experience:** Only the admin doing this sees anything – it populates the Edit User dialog with the user’s info. Regular connected users are not affected or informed.
+  **End-user experience:** Only the admin doing this sees anything – it
+  populates the Edit User dialog with the user’s info. Regular connected users
+  are not affected or informed.
 
-* **ID 353 – Set User** (`myTran_SetUser`) updates an existing user account’s information. **Purpose:** Save changes made to a user’s account (login, password, name, privileges). **Initiator:** Client (Admin).
+- **ID 353 – Set User** (`myTran_SetUser`) updates an existing user account’s
+  information. **Purpose:** Save changes made to a user’s account (login,
+  password, name, privileges). **Initiator:** Client (Admin).
 
-  * **Parameters:** The admin sends the account’s login (105) and new password (106) (if they changed it; if not changed, it might send the old one or some indicator), the new full name (102), and new access privileges bitmap (110). These privilege bits are the same as those in [Access Privilege Bits](#access-privilege-bits-field-110). Essentially the same fields as NewUser, but targeted at an existing user identified by the login.
-  * **Response:** None.
+  - **Parameters:** The admin sends the account’s login (105) and new password
+    (106) (if they changed it; if not changed, it might send the old one or some
+    indicator), the new full name (102), and new access privileges bitmap (110).
+    These privilege bits are the same as those in
+    [Access Privilege Bits](#access-privilege-bits-field-110). Essentially the
+    same fields as NewUser, but targeted at an existing user identified by the
+    login.
+  - **Response:** None.
 
-  **Server behavior:** The server finds that account and updates the provided fields. If the login itself was changed via this (e.g., renaming the account), it will update the account’s key (though some systems might treat login as immutable; Hotline allowed editing login names IIRC). The server then uses the new values henceforth. If the user corresponding to that account is currently online, the server might also update some of their session info: for example, if their privileges were changed, the server may immediately enforce that. In fact, when an admin edits privileges of a currently online user, the server will send that user a new **User Access (354)** transaction to update their permissions live. The protocol 354 is “Set access privileges for current user” initiated by server – likely the server uses it in this scenario. So if the admin removed someone’s ability to download files on the fly, the user might get a UserAccess update dropping that bit, and their client would grey out the download button immediately. (The documentation doesn’t explicitly tie 354 to SetUser, but logically that’s how a live change would be communicated.)
+  **Server behavior:** The server finds that account and updates the provided
+  fields. If the login itself was changed via this (e.g., renaming the account),
+  it will update the account’s key (though some systems might treat login as
+  immutable; Hotline allowed editing login names IIRC). The server then uses the
+  new values henceforth. If the user corresponding to that account is currently
+  online, the server might also update some of their session info: for example,
+  if their privileges were changed, the server may immediately enforce that. In
+  fact, when an admin edits privileges of a currently online user, the server
+  will send that user a new **User Access (354)** transaction to update their
+  permissions live. The protocol 354 is “Set access privileges for current user”
+  initiated by server – likely the server uses it in this scenario. So if the
+  admin removed someone’s ability to download files on the fly, the user might
+  get a UserAccess update dropping that bit, and their client would grey out the
+  download button immediately. (The documentation doesn’t explicitly tie 354 to
+  SetUser, but logically that’s how a live change would be communicated.)
 
-  Password changes take effect (the user will need to use the new password on next login; if they’re online, it doesn’t boot them or inform them).
+  Password changes take effect (the user will need to use the new password on
+  next login; if they’re online, it doesn’t boot them or inform them).
 
-  **End-user experience:** The admin uses an “Edit Account” dialog, changes some settings, and saves. They see the account list updated (maybe icon color changes if privileges changed, etc.). If the edited user is online and their privileges were altered, they might notice something: their client could immediately reflect new privileges (for instance, if now they are an admin, they might see new admin options appear, or if some privilege revoked, an option disappears). In practice, Hotline might not always live-update privileges, but the protocol support is there. At minimum, the effect will be in their next session. They are not explicitly notified “Your account was edited” (unless the admin tells them). If their password was changed while they’re on, they won’t know until they try to relogin later.
+  **End-user experience:** The admin uses an “Edit Account” dialog, changes some
+  settings, and saves. They see the account list updated (maybe icon color
+  changes if privileges changed, etc.). If the edited user is online and their
+  privileges were altered, they might notice something: their client could
+  immediately reflect new privileges (for instance, if now they are an admin,
+  they might see new admin options appear, or if some privilege revoked, an
+  option disappears). In practice, Hotline might not always live-update
+  privileges, but the protocol support is there. At minimum, the effect will be
+  in their next session. They are not explicitly notified “Your account was
+  edited” (unless the admin tells them). If their password was changed while
+  they’re on, they won’t know until they try to relogin later.
 
 ### Disconnecting a User (Transaction 110 & 111) – Admin/Server Use
 
-**ID 110 – Disconnect User** (`myTran_DisconnectUser`) is used by an admin (or potentially the server itself) to forcibly disconnect a user from the server. **Purpose:** Kick a user off (with optional banning). **Initiator:** Client (Admin).
+**ID 110 – Disconnect User** (`myTran_DisconnectUser`) is used by an admin (or
+potentially the server itself) to forcibly disconnect a user from the server.
+**Purpose:** Kick a user off (with optional banning). **Initiator:** Client
+(Admin).
 
-* **Parameters:** The admin specifies the target’s User ID (103). There’s an **Options** field (113) which can carry “ban options” – e.g., whether this should also ban the user’s account or IP. The exact encoding of ban options isn’t detailed in the doc, but likely a bit like 1 = ban IP, 2 = ban user, etc., if used. There is also an optional Data (101) which might be labeled “Name?” in the spec – possibly to provide a reason or the name of who’s banning? The documentation is a bit unclear on that field’s purpose.
-* **Response:** None (the action is taken, then the server will inform the user being kicked via transaction 111).
+- **Parameters:** The admin specifies the target’s User ID (103). There’s an
+  **Options** field (113) which can carry “ban options” – e.g., whether this
+  should also ban the user’s account or IP. The exact encoding of ban options
+  isn’t detailed in the doc, but likely a bit like 1 = ban IP, 2 = ban user,
+  etc., if used. There is also an optional Data (101) which might be labeled
+  “Name?” in the spec – possibly to provide a reason or the name of who’s
+  banning? The documentation is a bit unclear on that field’s purpose.
+- **Response:** None (the action is taken, then the server will inform the user
+  being kicked via transaction 111).
 
-**Server behavior:** When an admin issues DisconnectUser, the server immediately disconnects that user’s session. It will typically mark them as offline and send out a Notify Delete User (302) to others. If ban options were set, the server also adds the user to a ban list (e.g., by IP or account name). Hotline servers have a banlist feature (one can ban by address or account for a duration). The server does not reply to the admin client, but the admin client will reflect that the user is gone from user list. If the user cannot be disconnected (perhaps if they have “Cannot be disconnected” privilege, priv 23, which could be set for the Admin account to prevent other admins kicking each other), then the server might do nothing or send an error back (or just ignore the request for that ID). Privilege required to use DisconnectUser is *Disconnect User* priv (22), which typically only Admin accounts have.
+**Server behavior:** When an admin issues DisconnectUser, the server immediately
+disconnects that user’s session. It will typically mark them as offline and send
+out a Notify Delete User (302) to others. If ban options were set, the server
+also adds the user to a ban list (e.g., by IP or account name). Hotline servers
+have a banlist feature (one can ban by address or account for a duration). The
+server does not reply to the admin client, but the admin client will reflect
+that the user is gone from user list. If the user cannot be disconnected
+(perhaps if they have “Cannot be disconnected” privilege, priv 23, which could
+be set for the Admin account to prevent other admins kicking each other), then
+the server might do nothing or send an error back (or just ignore the request
+for that ID). Privilege required to use DisconnectUser is *Disconnect User* priv
+(22), which typically only Admin accounts have.
 
-**End-user experience (target user):** The user being kicked will suddenly get disconnected from the server. Their client will usually show a message like “You have been disconnected by an administrator.” This message is provided by **Disconnect Message (111)** which the server sends just before dropping the connection. We cover that next. If banned, they will also find they cannot reconnect (the server will refuse future login attempts, either indefinitely or for a set time if the server uses temporary bans). This is effectively a “kick” (and optional ban).
+**End-user experience (target user):** The user being kicked will suddenly get
+disconnected from the server. Their client will usually show a message like “You
+have been disconnected by an administrator.” This message is provided by
+**Disconnect Message (111)** which the server sends just before dropping the
+connection. We cover that next. If banned, they will also find they cannot
+reconnect (the server will refuse future login attempts, either indefinitely or
+for a set time if the server uses temporary bans). This is effectively a “kick”
+(and optional ban).
 
-**ID 111 – Disconnect Message** (`myTran_DisconnectMsg`) is the server telling a user that they are about to be (or have been) disconnected. **Purpose:** To convey a reason or message on disconnect, then instruct the client to close. **Initiator:** Server.
+**ID 111 – Disconnect Message** (`myTran_DisconnectMsg`) is the server telling a
+user that they are about to be (or have been) disconnected. **Purpose:** To
+convey a reason or message on disconnect, then instruct the client to close.
+**Initiator:** Server.
 
-* **Parameters:** A Data field (101) containing the message to display to the user upon disconnect. This is mandatory when used.
-* **Response:** None (the client is expected to close the connection after receiving it).
+- **Parameters:** A Data field (101) containing the message to display to the
+  user upon disconnect. This is mandatory when used.
+- **Response:** None (the client is expected to close the connection after
+  receiving it).
 
-**Server behavior:** When the server is about to disconnect a user (either via admin action, or maybe due to inactivity timeout or other reasons), it sends DisconnectMsg with a reason text (for example, “You have been kicked by Admin” or “Server shutting down”). Immediately after sending this, the server closes the connection from its side as well. The user ID of the target is implicit (since it’s sent on that user’s connection).
+**Server behavior:** When the server is about to disconnect a user (either via
+admin action, or maybe due to inactivity timeout or other reasons), it sends
+DisconnectMsg with a reason text (for example, “You have been kicked by Admin”
+or “Server shutting down”). Immediately after sending this, the server closes
+the connection from its side as well. The user ID of the target is implicit
+(since it’s sent on that user’s connection).
 
-**End-user experience:** The user sees a message popup or in the status: whatever text the server sent. Commonly if an admin kicked them, they might see “Disconnected by Server: `<message>`”. Then the connection is lost – the client returns to the server list or login screen. This is more graceful than a silent drop; the user at least knows the cause. If the server simply dropped without sending 111, the user would just see “Connection lost.”
+**End-user experience:** The user sees a message popup or in the status:
+whatever text the server sent. Commonly if an admin kicked them, they might see
+“Disconnected by Server: `<message>`”. Then the connection is lost – the client
+returns to the server list or login screen. This is more graceful than a silent
+drop; the user at least knows the cause. If the server simply dropped without
+sending 111, the user would just see “Connection lost.”
 
 ### Broadcasting a Message (Transaction 355) – Admin/Server Initiated
 
-**ID 355 – User Broadcast** (`myTran_UserBroadcast`) allows an admin or privileged user to send a message to all online users. **Purpose:** To broadcast an announcement. **Initiator:** Client (Admin) *and* also can be Server.
+**ID 355 – User Broadcast** (`myTran_UserBroadcast`) allows an admin or
+privileged user to send a message to all online users. **Purpose:** To broadcast
+an announcement. **Initiator:** Client (Admin) *and* also can be Server.
 
-* **Parameters (Client→Server):** The admin client sends the text of the message in field 101 (Data). No other fields are needed.
+- **Parameters (Client→Server):** The admin client sends the text of the message
+  in field 101 (Data). No other fields are needed.
 
-* **Response:** None (server will forward it).
+- **Response:** None (server will forward it).
 
-* **Server as initiator:** The server itself (like via a scheduled message or console command) can also initiate a broadcast. In that case, it sends UserBroadcast with field 101 containing the message and possibly treats it as an “Administrator message” on clients. The protocol notes when server initiates, it uses the Data field for the “Administrator message” text.
+- **Server as initiator:** The server itself (like via a scheduled message or
+  console command) can also initiate a broadcast. In that case, it sends
+  UserBroadcast with field 101 containing the message and possibly treats it as
+  an “Administrator message” on clients. The protocol notes when server
+  initiates, it uses the Data field for the “Administrator message” text.
 
-**Server behavior:** Upon receiving a UserBroadcast from an admin, the server will take that text and send it out to every connected user as a **Server Message (104)** with no user ID (or it might use the dedicated broadcast mechanism). The spec actually defines UserBroadcast as a transaction that can be initiated by both client and server. Possibly, the server could use transaction 355 to deliver the broadcast to each client too, but it’s more likely it just uses the existing ServerMsg for actual delivery. However, since 355 exists, maybe the server simply relays the same 355 to all clients (with Initiator: Server for them). The documentation indicates: “The server can also be an initiator of this transaction”. In that scenario, presumably clients receiving a UserBroadcast treat it similarly to receiving a ServerMsg. Either way, the message gets to everyone.
+**Server behavior:** Upon receiving a UserBroadcast from an admin, the server
+will take that text and send it out to every connected user as a **Server
+Message (104)** with no user ID (or it might use the dedicated broadcast
+mechanism). The spec actually defines UserBroadcast as a transaction that can be
+initiated by both client and server. Possibly, the server could use transaction
+355 to deliver the broadcast to each client too, but it’s more likely it just
+uses the existing ServerMsg for actual delivery. However, since 355 exists,
+maybe the server simply relays the same 355 to all clients (with Initiator:
+Server for them). The documentation indicates: “The server can also be an
+initiator of this transaction”. In that scenario, presumably clients receiving a
+UserBroadcast treat it similarly to receiving a ServerMsg. Either way, the
+message gets to everyone.
 
-Privilege required to send a broadcast via 355 is *Broadcast* priv (32), which typically only admin or moderators have.
+Privilege required to send a broadcast via 355 is *Broadcast* priv (32), which
+typically only admin or moderators have.
 
-**End-user experience:** All users will see a message appear, usually in a separate system message window or as a highlighted text, often prefixed by something like “Broadcast from Admin: `<text>`”. For example, an admin might announce “Server will restart in 5 minutes.” Users see that in real-time. It’s not part of public chat; it’s a distinct message, often modal or clearly different (Hotline client had a floating window or a different color for admin broadcasts). They cannot reply to it (except via PM or such privately). It’s essentially like a server announcement PA system.
+**End-user experience:** All users will see a message appear, usually in a
+separate system message window or as a highlighted text, often prefixed by
+something like “Broadcast from Admin: `<text>`”. For example, an admin might
+announce “Server will restart in 5 minutes.” Users see that in real-time. It’s
+not part of public chat; it’s a distinct message, often modal or clearly
+different (Hotline client had a floating window or a different color for admin
+broadcasts). They cannot reply to it (except via PM or such privately). It’s
+essentially like a server announcement PA system.
 
 ### Additional Admin Privileges Note
 
 The admin can also use some of the normal user transactions in special ways:
 
-* They can invite themselves into any private chat, or disconnect a chat (there was mention of Open Chat/Close Chat privileges (11,12) in the list, which possibly allowed forcibly entering or closing chat rooms).
-* “Cannot be disconnected” privilege (23) if set on an account means no one can kick that account via 110 – the server would refuse a disconnect attempt, ensuring the main admin can’t be booted by a subordinate.
+- They can invite themselves into any private chat, or disconnect a chat (there
+  was mention of Open Chat/Close Chat privileges (11,12) in the list, which
+  possibly allowed forcibly entering or closing chat rooms).
+- “Cannot be disconnected” privilege (23) if set on an account means no one can
+  kick that account via 110 – the server would refuse a disconnect attempt,
+  ensuring the main admin can’t be booted by a subordinate.
 
-Administration tasks like setting the server message of the day or agreements are done out-of-band (like editing a text file or using server config UI, not via a specific transaction except in global server context, which we skip).
+Administration tasks like setting the server message of the day or agreements
+are done out-of-band (like editing a text file or using server config UI, not
+via a specific transaction except in global server context, which we skip).
 
-**Summary of Admin functions:** Account management (350-353) lets you maintain who can log in and what they can do. The disconnect and broadcast tools (110, 111, 355) let you moderate users in real-time and communicate announcements. These transactions are protected by privileges to prevent abuse. Implementers should ensure that only authorized sessions (e.g., logged in as Admin or with appropriate priv bits in User Access) can invoke them, and that they correctly propagate their effects (e.g., update privileges immediately, send notifications, etc.). Regular users never directly use these transactions.
+**Summary of Admin functions:** Account management (350-353) lets you maintain
+who can log in and what they can do. The disconnect and broadcast tools (110,
+111, 355) let you moderate users in real-time and communicate announcements.
+These transactions are protected by privileges to prevent abuse. Implementers
+should ensure that only authorized sessions (e.g., logged in as Admin or with
+appropriate priv bits in User Access) can invoke them, and that they correctly
+propagate their effects (e.g., update privileges immediately, send
+notifications, etc.). Regular users never directly use these transactions.
 
----
+______________________________________________________________________
 
 **References:**
 
-* Hotline Protocol Specification (v1.8.x) – for transaction definitions and fields.
-* Hotline Server Configuration Manual – for context on admin actions and user experience (account icons and privileges).
+- Hotline Protocol Specification (v1.8.x) – for transaction definitions and
+  fields.
+- Hotline Server Configuration Manual – for context on admin actions and user
+  experience (account icons and privileges).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Implementation Roadmap
 
 This document tracks the major features required for a full Hotline-inspired BBS
-server.  Features are grouped by domain with checkboxes.  Items that have
-already been implemented in the repository are checked off.
+server. Features are grouped by domain with checkboxes. Items that have already
+been implemented in the repository are checked off.
 
 ## Core Server
 
@@ -62,6 +62,6 @@ already been implemented in the repository are checked off.
 - [x] SQLite support with migrations
 - [ ] PostgreSQL backend support
 
-The roadmap will evolve as the project grows.  Checked items indicate
-functionality present in the current code base.  Unchecked items highlight areas
+The roadmap will evolve as the project grows. Checked items indicate
+functionality present in the current code base. Unchecked items highlight areas
 for future development.


### PR DESCRIPTION
## Summary
- mdformat all Markdown documentation
- resolve markdownlint warnings

## Testing
- `npx markdownlint-cli2 '**/*.md'`
- `nixie docs/*.md`
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684937548d54832284a83add085a5e65

## Summary by Sourcery

Apply mdformat to all Markdown documentation and resolve markdownlint warnings to improve consistency and readability

Documentation:
- Run mdformat across all .md files to enforce consistent wrapping and indentation
- Fix markdownlint issues by correcting list indentation, table alignment, and horizontal separators
- Normalize table and code block formatting in protocol, schema, and migration guides
- Clean up AGENTS and ROADMAP documents with uniform bullet and spacing conventions