### PR TITLE
Add external Postgres option for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ name = "test-util"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "cfg-if",
  "chrono",
  "diesel",
  "diesel-async",

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ cargo test
 
 Integration tests live in the repository's `tests/` directory.
 
+When the `postgres` feature is enabled, tests normally spin up an embedded
+PostgreSQL server. Set `POSTGRES_TEST_URL` to use an existing database URL
+instead of starting the embedded server.
+
 ## Validation harness
 
 The `validator` crate provides a compatibility check using the `hx` client and

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ cargo test
 Integration tests live in the repository's `tests/` directory.
 
 When the `postgres` feature is enabled, tests normally spin up an embedded
-PostgreSQL server. Set `POSTGRES_TEST_URL` to use an existing database URL
-instead of starting the embedded server.
+PostgreSQL server. Set `POSTGRES_TEST_URL` to reuse an existing database URL
+instead of starting the embedded server. The referenced database must be
+emptied between runs as the suite assumes a pristine schema.
 
 ## Validation harness
 

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,6 +15,7 @@ postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = tru
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
+cfg-if = "1"
 
 [features]
 default = ["sqlite"]

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -20,7 +20,7 @@ pub struct TestServer {
     child: Child,
     port: u16,
     db_url: String,
-    _temp: TempDir,
+    _temp: Option<TempDir>,
     #[cfg(feature = "postgres")]
     pg: Option<PostgreSQL>,
 }
@@ -40,9 +40,13 @@ fn setup_postgres<F>(setup: F) -> Result<(String, Option<PostgreSQL>), Box<dyn s
 where
     F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
 {
-    if let Ok(url) = std::env::var("POSTGRES_TEST_URL") {
-        setup(&url)?;
-        return Ok((url, None));
+    if let Some(value) = std::env::var_os("POSTGRES_TEST_URL") {
+        let url = value.to_string_lossy();
+        if !url.trim().is_empty() {
+            let url = url.into_owned();
+            setup(&url)?;
+            return Ok((url, None));
+        }
     }
 
     let mut pg = PostgreSQL::default();
@@ -137,14 +141,26 @@ impl TestServer {
     where
         F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
     {
-        let temp = TempDir::new()?;
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "sqlite")] {
+                let temp = TempDir::new()?;
+                let db_url = setup_sqlite(&temp, setup)?;
+                Self::launch(manifest_path, db_url, Some(temp))
+            } else if #[cfg(feature = "postgres")] {
+                let (db_url, pg) = setup_postgres(setup)?;
+                Self::launch(manifest_path, db_url, None, pg)
+            } else {
+                compile_error!("Either feature 'sqlite' or 'postgres' must be enabled");
+            }
+        }
+    }
 
-        #[cfg(feature = "sqlite")]
-        let db_url = setup_sqlite(&temp, setup)?;
-
-        #[cfg(feature = "postgres")]
-        let (db_url, pg) = setup_postgres(setup)?;
-
+    #[cfg(feature = "sqlite")]
+    fn launch(
+        manifest_path: &str,
+        db_url: String,
+        temp: Option<TempDir>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let socket = TcpListener::bind("127.0.0.1:0")?;
         let port = socket.local_addr()?.port();
         drop(socket);
@@ -158,7 +174,29 @@ impl TestServer {
             port,
             db_url,
             _temp: temp,
-            #[cfg(feature = "postgres")]
+        })
+    }
+
+    #[cfg(feature = "postgres")]
+    fn launch(
+        manifest_path: &str,
+        db_url: String,
+        temp: Option<TempDir>,
+        pg: Option<PostgreSQL>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let socket = TcpListener::bind("127.0.0.1:0")?;
+        let port = socket.local_addr()?.port();
+        drop(socket);
+
+        let mut child = build_server_command(manifest_path, port, &db_url).spawn()?;
+
+        wait_for_server(&mut child)?;
+
+        Ok(Self {
+            child,
+            port,
+            db_url,
+            _temp: temp,
             pg,
         })
     }


### PR DESCRIPTION
## Summary
- allow tests to reuse an existing PostgreSQL instance via `POSTGRES_TEST_URL`
- store embedded Postgres handle optionally
- mention `POSTGRES_TEST_URL` in README

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`
- `npx markdownlint-cli2 '**/*.md' '#node_modules'`
- `npx nixie '**/*.md' '!node_modules'` *(fails: `use strict: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684abdf1fd7c83228ebcfd3622ab5c44

## Summary by Sourcery

Allow tests to reuse an external PostgreSQL instance via POSTGRES_TEST_URL and refactor test utilities for optional embedded resources

New Features:
- Allow tests to reuse an existing PostgreSQL instance via POSTGRES_TEST_URL

Enhancements:
- Refactor TestServer to support optional embedded Postgres and unified launch logic across sqlite and postgres features

Build:
- Add cfg-if dependency for feature-based branching in test utilities

Documentation:
- Document POSTGRES_TEST_URL usage in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README to clarify how tests use an embedded PostgreSQL server by default, and how to override this with the `POSTGRES_TEST_URL` environment variable.

- **New Features**
  - Tests now support using an external PostgreSQL instance by setting the `POSTGRES_TEST_URL` environment variable, bypassing the embedded server setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->