### PR TITLE
Add build targets for Postgres and SQLite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,21 @@
-.PHONY: corpus
+.PHONY: corpus sqlite postgres sqlite-release postgres-release
+
 corpus:
 	cargo run --bin gen_corpus
+
+sqlite: target/debug/mxd
+postgres: target/postgres/debug/mxd
+sqlite-release: target/release/mxd
+postgres-release: target/postgres/release/mxd
+
+target/debug/mxd:
+	cargo build --bin mxd --features sqlite
+
+target/postgres/debug/mxd:
+	cargo build --bin mxd --no-default-features --features postgres --target-dir target/postgres
+
+target/release/mxd:
+	cargo build --release --bin mxd --features sqlite
+
+target/postgres/release/mxd:
+	cargo build --release --bin mxd --no-default-features --features postgres --target-dir target/postgres


### PR DESCRIPTION
## Summary
- add Makefile targets for debug and release builds of each backend

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ab6ef18e0832283f4c4ddd85e3c11

## Summary by Sourcery

Add Makefile targets to build the mxd binary with SQLite and Postgres backends in both debug and release modes.

New Features:
- Introduce 'sqlite' and 'sqlite-release' targets for building with the SQLite feature.
- Introduce 'postgres' and 'postgres-release' targets for building with the Postgres feature using an isolated target directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added new build options for creating binaries with either SQLite or Postgres support, available for both debug and release modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->