### PR TITLE
Handle errors from embedded Postgres startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ dependencies = [
 name = "test-util"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "argon2",
  "chrono",
  "diesel",

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,7 +15,7 @@ postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = tru
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
-anyhow = "1"
+anyhow = { version = "1", optional = true }
 
 [features]
 default = ["sqlite"]
@@ -25,6 +25,7 @@ postgres = [
     "mxd/postgres",
     "postgresql_embedded",
     "diesel_migrations/postgres",
+    "anyhow",
 ]
 sqlite = [
     "diesel/sqlite",

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,6 +15,7 @@ postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = tru
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
+anyhow = "1"
 
 [features]
 default = ["sqlite"]

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -39,6 +39,9 @@ where
 }
 
 #[cfg(feature = "postgres")]
+/// Sets up an embedded PostgreSQL instance for testing and applies a custom setup function.
+///
+/// Starts an embedded PostgreSQL server, creates a test database, and invokes the provided setup function with the database URL. Returns the database URL and the running PostgreSQL instance. If any step fails, ensures the PostgreSQL instance is stopped and returns an error.
 fn setup_postgres<F>(setup: F) -> Result<(String, PostgreSQL), Box<dyn std::error::Error>>
 where
     F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
@@ -153,6 +156,27 @@ impl TestServer {
     ///     // Custom setup logic here
     ///     Ok(())
     /// })?;
+    /// Starts a test instance of the "mxd" server with a temporary database and custom setup.
+    ///
+    /// Creates a temporary directory, sets up a SQLite or PostgreSQL database using the provided setup function, reserves an ephemeral TCP port, and launches the server process. Waits for the server to signal readiness before returning a `TestServer` instance that manages the server process and database lifecycle.
+    ///
+    /// # Parameters
+    /// - `manifest_path`: Path to the Cargo manifest for the "mxd" server binary.
+    /// - `setup`: Function to initialise the database at the given URL or path.
+    ///
+    /// # Returns
+    /// A `TestServer` instance managing the server process and temporary database.
+    ///
+    /// # Errors
+    /// Returns an error if database setup, port binding, server launch, or readiness check fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let server = TestServer::start_with_setup("path/to/Cargo.toml", |db_url| {
+    ///     // Custom database setup logic here
+    ///     Ok(())
+    /// }).expect("Failed to start test server");
     /// ```
     pub fn start_with_setup<F>(
         manifest_path: &str,


### PR DESCRIPTION
## Summary
- handle possible failures when starting embedded Postgres
- include an error context if the embedded database cannot be prepared

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684abdf3710083229e81750a7d872fe3

## Summary by Sourcery

Improve error handling for embedded PostgreSQL in test utilities by adding context to failures during setup, start, and database creation, and by introducing a helper function to ensure proper cleanup on errors

Enhancements:
- Introduce pg_step helper to wrap embedded PostgreSQL setup, start, and database creation steps with error context and cleanup
- Add contextual error propagation when initializing embedded PostgreSQL in TestServer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling and reporting during embedded PostgreSQL setup, providing clearer error messages and ensuring proper resource cleanup on failure.

- **Chores**
  - Updated internal dependencies to enhance error context and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->