### PR TITLE
Fix install-action syntax in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,9 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - uses: taiki-e/install-action@cargo-llvm-cov@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Generate coverage
         run: |


### PR DESCRIPTION
## Summary
- fix `uses:` syntax for taiki-e/install-action in coverage workflow

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6849755c3bf483228312baad80ecd361

## Summary by Sourcery

CI:
- Update taiki-e/install-action to @v2 and provide the cargo-llvm-cov tool via the with block