### PR TITLE
Fix coverage workflow output paths

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Generate coverage
         run: |
-          cargo llvm-cov --workspace --all-features \
-                         --lcov --output-path lcov.info \
-                         --codecov --output-path codecov.json
+          cargo llvm-cov --workspace --all-features --no-report
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --codecov --output-path codecov.json
 
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## Summary
- avoid passing `--output-path` twice in coverage workflow
- run cargo llvm-cov once with `--no-report` and generate reports separately

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68497783e0188322b620565d63287217

## Summary by Sourcery

CI:
- Run cargo llvm-cov with --no-report and then generate reports separately to avoid passing --output-path twice in the coverage workflow