### PR TITLE
Reduce news category test length

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -349,12 +349,29 @@ pub async fn create_category(
 pub async fn create_bundle(
     conn: &mut DbConnection,
     bun: &crate::models::NewBundle<'_>,
-) -> QueryResult<usize> {
-    use crate::schema::news_bundles::dsl::news_bundles;
-    diesel::insert_into(news_bundles)
+) -> QueryResult<i32> {
+    use crate::schema::news_bundles::dsl as b;
+
+    #[cfg(feature = "returning_clauses_for_sqlite_3_35")]
+    let inserted_id: i32 = diesel::insert_into(b::news_bundles)
         .values(bun)
-        .execute(conn)
-        .await
+        .returning(b::id)
+        .get_result(conn)
+        .await?;
+
+    #[cfg(not(feature = "returning_clauses_for_sqlite_3_35"))]
+    let inserted_id: i32 = {
+        use diesel::sql_types::Integer;
+        diesel::insert_into(b::news_bundles)
+            .values(bun)
+            .execute(conn)
+            .await?;
+        diesel::select(diesel::dsl::sql::<Integer>("last_insert_rowid()"))
+            .get_result(conn)
+            .await?
+    };
+
+    Ok(inserted_id)
 }
 
 /// Retrieve a single article by path and identifier.
@@ -595,7 +612,7 @@ mod tests {
             parent_bundle_id: None,
             name: "Bundle",
         };
-        create_bundle(&mut conn, &bun).await.unwrap();
+        let _ = create_bundle(&mut conn, &bun).await.unwrap();
         let cat = NewCategory {
             name: "General",
             bundle_id: None,

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -338,12 +338,10 @@ pub fn setup_news_db(db: &str) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Populate the database with a bundle and two categories at the root level.
-pub fn setup_news_categories_root_db(
-    db: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn setup_news_categories_root_db(db: &str) -> Result<(), Box<dyn std::error::Error>> {
     with_db(db, |conn| {
         Box::pin(async move {
-            use mxd::db::{create_category};
+            use mxd::db::create_category;
 
             let _ = insert_root_bundle(conn).await?;
 
@@ -369,9 +367,7 @@ pub fn setup_news_categories_root_db(
 }
 
 /// Populate the database with a nested bundle containing a single category.
-pub fn setup_news_categories_nested_db(
-    db: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn setup_news_categories_nested_db(db: &str) -> Result<(), Box<dyn std::error::Error>> {
     with_db(db, |conn| {
         Box::pin(async move {
             use mxd::db::{create_bundle, create_category};
@@ -401,9 +397,7 @@ pub fn setup_news_categories_nested_db(
     })
 }
 
-async fn insert_root_bundle(
-    conn: &mut DbConnection,
-) -> Result<i32, Box<dyn std::error::Error>> {
+async fn insert_root_bundle(conn: &mut DbConnection) -> Result<i32, Box<dyn std::error::Error>> {
     use mxd::db::create_bundle;
     use mxd::models::NewBundle;
 

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -343,15 +343,10 @@ pub fn setup_news_categories_root_db(
 ) -> Result<(), Box<dyn std::error::Error>> {
     with_db(db, |conn| {
         Box::pin(async move {
-            use mxd::db::{create_bundle, create_category};
-            let _ = create_bundle(
-                conn,
-                &mxd::models::NewBundle {
-                    parent_bundle_id: None,
-                    name: "Bundle",
-                },
-            )
-            .await?;
+            use mxd::db::{create_category};
+
+            let _ = insert_root_bundle(conn).await?;
+
             let _ = create_category(
                 conn,
                 &mxd::models::NewCategory {
@@ -380,16 +375,9 @@ pub fn setup_news_categories_nested_db(
     with_db(db, |conn| {
         Box::pin(async move {
             use mxd::db::{create_bundle, create_category};
-            use mxd::models::{NewBundle, NewCategory};
+            use mxd::models::NewBundle;
 
-            let root_id = create_bundle(
-                conn,
-                &NewBundle {
-                    parent_bundle_id: None,
-                    name: "Bundle",
-                },
-            )
-            .await?;
+            let root_id = insert_root_bundle(conn).await?;
 
             let sub_id = create_bundle(
                 conn,
@@ -402,7 +390,7 @@ pub fn setup_news_categories_nested_db(
 
             let _ = create_category(
                 conn,
-                &NewCategory {
+                &mxd::models::NewCategory {
                     name: "Inside",
                     bundle_id: Some(sub_id),
                 },
@@ -411,4 +399,22 @@ pub fn setup_news_categories_nested_db(
             Ok(())
         })
     })
+}
+
+async fn insert_root_bundle(
+    conn: &mut DbConnection,
+) -> Result<i32, Box<dyn std::error::Error>> {
+    use mxd::db::create_bundle;
+    use mxd::models::NewBundle;
+
+    let id = create_bundle(
+        conn,
+        &NewBundle {
+            parent_bundle_id: None,
+            name: "Bundle",
+        },
+    )
+    .await?;
+
+    Ok(id)
 }

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -70,11 +70,11 @@ fn list_categories(
 ///
 /// Returns an error if the test server setup, TCP communication, or protocol validation fails.
 fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
-    let server =
-        TestServer::start_with_setup("./Cargo.toml", |db| setup_news_categories_root_db(db))?;
+    let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_root_db)?;
 
     let port = server.port();
-    let (_, names) = list_categories(port, Some("/"))?;
+    let (_, mut names) = list_categories(port, Some("/"))?;
+    names.sort();
     assert_eq!(names, vec!["Bundle", "General", "Updates"]);
     Ok(())
 }
@@ -94,11 +94,11 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
 /// list_news_categories_no_path().unwrap();
 /// ```
 fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
-    let server =
-        TestServer::start_with_setup("./Cargo.toml", |db| setup_news_categories_root_db(db))?;
+    let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_root_db)?;
 
     let port = server.port();
-    let (_, names) = list_categories(port, None)?;
+    let (_, mut names) = list_categories(port, None)?;
+    names.sort();
     assert_eq!(names, vec!["Bundle", "General", "Updates"]);
     Ok(())
 }
@@ -173,8 +173,7 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// Returns an error if the test server setup, database operations, TCP communication, or protocol decoding fails.
 fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
-    let server =
-        TestServer::start_with_setup("./Cargo.toml", |db| setup_news_categories_nested_db(db))?;
+    let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_nested_db)?;
 
     let port = server.port();
     let (_, names) = list_categories(port, Some("Bundle/Sub"))?;

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -1,18 +1,17 @@
 use std::io::{Read, Write};
 use std::net::TcpStream;
 
-use diesel::prelude::*;
 use diesel_async::AsyncConnection;
-use diesel_async::RunQueryDsl;
 use mxd::commands::NEWS_ERR_PATH_UNSUPPORTED;
-use mxd::db::apply_migrations;
-use mxd::db::{DbConnection, create_bundle, create_category};
+use mxd::db::{DbConnection, apply_migrations, create_category};
 use mxd::field_id::FieldId;
 use mxd::models::NewCategory;
 use mxd::transaction::encode_params;
 use mxd::transaction::{FrameHeader, Transaction, decode_params};
 use mxd::transaction_type::TransactionType;
-use test_util::{TestServer, handshake};
+use test_util::{
+    TestServer, handshake, setup_news_categories_nested_db, setup_news_categories_root_db,
+};
 
 fn list_categories(
     port: u16,
@@ -71,38 +70,8 @@ fn list_categories(
 ///
 /// Returns an error if the test server setup, TCP communication, or protocol validation fails.
 fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
-    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
-        let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            let mut conn = DbConnection::establish(db).await?;
-            apply_migrations(&mut conn, db).await?;
-            create_bundle(
-                &mut conn,
-                &mxd::models::NewBundle {
-                    parent_bundle_id: None,
-                    name: "Bundle",
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "General",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "Updates",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            Ok(())
-        })
-    })?;
+    let server =
+        TestServer::start_with_setup("./Cargo.toml", |db| setup_news_categories_root_db(db))?;
 
     let port = server.port();
     let (_, names) = list_categories(port, Some("/"))?;
@@ -125,38 +94,8 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
 /// list_news_categories_no_path().unwrap();
 /// ```
 fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
-    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
-        let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            let mut conn = DbConnection::establish(db).await?;
-            apply_migrations(&mut conn, db).await?;
-            create_bundle(
-                &mut conn,
-                &mxd::models::NewBundle {
-                    parent_bundle_id: None,
-                    name: "Bundle",
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "General",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "Updates",
-                    bundle_id: None,
-                },
-            )
-            .await?;
-            Ok(())
-        })
-    })?;
+    let server =
+        TestServer::start_with_setup("./Cargo.toml", |db| setup_news_categories_root_db(db))?;
 
     let port = server.port();
     let (_, names) = list_categories(port, None)?;
@@ -234,55 +173,8 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// Returns an error if the test server setup, database operations, TCP communication, or protocol decoding fails.
 fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
-    use mxd::models::{NewBundle, NewCategory};
-    let server = TestServer::start_with_setup("./Cargo.toml", |db| {
-        let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            let mut conn = DbConnection::establish(db).await?;
-            apply_migrations(&mut conn, db).await?;
-            use mxd::schema::news_bundles::dsl as b;
-
-            create_bundle(
-                &mut conn,
-                &NewBundle {
-                    parent_bundle_id: None,
-                    name: "Bundle",
-                },
-            )
-            .await?;
-            let root_id: i32 = b::news_bundles
-                .filter(b::name.eq("Bundle"))
-                .filter(b::parent_bundle_id.is_null())
-                .select(b::id)
-                .first(&mut conn)
-                .await?;
-
-            create_bundle(
-                &mut conn,
-                &NewBundle {
-                    parent_bundle_id: Some(root_id),
-                    name: "Sub",
-                },
-            )
-            .await?;
-            let sub_id: i32 = b::news_bundles
-                .filter(b::name.eq("Sub"))
-                .filter(b::parent_bundle_id.eq(root_id))
-                .select(b::id)
-                .first(&mut conn)
-                .await?;
-
-            create_category(
-                &mut conn,
-                &NewCategory {
-                    name: "Inside",
-                    bundle_id: Some(sub_id),
-                },
-            )
-            .await?;
-            Ok(())
-        })
-    })?;
+    let server =
+        TestServer::start_with_setup("./Cargo.toml", |db| setup_news_categories_nested_db(db))?;
 
     let port = server.port();
     let (_, names) = list_categories(port, Some("Bundle/Sub"))?;


### PR DESCRIPTION
## Summary
- cut duplication in news category integration tests
- add DB seeding helpers for news categories

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684a37d416488322ab583dcdac8c4fad

## Summary by Sourcery

Extract common database seeding logic into reusable helpers and streamline news category integration tests.

Enhancements:
- Introduce setup_news_categories_root_db and setup_news_categories_nested_db helpers in test-util for centralized DB seeding.
- Refactor news_categories integration tests to leverage the new helpers and eliminate repetitive inline setup code.
- Remove obsolete imports and tidy up test module dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined test setup by using reusable helper functions for database initialisation in news categories tests, reducing code duplication.
- **Chores**
	- Centralised database setup logic for tests, making test maintenance easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->