### PR TITLE
Fix clippy doc_markdown lint

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -146,7 +146,7 @@ pub async fn audit_sqlite_features(conn: &mut DbConnection) -> QueryResult<()> {
 /// cannot be parsed.
 #[cfg(feature = "postgres")]
 #[must_use = "handle the result"]
-/// Checks that the connected PostgreSQL server version is at least 14.
+/// Checks that the connected `PostgreSQL` server version is at least 14.
 ///
 /// Executes a version query and parses the result, returning an error if the version is unsupported or cannot be determined.
 ///


### PR DESCRIPTION
## Summary
- fix doc comment to escape `PostgreSQL`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `markdownlint docs/*.md README.md`
- `nixie docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_684aa9e5039883229fe28dd55ecc7bb6

## Summary by Sourcery

Documentation:
- Escape `PostgreSQL` in a doc comment to satisfy the doc_markdown lint.