### PR TITLE
Add external Postgres test and enforce features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ name = "test-util"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "cfg-if",
  "chrono",
  "diesel",
  "diesel-async",

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ cargo test
 
 Integration tests live in the repository's `tests/` directory.
 
+When the `postgres` feature is enabled, tests normally spin up an embedded
+PostgreSQL server. Set `POSTGRES_TEST_URL` to reuse an existing database URL
+instead of starting the embedded server. The referenced database must be
+emptied between runs as the suite assumes a pristine schema.
+
 ## Validation harness
 
 The `validator` crate provides a compatibility check using the `hx` client and

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,6 +15,7 @@ postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = tru
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
+cfg-if = "1"
 
 [features]
 default = ["sqlite"]

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -1,0 +1,25 @@
+#[cfg(feature = "postgres")]
+use postgresql_embedded::PostgreSQL;
+use test_util::TestServer;
+
+#[cfg(feature = "postgres")]
+#[test]
+fn reuse_external_postgres_via_env() -> Result<(), Box<dyn std::error::Error>> {
+    let mut pg = PostgreSQL::default();
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        pg.setup().await?;
+        pg.start().await?;
+        pg.create_database("test_env").await?;
+        Ok::<_, Box<dyn std::error::Error>>(())
+    })?;
+    let url = pg.settings().url("test_env");
+    std::env::set_var("POSTGRES_TEST_URL", &url);
+    let server = TestServer::start("./Cargo.toml")?;
+    assert_eq!(server.db_url(), url);
+    assert!(!server.uses_embedded_postgres());
+    std::env::remove_var("POSTGRES_TEST_URL");
+    drop(server);
+    rt.block_on(pg.stop())?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- enforce mutual exclusion of `sqlite` and `postgres` features in `test-util`
- expose `TestServer::uses_embedded_postgres` to verify which database path was taken
- add an integration test exercising the `POSTGRES_TEST_URL` code path

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test --quiet`
- `npx markdownlint-cli2 '**/*.md' '#node_modules'`
- `nixie docs/chat-schema.md docs/news-schema.md docs/file-sharing-design.md docs/fuzzing.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_684abdf1fd7c83228ebcfd3622ab5c44