### PR TITLE
Enable Postgres in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "futures-util",
  "mxd",
  "nix",
+ "postgresql_embedded",
  "tempfile",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "chrono",
  "diesel",
  "diesel-async",
+ "diesel_migrations",
  "futures-util",
  "mxd",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,14 @@ postgres = [
     "diesel_migrations/postgres",
     "diesel-async/postgres",
     "url",
+    "test-util/postgres",
 ]
 sqlite = [
     "diesel/sqlite",
     "diesel/returning_clauses_for_sqlite_3_35",
     "diesel_migrations/sqlite",
     "diesel-async/sqlite",
+    "test-util/sqlite",
 ]
 returning_clauses_for_sqlite_3_35 = ["diesel/returning_clauses_for_sqlite_3_35"]
 json5 = []
@@ -54,7 +56,7 @@ yaml = []
 toml = []
 
 [dev-dependencies]
-test-util = { path = "test-util" }
+test-util = { path = "test-util", default-features = false }
 postgresql_embedded = { version = "0.18.5", features = ["tokio"] }
 
 [lints.clippy]

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -10,6 +10,7 @@ mxd = { path = "..", default-features = false }
 tokio = { version = "1", features = ["rt", "macros"] }
 diesel = { version = "2", default-features = false, features = ["chrono"] }
 diesel-async = { version = "0.5", default-features = false, features = ["sync-connection-wrapper"] }
+diesel_migrations = { version = "2", default-features = false }
 postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = true }
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
@@ -22,6 +23,7 @@ postgres = [
     "diesel-async/postgres",
     "mxd/postgres",
     "postgresql_embedded",
+    "diesel_migrations/postgres",
 ]
 sqlite = [
     "diesel/sqlite",

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -6,18 +6,26 @@ edition = "2024"
 [dependencies]
 tempfile = "3"
 nix = { version = "0.27", features = ["signal"] }
-mxd = { path = "..", features = ["sqlite"] }
+mxd = { path = "..", default-features = false }
 tokio = { version = "1", features = ["rt", "macros"] }
-diesel = { version = "2", default-features = false, features = ["sqlite", "chrono", "returning_clauses_for_sqlite_3_35"] }
-diesel-async = { version = "0.5", default-features = false, features = ["sqlite", "sync-connection-wrapper"] }
+diesel = { version = "2", default-features = false, features = ["chrono"] }
+diesel-async = { version = "0.5", default-features = false, features = ["sync-connection-wrapper"] }
+postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = true }
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
 
 [features]
-default = []
+default = ["sqlite"]
+postgres = [
+    "diesel/postgres",
+    "diesel-async/postgres",
+    "mxd/postgres",
+    "postgresql_embedded",
+]
 sqlite = [
     "diesel/sqlite",
     "diesel/returning_clauses_for_sqlite_3_35",
     "diesel-async/sqlite",
+    "mxd/sqlite",
 ]

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -255,7 +255,7 @@ fn post_news_article_root() -> Result<(), Box<dyn std::error::Error>> {
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
-        let mut conn = DbConnection::establish(server.db_path().to_str().unwrap()).await?;
+        let mut conn = DbConnection::establish(server.db_url()).await?;
         use mxd::schema::news_articles::dsl as a;
         let titles = a::news_articles
             .select(a::title)

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -18,7 +18,7 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
-            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            let mut conn = DbConnection::establish(db).await?;
             run_migrations(&mut conn).await?;
             create_bundle(
                 &mut conn,
@@ -106,7 +106,7 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
-            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            let mut conn = DbConnection::establish(db).await?;
             run_migrations(&mut conn).await?;
             create_bundle(
                 &mut conn,
@@ -193,7 +193,7 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
-            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            let mut conn = DbConnection::establish(db).await?;
             run_migrations(&mut conn).await?;
             create_category(
                 &mut conn,
@@ -247,7 +247,7 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
-            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            let mut conn = DbConnection::establish(db).await?;
             run_migrations(&mut conn).await?;
             Ok(())
         })
@@ -311,7 +311,7 @@ fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
-            let mut conn = DbConnection::establish(db.to_str().unwrap()).await?;
+            let mut conn = DbConnection::establish(db).await?;
             run_migrations(&mut conn).await?;
             use mxd::schema::news_bundles::dsl as b;
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -11,5 +11,5 @@ nix = { version = "0.27", optional = false, features = ["signal"] }
 
 [dev-dependencies]
 test-util = { path = "../test-util" }
-mxd = { path = "..", features = ["sqlite"] }
+mxd = { path = "..", default-features = false }
 argon2 = { version = "0.5", features = ["std"] }


### PR DESCRIPTION
## Summary
- gate `test-util` Diesel deps behind features
- support Postgres in `TestServer`
- update integration tests to use connection URLs
- forward main crate features to `test-util`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849897e63488322afad1078d5a80215

## Summary by Sourcery

Enable optional PostgreSQL in test utilities by feature-gating Diesel dependencies, using database URLs in TestServer, and aligning feature flags across crates

New Features:
- Add optional PostgreSQL support in TestServer behind a new `postgres` feature

Enhancements:
- Switch TestServer and test-util setup functions to use database URL strings instead of file paths
- Gate Diesel and Diesel-async dependencies in test-util behind separate `sqlite` and `postgres` features
- Propagate primary crate feature flags (`sqlite` and `postgres`) to test-util for consistent configuration

Build:
- Revise Cargo.toml in test-util, main, and validator crates to disable default features and define `sqlite` and `postgres` features for dependency gating

Tests:
- Update integration tests to use `db_url()` and establish connections via URL strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for PostgreSQL in test utilities, enabling tests to run against both SQLite and PostgreSQL databases.

- **Refactor**
  - Unified database handling in tests to use database URLs instead of file paths.
  - Updated test server and utility APIs to reflect the new database URL approach.

- **Chores**
  - Updated dependency configurations for improved feature management and compatibility across crates.
  - Adjusted development dependencies to better control enabled features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->