### PR TITLE
Switch to AsyncPgConnection and clean up tests

### DIFF
--- a/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
+++ b/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
@@ -190,6 +190,11 @@ where
 }
 ```
 
+The real code base uses `diesel_async` for all queries. `MigrationHarness`
+only works with synchronous connections, so `mxd` spawns a blocking task for
+PostgreSQL to run migrations on a temporary `PgConnection` while SQLite relies
+on `SyncConnectionWrapper`.
+
 ---
 
 ### CLI database argument

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,6 +3,7 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::bb8::Pool;
+#[cfg(feature = "sqlite")]
 use diesel_async::sync_connection_wrapper::SyncConnectionWrapper;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 
@@ -14,10 +15,11 @@ cfg_if! {
         pub type DbConnection = SyncConnectionWrapper<SqliteConnection>;
         pub type DbPool = Pool<DbConnection>;
     } else if #[cfg(feature = "postgres")] {
-        use diesel::pg::{Pg, PgConnection};
+        use diesel::pg::Pg;
+        use diesel_async::AsyncPgConnection;
         pub type Backend = Pg;
         pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/postgres");
-        pub type DbConnection = SyncConnectionWrapper<PgConnection>;
+        pub type DbConnection = AsyncPgConnection;
         pub type DbPool = Pool<DbConnection>;
     } else {
         compile_error!("Either feature 'sqlite' or 'postgres' must be enabled");
@@ -37,22 +39,50 @@ pub async fn establish_pool(database_url: &str) -> DbPool {
         .expect("Failed to create pool")
 }
 
-/// Run embedded database migrations.
-///
-/// # Errors
-/// Returns any error produced by Diesel while running migrations.
-#[must_use = "handle the result"]
-pub async fn run_migrations(conn: &mut DbConnection) -> QueryResult<()> {
-    use diesel::result::Error as DieselError;
-    conn.spawn_blocking(|c| {
-        c.run_pending_migrations(MIGRATIONS)
-            .map(|_| ())
+cfg_if! {
+    if #[cfg(feature = "sqlite")] {
+        /// Run embedded database migrations.
+        ///
+        /// # Errors
+        /// Returns any error produced by Diesel while running migrations.
+        #[must_use = "handle the result"]
+        pub async fn run_migrations(conn: &mut DbConnection) -> QueryResult<()> {
+            use diesel::result::Error as DieselError;
+            conn.spawn_blocking(|c| {
+                c.run_pending_migrations(MIGRATIONS)
+                    .map(|_| ())
+                    .map_err(|e| {
+                        DieselError::QueryBuilderError(Box::new(std::io::Error::other(e.to_string())))
+                    })
+            })
+            .await?;
+            Ok(())
+        }
+    } else if #[cfg(feature = "postgres")] {
+        /// Run embedded database migrations.
+        ///
+        /// # Errors
+        /// Returns any error produced by Diesel while running migrations.
+        #[must_use = "handle the result"]
+        pub async fn run_migrations(database_url: &str) -> QueryResult<()> {
+            use diesel::pg::PgConnection;
+            use diesel::result::Error as DieselError;
+            let url = database_url.to_owned();
+            tokio::task::spawn_blocking(move || -> QueryResult<()> {
+                let mut conn = PgConnection::establish(&url)
+                    .map_err(|e| DieselError::QueryBuilderError(Box::new(e)))?;
+                conn.run_pending_migrations(MIGRATIONS)
+                    .map(|_| ())
+                    .map_err(|e| {
+                        DieselError::QueryBuilderError(Box::new(std::io::Error::other(e.to_string())))
+                    })
+            })
+            .await
             .map_err(|e| {
                 DieselError::QueryBuilderError(Box::new(std::io::Error::other(e.to_string())))
-            })
-    })
-    .await?;
-    Ok(())
+            })?
+        }
+    }
 }
 
 /// Verify that `SQLite` supports features required by the application.
@@ -122,8 +152,7 @@ pub async fn audit_postgres_features(
     if major < 14 {
         return Err(DieselError::QueryBuilderError(Box::new(
             std::io::Error::other(format!(
-                "postgres version {} is not supported (require >= 14)",
-                major
+                "postgres version {major} is not supported (require >= 14)"
             )),
         )));
     }
@@ -494,9 +523,11 @@ pub async fn list_files_for_user(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "sqlite")]
     use crate::models::{NewBundle, NewCategory, NewUser};
     use diesel_async::AsyncConnection;
 
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn test_create_and_get_user() {
         let mut conn = DbConnection::establish(":memory:").await.unwrap();
@@ -512,6 +543,7 @@ mod tests {
     }
 
     // basic smoke test for migrations and insertion
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn test_create_bundle_and_category() {
         let mut conn = DbConnection::establish(":memory:").await.unwrap();
@@ -529,6 +561,7 @@ mod tests {
         let _names = list_names_at_path(&mut conn, None).await.unwrap();
     }
 
+    #[cfg(feature = "sqlite")]
     #[tokio::test]
     async fn test_audit_features() {
         let mut conn = DbConnection::establish(":memory:").await.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,9 @@ impl Run for CreateUserArgs {
                 password: &hashed,
             };
             let mut conn = DbConnection::establish(&cfg.database).await?;
+            #[cfg(feature = "postgres")]
+            run_migrations(&cfg.database).await?;
+            #[cfg(feature = "sqlite")]
             run_migrations(&mut conn).await?;
             create_user(&mut conn, &new_user).await?;
             println!("User {username} created");
@@ -189,6 +192,9 @@ async fn setup_database(database: &str) -> Result<DbPool> {
         audit_sqlite_features(&mut conn).await?;
         #[cfg(feature = "postgres")]
         audit_postgres_features(&mut conn).await?;
+        #[cfg(feature = "postgres")]
+        run_migrations(database).await?;
+        #[cfg(feature = "sqlite")]
         run_migrations(&mut conn).await?;
     }
     Ok(pool)

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -5,152 +5,24 @@ use diesel::prelude::*;
 use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
 use mxd::commands::NEWS_ERR_PATH_UNSUPPORTED;
-use mxd::db::{DbConnection, create_bundle, create_category, run_migrations};
+use mxd::db::{DbConnection, create_bundle, create_category};
 use mxd::field_id::FieldId;
 use mxd::models::NewCategory;
 use mxd::transaction::encode_params;
 use mxd::transaction::{FrameHeader, Transaction, decode_params};
 use mxd::transaction_type::TransactionType;
-use test_util::TestServer;
+use test_util::{TestServer, apply_migrations, handshake};
 
-#[test]
-fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
-    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
-        let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            let mut conn = DbConnection::establish(db).await?;
-            run_migrations(&mut conn).await?;
-            create_bundle(
-                &mut conn,
-                &mxd::models::NewBundle {
-                    parent_bundle_id: None,
-                    name: "Bundle",
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "General",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "Updates",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            Ok(())
-        })
-    })?;
-
-    let port = server.port();
+fn list_categories(
+    port: u16,
+    path: Option<&str>,
+) -> Result<(FrameHeader, Vec<String>), Box<dyn std::error::Error>> {
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
-    let mut handshake = Vec::new();
-    handshake.extend_from_slice(b"TRTP");
-    handshake.extend_from_slice(&0u32.to_be_bytes());
-    handshake.extend_from_slice(&1u16.to_be_bytes());
-    handshake.extend_from_slice(&0u16.to_be_bytes());
-    stream.write_all(&handshake)?;
-
-    let mut reply = [0u8; 8];
-    stream.read_exact(&mut reply)?;
-    assert_eq!(&reply[0..4], b"TRTP");
-    assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
-
-    let params = vec![(FieldId::NewsPath, b"/".as_ref())];
+    handshake(&mut stream)?;
+    let params = path
+        .map(|p| vec![(FieldId::NewsPath, p.as_bytes())])
+        .unwrap_or_default();
     let payload = encode_params(&params)?;
-    let header = FrameHeader {
-        flags: 0,
-        is_reply: 0,
-        ty: TransactionType::NewsCategoryNameList.into(),
-        id: 3,
-        error: 0,
-        total_size: payload.len() as u32,
-        data_size: payload.len() as u32,
-    };
-    let tx = Transaction { header, payload };
-    let frame = tx.to_bytes();
-    stream.write_all(&frame)?;
-
-    let mut hdr_buf = [0u8; 20];
-    stream.read_exact(&mut hdr_buf)?;
-    let hdr = FrameHeader::from_bytes(&hdr_buf);
-    let mut data = vec![0u8; hdr.data_size as usize];
-    stream.read_exact(&mut data)?;
-    let reply_tx = Transaction {
-        header: hdr,
-        payload: data,
-    };
-    let params = decode_params(&reply_tx.payload)?;
-    let names = params
-        .into_iter()
-        .filter_map(|(id, d)| {
-            if id == FieldId::NewsCategory {
-                Some(String::from_utf8(d).unwrap())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(names, vec!["Bundle", "General", "Updates"]);
-    Ok(())
-}
-
-#[test]
-fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
-    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
-        let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            let mut conn = DbConnection::establish(db).await?;
-            run_migrations(&mut conn).await?;
-            create_bundle(
-                &mut conn,
-                &mxd::models::NewBundle {
-                    parent_bundle_id: None,
-                    name: "Bundle",
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "General",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "Updates",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            Ok(())
-        })
-    })?;
-
-    let port = server.port();
-    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
-    let mut handshake = Vec::new();
-    handshake.extend_from_slice(b"TRTP");
-    handshake.extend_from_slice(&0u32.to_be_bytes());
-    handshake.extend_from_slice(&1u16.to_be_bytes());
-    handshake.extend_from_slice(&0u16.to_be_bytes());
-    stream.write_all(&handshake)?;
-
-    let mut reply = [0u8; 8];
-    stream.read_exact(&mut reply)?;
-    assert_eq!(&reply[0..4], b"TRTP");
-    assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
-
-    let payload = encode_params(&[])?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -161,8 +33,7 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
         data_size: payload.len() as u32,
     };
     let tx = Transaction { header, payload };
-    let frame = tx.to_bytes();
-    stream.write_all(&frame)?;
+    stream.write_all(&tx.to_bytes())?;
 
     let mut hdr_buf = [0u8; 20];
     stream.read_exact(&mut hdr_buf)?;
@@ -183,7 +54,88 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
                 None
             }
         })
-        .collect::<Vec<_>>();
+        .collect();
+    Ok((reply_tx.header, names))
+}
+
+#[test]
+fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
+    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let mut conn = DbConnection::establish(db).await?;
+            apply_migrations(&mut conn, db).await?;
+            create_bundle(
+                &mut conn,
+                &mxd::models::NewBundle {
+                    parent_bundle_id: None,
+                    name: "Bundle",
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "Updates",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    })?;
+
+    let port = server.port();
+    let (_, names) = list_categories(port, Some("/"))?;
+    assert_eq!(names, vec!["Bundle", "General", "Updates"]);
+    Ok(())
+}
+
+#[test]
+fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
+    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let mut conn = DbConnection::establish(db).await?;
+            apply_migrations(&mut conn, db).await?;
+            create_bundle(
+                &mut conn,
+                &mxd::models::NewBundle {
+                    parent_bundle_id: None,
+                    name: "Bundle",
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "General",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            create_category(
+                &mut conn,
+                &NewCategory {
+                    name: "Updates",
+                    bundle_id: None,
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    })?;
+
+    let port = server.port();
+    let (_, names) = list_categories(port, None)?;
     assert_eq!(names, vec!["Bundle", "General", "Updates"]);
     Ok(())
 }
@@ -194,7 +146,7 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
-            run_migrations(&mut conn).await?;
+            apply_migrations(&mut conn, db).await?;
             create_category(
                 &mut conn,
                 &NewCategory {
@@ -208,37 +160,7 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
     })?;
 
     let port = server.port();
-    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
-    let mut handshake = Vec::new();
-    handshake.extend_from_slice(b"TRTP");
-    handshake.extend_from_slice(&0u32.to_be_bytes());
-    handshake.extend_from_slice(&1u16.to_be_bytes());
-    handshake.extend_from_slice(&0u16.to_be_bytes());
-    stream.write_all(&handshake)?;
-
-    let mut reply = [0u8; 8];
-    stream.read_exact(&mut reply)?;
-    assert_eq!(&reply[0..4], b"TRTP");
-    assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
-
-    let params = vec![(FieldId::NewsPath, b"some/path".as_ref())];
-    let payload = encode_params(&params)?;
-    let header = FrameHeader {
-        flags: 0,
-        is_reply: 0,
-        ty: TransactionType::NewsCategoryNameList.into(),
-        id: 2,
-        error: 0,
-        total_size: payload.len() as u32,
-        data_size: payload.len() as u32,
-    };
-    let tx = Transaction { header, payload };
-    let frame = tx.to_bytes();
-    stream.write_all(&frame)?;
-
-    let mut hdr_buf = [0u8; 20];
-    stream.read_exact(&mut hdr_buf)?;
-    let hdr = FrameHeader::from_bytes(&hdr_buf);
+    let (hdr, _) = list_categories(port, Some("some/path"))?;
     assert_eq!(hdr.error, NEWS_ERR_PATH_UNSUPPORTED);
     Ok(())
 }
@@ -248,59 +170,13 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
-            run_migrations(&mut conn).await?;
+            apply_migrations(&mut conn, db).await?;
             Ok(())
         })
     })?;
 
     let port = server.port();
-    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
-    let mut handshake = Vec::new();
-    handshake.extend_from_slice(b"TRTP");
-    handshake.extend_from_slice(&0u32.to_be_bytes());
-    handshake.extend_from_slice(&1u16.to_be_bytes());
-    handshake.extend_from_slice(&0u16.to_be_bytes());
-    stream.write_all(&handshake)?;
-
-    let mut reply = [0u8; 8];
-    stream.read_exact(&mut reply)?;
-    assert_eq!(&reply[0..4], b"TRTP");
-    assert_eq!(u32::from_be_bytes(reply[4..8].try_into().unwrap()), 0);
-
-    let payload = encode_params(&[])?;
-    let header = FrameHeader {
-        flags: 0,
-        is_reply: 0,
-        ty: TransactionType::NewsCategoryNameList.into(),
-        id: 4,
-        error: 0,
-        total_size: payload.len() as u32,
-        data_size: payload.len() as u32,
-    };
-    let tx = Transaction { header, payload };
-    let frame = tx.to_bytes();
-    stream.write_all(&frame)?;
-
-    let mut hdr_buf = [0u8; 20];
-    stream.read_exact(&mut hdr_buf)?;
-    let hdr = FrameHeader::from_bytes(&hdr_buf);
-    let mut data = vec![0u8; hdr.data_size as usize];
-    stream.read_exact(&mut data)?;
-    let reply_tx = Transaction {
-        header: hdr,
-        payload: data,
-    };
-    let params = decode_params(&reply_tx.payload)?;
-    let names: Vec<String> = params
-        .into_iter()
-        .filter_map(|(id, d)| {
-            if id == FieldId::NewsCategory {
-                Some(String::from_utf8(d).unwrap())
-            } else {
-                None
-            }
-        })
-        .collect();
+    let (_, names) = list_categories(port, None)?;
     assert!(names.is_empty());
     Ok(())
 }
@@ -312,7 +188,7 @@ fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let mut conn = DbConnection::establish(db).await?;
-            run_migrations(&mut conn).await?;
+            apply_migrations(&mut conn, db).await?;
             use mxd::schema::news_bundles::dsl as b;
 
             create_bundle(
@@ -358,50 +234,7 @@ fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     let port = server.port();
-    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
-    let mut handshake = Vec::new();
-    handshake.extend_from_slice(b"TRTP");
-    handshake.extend_from_slice(&0u32.to_be_bytes());
-    handshake.extend_from_slice(&1u16.to_be_bytes());
-    handshake.extend_from_slice(&0u16.to_be_bytes());
-    stream.write_all(&handshake)?;
-    let mut reply = [0u8; 8];
-    stream.read_exact(&mut reply)?;
-
-    let params = vec![(FieldId::NewsPath, b"Bundle/Sub".as_ref())];
-    let payload = encode_params(&params)?;
-    let header = FrameHeader {
-        flags: 0,
-        is_reply: 0,
-        ty: TransactionType::NewsCategoryNameList.into(),
-        id: 5,
-        error: 0,
-        total_size: payload.len() as u32,
-        data_size: payload.len() as u32,
-    };
-    let tx = Transaction { header, payload };
-    stream.write_all(&tx.to_bytes())?;
-
-    let mut hdr_buf = [0u8; 20];
-    stream.read_exact(&mut hdr_buf)?;
-    let hdr = FrameHeader::from_bytes(&hdr_buf);
-    let mut data = vec![0u8; hdr.data_size as usize];
-    stream.read_exact(&mut data)?;
-    let reply_tx = Transaction {
-        header: hdr,
-        payload: data,
-    };
-    let params = decode_params(&reply_tx.payload)?;
-    let names: Vec<String> = params
-        .into_iter()
-        .filter_map(|(id, d)| {
-            if id == FieldId::NewsCategory {
-                Some(String::from_utf8(d).unwrap())
-            } else {
-                None
-            }
-        })
-        .collect();
+    let (_, names) = list_categories(port, Some("Bundle/Sub"))?;
     assert_eq!(names, vec!["Inside"]);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- use `AsyncPgConnection` for the Postgres backend
- pass only the database URL to run migrations for Postgres
- provide `apply_migrations` helper for tests
- deduplicate category list tests using a new helper

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`
- `cargo clippy --no-default-features --features postgres -- -D warnings`
- `cargo build --no-default-features --features postgres`
- `markdownlint docs/supporting-both-sqlite3-and-postgresql-in-diesel.md`
- `nixie docs/supporting-both-sqlite3-and-postgresql-in-diesel.md`


------
https://chatgpt.com/codex/tasks/task_e_684a0e7bd68c8322b29a4143e9166965