### PR TITLE
Enforce backend feature selection

### DIFF
--- a/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
+++ b/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
@@ -137,6 +137,9 @@ sqlite   = [
 ]
 ```
 
+Exactly one of these features must be active. The `mxd` crate emits a
+compile-time error if both or neither are enabled.
+
 and enable the feature you actually link at build-time. If you use the
 `diesel` CLI for manual migration commands, install it with matching features:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,14 @@
+#[cfg(all(feature = "sqlite", feature = "postgres"))]
+compile_error!("Choose either sqlite or postgres, not both");
+
+#[cfg(not(any(feature = "sqlite", feature = "postgres")))]
+compile_error!("Either the 'sqlite' or 'postgres' feature must be enabled");
+
+#[cfg(feature = "postgres")]
+pub use diesel::pg::Pg as DbBackend;
+#[cfg(feature = "sqlite")]
+pub use diesel::sqlite::Sqlite as DbBackend;
+
 pub mod commands;
 pub mod db;
 pub mod field_id;


### PR DESCRIPTION
## Summary
- ensure only one database backend feature is selected
- document that exactly one backend feature is required

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `npx markdownlint-cli2 "docs/**/*.md" README.md`
- `nixie docs/chat-schema.md docs/news-schema.md` *(fails: `Failed to link vscode-languageserver: EEXIST`)*

------
https://chatgpt.com/codex/tasks/task_e_68495d917b08832281f32a5fab351b25