### PR TITLE
Fix warnings when compiling with postgres feature

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -615,7 +615,6 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_audit_postgres() {
-        use diesel_async::AsyncConnection;
         use postgresql_embedded::PostgreSQL;
 
         let mut pg = PostgreSQL::default();

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -103,7 +103,28 @@ impl TestServer {
         Self::start_with_setup(manifest_path, |_| Ok(()))
     }
 
-    /// Start the server and run a setup function before launching.
+    /// Starts the test server after running a setup function on a temporary database.
+    ///
+    /// The setup function is called with the database URL before the server is launched, allowing initialisation or seeding of the database for integration tests. The server is started on a random available port.
+    ///
+    /// # Parameters
+    /// - `manifest_path`: Path to the Cargo manifest for the server binary.
+    /// - `setup`: Function to run database setup logic, receiving the database URL.
+    ///
+    /// # Returns
+    /// Returns a `TestServer` instance managing the server process and test database.
+    ///
+    /// # Errors
+    /// Returns an error if temporary directory creation, database setup, server startup, or protocol handshake fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let server = TestServer::start_with_setup("path/to/Cargo.toml", |db_url| {
+    ///     // Custom setup logic here
+    ///     Ok(())
+    /// })?;
+    /// ```
     pub fn start_with_setup<F>(
         manifest_path: &str,
         setup: F,

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -117,7 +117,7 @@ impl TestServer {
         let db_url = setup_sqlite(&temp, setup)?;
 
         #[cfg(feature = "postgres")]
-        let (db_url, mut pg) = setup_postgres(setup)?;
+        let (db_url, pg) = setup_postgres(setup)?;
 
         #[cfg(feature = "postgres")]
         let db_url = db_url;


### PR DESCRIPTION
## Summary
- fix unused `pg` binding in test-util
- remove unused import in db tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --no-default-features --features postgres` *(fails: DatabaseInitializationError due to running as root)*

------
https://chatgpt.com/codex/tasks/task_e_684ab2a3059883229056b37370a57502

## Summary by Sourcery

Fix unused bindings and imports to eliminate compilation warnings when building with the Postgres feature.

Bug Fixes:
- Remove unused mutable binding on `pg` from Postgres setup in test-util.
- Remove unused `diesel_async::AsyncConnection` import from Postgres tests in db.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed an unused import to improve code cleanliness.
  - Updated variable mutability for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->