### PR TITLE
Add db_url helper for TestServer

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -100,6 +100,18 @@ impl TestServer {
     pub fn db_path(&self) -> &Path {
         &self.db_path
     }
+
+    /// Return the database connection URL used by the server.
+    ///
+    /// Currently tests only use SQLite, so this is just the path as a string.
+    /// The method returns an owned `String` to match Diesel's `establish`
+    /// signature, which takes `&str`.
+    pub fn db_url(&self) -> String {
+        self.db_path
+            .to_str()
+            .expect("database path utf8")
+            .to_owned()
+    }
 }
 
 impl Drop for TestServer {

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -103,14 +103,12 @@ impl TestServer {
 
     /// Return the database connection URL used by the server.
     ///
-    /// Currently tests only use SQLite, so this is just the path as a string.
-    /// The method returns an owned `String` to match Diesel's `establish`
-    /// signature, which takes `&str`.
-    pub fn db_url(&self) -> String {
+    /// Currently tests only use SQLite, so this is just the path rendered
+    /// as UTF-8. Borrowing avoids allocating a new `String` for each call.
+    pub fn db_url(&self) -> &str {
         self.db_path
             .to_str()
             .expect("database path utf8")
-            .to_owned()
     }
 }
 

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -255,7 +255,7 @@ fn post_news_article_root() -> Result<(), Box<dyn std::error::Error>> {
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
-        let mut conn = DbConnection::establish(server.db_path().to_str().unwrap()).await?;
+        let mut conn = DbConnection::establish(&server.db_url()).await?;
         use mxd::schema::news_articles::dsl as a;
         let titles = a::news_articles
             .select(a::title)

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -255,7 +255,7 @@ fn post_news_article_root() -> Result<(), Box<dyn std::error::Error>> {
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
-        let mut conn = DbConnection::establish(&server.db_url()).await?;
+        let mut conn = DbConnection::establish(server.db_url()).await?;
         use mxd::schema::news_articles::dsl as a;
         let titles = a::news_articles
             .select(a::title)


### PR DESCRIPTION
## Summary
- provide `TestServer::db_url` returning a connection string
- use the helper in `news_articles` integration test

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6849e1148dfc83229a3ababff807a7e8

## Summary by Sourcery

Add a db_url helper to TestServer for obtaining the database connection string and update the news_articles integration test to use this helper.

New Features:
- Add TestServer::db_url method to return the database URL as a String.

Tests:
- Update news_articles integration test to use the new db_url helper instead of manual path conversion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved how database connections are established in tests by using a dedicated method to retrieve the database URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->