### PR TITLE
Fix Postgres feature instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           cargo llvm-cov --workspace --features sqlite --lcov --output-path lcov-sqlite.info
       - name: Generate coverage for Postgres
         run: |
-          cargo llvm-cov --workspace --features postgres --lcov --output-path lcov-postgres.info
+          cargo llvm-cov --workspace --no-default-features --features postgres --lcov --output-path lcov-postgres.info
       - name: Merge coverage results
         run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
       - name: Install cs tool

--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ daemon checks this at startup and refuses to launch on older versions.
 
 mxd supports both SQLite and PostgreSQL backends. Select one at compile
 time using `--features sqlite` or `--features postgres`. Exactly one of
-these features must be enabled for a successful build.
+these features must be enabled for a successful build. Because the
+`sqlite` feature is enabled by default, you must disable default
+features when opting into PostgreSQL:
+
+```bash
+cargo run --no-default-features --features postgres -- --help
+```
+
+The same applies to `cargo build` and `cargo test` commands targeting
+PostgreSQL.
 **Note**: PostgreSQL backend support is currently a work in progress.
 
 ## Running
@@ -45,9 +54,9 @@ cargo build --features sqlite
 
 # Run server listening on the default address
 cargo run --features sqlite -- --bind 0.0.0.0:5500 --database mxd.db
- 
+
 # PostgreSQL example
-# cargo run --features postgres -- --database postgres://user:pass@localhost/mxd
+# cargo run --no-default-features --features postgres -- --database postgres://user:pass@localhost/mxd
 ```
 
 ### Creating users

--- a/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
+++ b/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
@@ -3,8 +3,11 @@
 Build the application with PostgreSQL support enabled:
 
 ```bash
-cargo build --features postgres
+cargo build --no-default-features --features postgres
 ```
+
+The `sqlite` feature is enabled by default, so `--no-default-features`
+is required when targeting PostgreSQL.
 
 Build the application with SQLite support enabled:
 
@@ -217,7 +220,7 @@ Non-URL strings are treated as SQLite paths.
 - When using PostgreSQL, ensure the server version is **14 or greater**.
   The application performs a runtime check and fails on older versions.
 
-With that structure you can `cargo build --features postgres` for the version
-that targets *postgresql-embedded* (or a real server) and
+With that structure you can `cargo build --no-default-features --features postgres`
+for the version that targets *postgresql-embedded* (or a real server) and
 `cargo build --features sqlite` for the lightweight single-file deployment,
 without touching the migration history.


### PR DESCRIPTION
## Summary
- document that the default `sqlite` feature must be disabled when compiling for PostgreSQL
- update examples in README and backend guide
- set `--no-default-features` for Postgres coverage step in CI

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `markdownlint README.md docs/supporting-both-sqlite3-and-postgresql-in-diesel.md`
- `nixie README.md docs/supporting-both-sqlite3-and-postgresql-in-diesel.md`


------
https://chatgpt.com/codex/tasks/task_e_684aae18b744832288d3f11bd5d23448