### PR TITLE
Run rustfmt

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -37,8 +37,11 @@ cfg_if! {
 ///
 /// # Examples
 ///
-/// ```
-/// let pool = establish_pool("sqlite::memory:").await;
+/// ```no_run
+/// use mxd::db::establish_pool;
+/// async fn example() {
+///     let pool = establish_pool("sqlite::memory:").await;
+/// }
 /// ```
 pub async fn establish_pool(database_url: &str) -> DbPool {
     let config = AsyncDieselConnectionManager::<DbConnection>::new(database_url);

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -203,7 +203,7 @@ use chrono::{DateTime, Utc};
 use diesel_async::{AsyncConnection, RunQueryDsl};
 use futures_util::future::BoxFuture;
 use mxd::db::{
-    apply_migrations, add_file_acl, create_category, create_file, create_user, DbConnection,
+    DbConnection, add_file_acl, apply_migrations, create_category, create_file, create_user,
 };
 use mxd::models::{NewArticle, NewCategory, NewFileAcl, NewFileEntry, NewUser};
 use mxd::users::hash_password;


### PR DESCRIPTION
## Summary
- format crates using `cargo fmt`
- correct doctest snippet for `establish_pool`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684a3492a6a08322b92dcb9ecb12b4e7

## Summary by Sourcery

Format codebase with `cargo fmt` and update the `establish_pool` documentation example to be valid in doctests

Enhancements:
- Apply `rustfmt` formatting across all crates

Documentation:
- Correct the `establish_pool` doctest by adding `no_run`, import statement, and an async wrapper