### PR TITLE
Add backend-agnostic DbConnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "cfg-if",
  "chrono",
  "clap",
  "clap-dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
+cfg-if = "1"
 ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.1.0" }
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"


### PR DESCRIPTION
## Summary
- conditionally import the correct Diesel connection
- use `cfg_if!` to define `DbConnection` and `DbPool`
- update path lookup helpers to use generic backend
- add `cfg-if` crate

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --features sqlite -- --nocapture`
- `cargo test --no-default-features --features postgres -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68495d9f23588322914a31a5059b8007