### PR TITLE
Switch to AsyncPgConnection and update migrations

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -31,6 +31,15 @@ cfg_if! {
 /// # Panics
 /// Panics if the connection pool cannot be created.
 #[must_use = "handle the pool"]
+/// Asynchronously establishes a database connection pool for the configured backend.
+///
+/// Panics if the pool cannot be created.
+///
+/// # Examples
+///
+/// ```
+/// let pool = establish_pool("sqlite::memory:").await;
+/// ```
 pub async fn establish_pool(database_url: &str) -> DbPool {
     let config = AsyncDieselConnectionManager::<DbConnection>::new(database_url);
     Pool::builder()
@@ -122,6 +131,24 @@ pub async fn audit_sqlite_features(conn: &mut DbConnection) -> QueryResult<()> {
 /// cannot be parsed.
 #[cfg(feature = "postgres")]
 #[must_use = "handle the result"]
+/// Checks that the connected PostgreSQL server version is at least 14.
+///
+/// Executes a version query and parses the result, returning an error if the version is unsupported or cannot be determined.
+///
+/// # Returns
+///
+/// - `Ok(())` if the server version is 14 or higher.
+/// - An error if the version is below 14 or cannot be parsed.
+///
+/// # Examples
+///
+/// ```
+/// # use your_crate::audit_postgres_features;
+/// # async fn check(conn: &mut diesel_async::AsyncPgConnection) {
+/// let result = audit_postgres_features(conn).await;
+/// assert!(result.is_ok());
+/// # }
+/// ```
 pub async fn audit_postgres_features(
     conn: &mut diesel_async::AsyncPgConnection,
 ) -> QueryResult<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,9 @@ impl Run for CreateUserArgs {
                 password: &hashed,
             };
             let mut conn = DbConnection::establish(&cfg.database).await?;
+            #[cfg(feature = "postgres")]
+            run_migrations(&mut conn, &cfg.database).await?;
+            #[cfg(not(feature = "postgres"))]
             run_migrations(&mut conn).await?;
             create_user(&mut conn, &new_user).await?;
             println!("User {username} created");
@@ -189,6 +192,9 @@ async fn setup_database(database: &str) -> Result<DbPool> {
         audit_sqlite_features(&mut conn).await?;
         #[cfg(feature = "postgres")]
         audit_postgres_features(&mut conn).await?;
+        #[cfg(feature = "postgres")]
+        run_migrations(&mut conn, database).await?;
+        #[cfg(not(feature = "postgres"))]
         run_migrations(&mut conn).await?;
     }
     Ok(pool)

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,13 @@ enum Commands {
 }
 
 impl Run for CreateUserArgs {
+    /// Creates a new user with the specified username and password, hashing the password securely and storing the user in the database.
+    ///
+    /// Validates that both username and password are provided, hashes the password using Argon2id with parameters from the configuration, runs database migrations if necessary, and inserts the new user record. Prints a confirmation message upon successful creation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if required arguments are missing, password hashing fails, database connection or migrations fail, or user creation is unsuccessful.
     fn run(self, cfg: &AppConfig) -> Result<()> {
         tokio::runtime::Handle::current().block_on(async {
             let username = self
@@ -184,6 +191,24 @@ async fn create_pool(database: &str) -> DbPool {
     establish_pool(database).await
 }
 
+/// Sets up the database connection pool and runs migrations.
+///
+/// Establishes a connection pool for the specified database, audits database-specific features,
+/// and applies any pending migrations. Returns the initialised connection pool on success.
+///
+/// # Arguments
+///
+/// * `database` - The database connection string or file path.
+///
+/// # Returns
+///
+/// A result containing the initialised database connection pool, or an error if setup fails.
+///
+/// # Examples
+///
+/// ```
+/// let pool = setup_database("mxd.db").await?;
+/// ```
 async fn setup_database(database: &str) -> Result<DbPool> {
     let pool = create_pool(database).await;
     {

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -203,7 +203,15 @@ use mxd::db::{
 use mxd::models::{NewArticle, NewCategory, NewFileAcl, NewFileEntry, NewUser};
 use mxd::users::hash_password;
 
-/// Run an async database setup function using a temporary Tokio runtime.
+/// Executes an asynchronous database setup function within a temporary Tokio runtime.
+///
+/// Establishes a database connection, runs migrations, and invokes the provided async closure with the connection. Suitable for preparing test databases synchronously from non-async contexts.
+///
+/// # Parameters
+/// - `db`: Database connection string.
+///
+/// # Returns
+/// Returns `Ok(())` if the setup function completes successfully; otherwise, returns an error.
 pub fn with_db<F>(db: &str, f: F) -> Result<(), Box<dyn std::error::Error>>
 where
     F: for<'c> FnOnce(

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -213,6 +213,9 @@ where
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let mut conn = DbConnection::establish(db).await?;
+        #[cfg(feature = "postgres")]
+        run_migrations(&mut conn, db).await?;
+        #[cfg(not(feature = "postgres"))]
         run_migrations(&mut conn).await?;
         f(&mut conn).await
     })

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -14,6 +14,14 @@ use mxd::transaction_type::TransactionType;
 use test_util::TestServer;
 
 #[test]
+/// Tests that listing news categories at the root path returns all root-level bundles and categories.
+///
+/// Sets up a test server with one bundle ("Bundle") and two categories ("General", "Updates") at the root level.
+/// Sends a transaction requesting news categories at the root path ("/") and verifies that the response contains all expected category names.
+///
+/// # Errors
+///
+/// Returns an error if the test server setup, TCP communication, or protocol validation fails.
 fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
@@ -105,6 +113,19 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+/// Tests that listing news categories with no path parameter returns all root-level bundles and categories.
+///
+/// Sets up a database with one bundle ("Bundle") and two categories ("General", "Updates") not associated with any bundle. Sends a transaction request without a path parameter and verifies that the response contains all three names.
+///
+/// # Errors
+///
+/// Returns an error if the test server setup, database operations, TCP communication, or protocol decoding fails.
+///
+/// # Examples
+///
+/// ```
+/// list_news_categories_no_path().unwrap();
+/// ```
 fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
@@ -195,6 +216,12 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+/// Tests that requesting news categories with an invalid path returns the expected unsupported path error.
+///
+/// Sets up a database with a single category, sends a transaction with an invalid path parameter, and asserts that the server responds with the `NEWS_ERR_PATH_UNSUPPORTED` error code.
+///
+/// # Returns
+/// Returns `Ok(())` if the test passes; otherwise, returns an error if any step fails.
 fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
@@ -252,6 +279,20 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 #[test]
+/// Tests that requesting a list of news categories from an empty database returns no categories.
+///
+/// This test sets up a test server with an empty database, performs a TCP handshake,
+/// sends a news category listing transaction, and asserts that the response contains no category names.
+///
+/// # Errors
+///
+/// Returns an error if the test server setup, TCP communication, or protocol operations fail.
+///
+/// # Examples
+///
+/// ```
+/// list_news_categories_empty().unwrap();
+/// ```
 fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
@@ -318,6 +359,13 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+/// Tests that requesting news categories at a nested bundle path returns only the categories within that sub-bundle.
+///
+/// Sets up a nested bundle structure with a root bundle and a sub-bundle containing a single category. Sends a transaction requesting categories at the nested path and verifies that only the expected category is returned.
+///
+/// # Errors
+///
+/// Returns an error if the test server setup, database operations, TCP communication, or protocol decoding fails.
 fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
     use mxd::models::{NewBundle, NewCategory};
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -19,6 +19,9 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
+            #[cfg(feature = "postgres")]
+            run_migrations(&mut conn, db).await?;
+            #[cfg(not(feature = "postgres"))]
             run_migrations(&mut conn).await?;
             create_bundle(
                 &mut conn,
@@ -107,6 +110,9 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
+            #[cfg(feature = "postgres")]
+            run_migrations(&mut conn, db).await?;
+            #[cfg(not(feature = "postgres"))]
             run_migrations(&mut conn).await?;
             create_bundle(
                 &mut conn,
@@ -194,6 +200,9 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
+            #[cfg(feature = "postgres")]
+            run_migrations(&mut conn, db).await?;
+            #[cfg(not(feature = "postgres"))]
             run_migrations(&mut conn).await?;
             create_category(
                 &mut conn,
@@ -248,6 +257,9 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
+            #[cfg(feature = "postgres")]
+            run_migrations(&mut conn, db).await?;
+            #[cfg(not(feature = "postgres"))]
             run_migrations(&mut conn).await?;
             Ok(())
         })
@@ -312,6 +324,9 @@ fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
+            #[cfg(feature = "postgres")]
+            run_migrations(&mut conn, db).await?;
+            #[cfg(not(feature = "postgres"))]
             run_migrations(&mut conn).await?;
             use mxd::schema::news_bundles::dsl as b;
 


### PR DESCRIPTION
## Summary
- use `AsyncPgConnection` for the Postgres backend
- run Postgres migrations with a temporary synchronous connection
- pass the database URL to `run_migrations` when using Postgres
- adjust tests and utilities for the new signature

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo clippy --no-default-features --features postgres -- -D warnings`
- `cargo build --no-default-features --features postgres`


------
https://chatgpt.com/codex/tasks/task_e_684a0e7bd68c8322b29a4143e9166965

## Summary by Sourcery

Switch the PostgreSQL backend to use asynchronous connections and update the embedded migrations logic and call sites to accommodate a new run_migrations signature.

Enhancements:
- Use diesel_async::AsyncPgConnection for the PostgreSQL DbConnection type
- Refactor run_migrations into separate SQLite and Postgres implementations, spawning a blocking PgConnection for Postgres and requiring the database URL
- Consolidate migrations logic under cfg_if to handle both backends cleanly

Tests:
- Update run_migrations invocations across tests, main.rs, and utilities to pass the database URL when the Postgres feature is enabled

Chores:
- Fix the Postgres version error message formatting in audit_postgres_features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added automatic auditing of PostgreSQL server version to ensure compatibility (requires version 14 or higher).
- **Bug Fixes**
	- Improved handling of database migrations for both SQLite and PostgreSQL backends.
- **Documentation**
	- Enhanced documentation for database setup, migration functions, and test utilities.
	- Added detailed comments to test functions for improved clarity.
- **Chores**
	- Refined internal logic to support conditional behaviour based on the selected database backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->