### PR TITLE
Add external Postgres option for tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,9 @@ top-level `tests/` directory (not under `validator/tests`).**
 ## Markdown Guidance
 
 - Validate Markdown files using `markdownlint`.
-- Validate Markdown Mermaid diagrams using `nixie`.
+- Validate Markdown Mermaid diagrams using the `nixie` CLI.
+  `nixie` is a standalone command-line tool, not an npm package, so invoke it
+  directly rather than via `npx`.
 
 **These practices will help maintain a high-quality codebase and make
 collaboration easier**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,7 +2455,6 @@ name = "test-util"
 version = "0.1.0"
 dependencies = [
  "argon2",
- "cfg-if",
  "chrono",
  "diesel",
  "diesel-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ name = "test-util"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "cfg-if",
  "chrono",
  "diesel",
  "diesel-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "temp-env",
  "test-util",
  "thiserror 1.0.69",
  "tokio",
@@ -2436,6 +2437,15 @@ name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot 0.12.4",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ toml = []
 [dev-dependencies]
 test-util = { path = "test-util", default-features = false }
 postgresql_embedded = { version = "0.18.5", features = ["tokio"] }
+temp-env = "0.3"
 
 [lints.clippy]
 pedantic = "warn"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ cargo test
 
 Integration tests live in the repository's `tests/` directory.
 
+When the `postgres` feature is enabled, tests normally spin up an embedded
+PostgreSQL server. Set `POSTGRES_TEST_URL` to reuse an existing database URL
+instead of starting the embedded server. The referenced database must be
+emptied between runs as the suite assumes a pristine schema.
+
 ## Validation harness
 
 The `validator` crate provides a compatibility check using the `hx` client and

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,7 +15,6 @@ postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = tru
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
-cfg-if = "1"
 
 [features]
 default = ["sqlite"]

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,6 +15,7 @@ postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = tru
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
+cfg-if = "1"
 
 [features]
 default = ["sqlite"]

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -126,6 +126,9 @@ fn spawn_server(
 
             let (child, port) = spawn_server(manifest_path, &db_url)?;
             return Ok(Self {
+    ///
+    /// This is a convenience wrapper around [`Self::start_with_setup`] that
+    /// performs no additional database setup.
                 child,
                 port,
                 db_url,

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -32,16 +32,29 @@ pub struct TestServer {
 }
 
 #[cfg(feature = "sqlite")]
-/// Creates a temporary SQLite database file, runs a setup function on it, and returns the database URL.
-///
-/// The setup function is called with the path to the database file, allowing for schema initialisation or test data insertion.
-///
-/// # Arguments
-///
-/// * `temp` - Reference to a temporary directory where the database file will be created.
-/// * `setup` - Function to run custom setup logic on the database file path.
-///
-/// # Returns
+fn external_postgres_url() -> Option<String> {
+    std::env::var_os("POSTGRES_TEST_URL").and_then(|raw| {
+        let url = raw.to_string_lossy();
+        (!url.trim().is_empty()).then(|| url.into_owned())
+    })
+}
+
+#[cfg(feature = "postgres")]
+fn start_embedded_postgres<F>(setup: F) -> Result<(String, PostgreSQL), Box<dyn std::error::Error>>
+    Ok((url, pg))
+}
+
+#[cfg(feature = "postgres")]
+fn setup_postgres<F>(setup: F) -> Result<(String, Option<PostgreSQL>), Box<dyn std::error::Error>>
+where
+    F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
+{
+    if let Some(url) = external_postgres_url() {
+        setup(&url)?;
+        return Ok((url, None));
+    }
+
+    let (url, pg) = start_embedded_postgres(setup)?;
 ///
 /// Returns the SQLite database URL as a string on success, or an error if setup fails.
 ///

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -34,7 +34,7 @@ pub struct TestServer {
     pg: Option<PostgreSQL>,
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
 fn external_postgres_url() -> Option<String> {
     std::env::var_os("POSTGRES_TEST_URL").and_then(|raw| {
         let url = raw.to_string_lossy();

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -8,6 +8,12 @@ use tempfile::TempDir;
 #[cfg(feature = "postgres")]
 use postgresql_embedded::PostgreSQL;
 
+#[cfg(all(feature = "sqlite", feature = "postgres"))]
+compile_error!("Choose either sqlite or postgres, not both");
+
+#[cfg(not(any(feature = "sqlite", feature = "postgres")))]
+compile_error!("Either feature 'sqlite' or 'postgres' must be enabled");
+
 #[cfg(unix)]
 use nix::sys::signal::{Signal, kill};
 #[cfg(unix)]
@@ -20,7 +26,7 @@ pub struct TestServer {
     child: Child,
     port: u16,
     db_url: String,
-    _temp: TempDir,
+    _temp: Option<TempDir>,
     #[cfg(feature = "postgres")]
     pg: Option<PostgreSQL>,
 }
@@ -36,10 +42,19 @@ where
 }
 
 #[cfg(feature = "postgres")]
-fn setup_postgres<F>(setup: F) -> Result<(String, PostgreSQL), Box<dyn std::error::Error>>
+fn setup_postgres<F>(setup: F) -> Result<(String, Option<PostgreSQL>), Box<dyn std::error::Error>>
 where
     F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
 {
+    if let Some(value) = std::env::var_os("POSTGRES_TEST_URL") {
+        let url = value.to_string_lossy();
+        if !url.trim().is_empty() {
+            let url = url.into_owned();
+            setup(&url)?;
+            return Ok((url, None));
+        }
+    }
+
     let mut pg = PostgreSQL::default();
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -50,7 +65,18 @@ where
     })?;
     let url = pg.settings().url("test");
     setup(&url)?;
-    Ok((url, pg))
+    Ok((url, Some(pg)))
+}
+
+#[cfg(feature = "postgres")]
+#[doc(hidden)]
+pub fn setup_postgres_for_test<F>(
+    setup: F,
+) -> Result<(String, Option<PostgreSQL>), Box<dyn std::error::Error>>
+where
+    F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
+{
+    setup_postgres(setup)
 }
 
 fn wait_for_server(child: &mut Child) -> Result<(), Box<dyn std::error::Error>> {
@@ -132,17 +158,26 @@ impl TestServer {
     where
         F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
     {
-        let temp = TempDir::new()?;
-
         #[cfg(feature = "sqlite")]
-        let db_url = setup_sqlite(&temp, setup)?;
+        {
+            let temp = TempDir::new()?;
+            let db_url = setup_sqlite(&temp, setup)?;
+            return Self::launch(manifest_path, db_url, Some(temp));
+        }
 
         #[cfg(feature = "postgres")]
-        let (db_url, pg) = setup_postgres(setup)?;
+        {
+            let (db_url, pg) = setup_postgres(setup)?;
+            return Self::launch(manifest_path, db_url, None, pg);
+        }
+    }
 
-        #[cfg(feature = "postgres")]
-        let db_url = db_url;
-
+    #[cfg(feature = "sqlite")]
+    fn launch(
+        manifest_path: &str,
+        db_url: String,
+        temp: Option<TempDir>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let socket = TcpListener::bind("127.0.0.1:0")?;
         let port = socket.local_addr()?.port();
         drop(socket);
@@ -156,8 +191,30 @@ impl TestServer {
             port,
             db_url,
             _temp: temp,
-            #[cfg(feature = "postgres")]
-            pg: Some(pg),
+        })
+    }
+
+    #[cfg(feature = "postgres")]
+    fn launch(
+        manifest_path: &str,
+        db_url: String,
+        temp: Option<TempDir>,
+        pg: Option<PostgreSQL>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let socket = TcpListener::bind("127.0.0.1:0")?;
+        let port = socket.local_addr()?.port();
+        drop(socket);
+
+        let mut child = build_server_command(manifest_path, port, &db_url).spawn()?;
+
+        wait_for_server(&mut child)?;
+
+        Ok(Self {
+            child,
+            port,
+            db_url,
+            _temp: temp,
+            pg,
         })
     }
 
@@ -175,6 +232,12 @@ impl TestServer {
         // `db_url` was validated when the server was created, so borrowing is
         // safe and avoids repeated validation.
         self.db_url.as_str()
+    }
+
+    #[cfg(feature = "postgres")]
+    /// Whether the server started its own embedded PostgreSQL instance.
+    pub fn uses_embedded_postgres(&self) -> bool {
+        self.pg.is_some()
     }
 }
 

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -3,6 +3,16 @@ use test_util::setup_postgres_for_test;
 
 #[cfg(feature = "postgres")]
 #[test]
+/// Tests that an external Postgres URL from the `POSTGRES_TEST_URL` environment variable is used instead of creating an internal Postgres instance.
+///
+/// This test sets the `POSTGRES_TEST_URL` environment variable, invokes `setup_postgres_for_test`, and verifies that the returned URL matches the environment variable and that no internal Postgres instance is created. The environment variable is cleaned up after the test.
+///
+/// # Examples
+///
+/// ```
+/// // This test is intended to be run with the "postgres" feature enabled.
+/// external_postgres_is_used().unwrap();
+/// ```
 fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
     unsafe {
         std::env::set_var("POSTGRES_TEST_URL", "postgres://example");

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -1,24 +1,16 @@
 #[cfg(feature = "postgres")]
+use temp_env::with_var;
+#[cfg(feature = "postgres")]
 use test_util::setup_postgres_for_test;
 
 #[cfg(feature = "postgres")]
 #[test]
-    set_var("POSTGRES_TEST_URL", "postgres://example");
-    remove_var("POSTGRES_TEST_URL");
-
-#[cfg(feature = "postgres")]
-fn set_var(key: &str, value: &str) {
-    unsafe { std::env::set_var(key, value) }
-}
-
-#[cfg(feature = "postgres")]
-fn remove_var(key: &str) {
-    unsafe { std::env::remove_var(key) }
-}
-/// ```
-/// // This test is intended to be run with the "postgres" feature enabled.
-/// external_postgres_is_used().unwrap();
-/// ```
+    with_var("POSTGRES_TEST_URL", Some("postgres://example"), || {
+        let (url, pg) = setup_postgres_for_test(|_| Ok(()))?;
+        assert_eq!(url, "postgres://example");
+        assert!(pg.is_none());
+        Ok::<_, Box<dyn std::error::Error>>(())
+    })
 fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
     unsafe {
         std::env::set_var("POSTGRES_TEST_URL", "postgres://example");

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "postgres")]
+use test_util::setup_postgres_for_test;
+
+#[cfg(feature = "postgres")]
+#[test]
+fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
+    unsafe {
+        std::env::set_var("POSTGRES_TEST_URL", "postgres://example");
+    }
+    let (url, pg) = setup_postgres_for_test(|_| Ok(()))?;
+    assert_eq!(url, "postgres://example");
+    assert!(pg.is_none());
+    unsafe {
+        std::env::remove_var("POSTGRES_TEST_URL");
+    }
+    Ok(())
+}

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -3,8 +3,18 @@ use test_util::setup_postgres_for_test;
 
 #[cfg(feature = "postgres")]
 #[test]
-    std::env::set_var("POSTGRES_TEST_URL", "postgres://example");
-    std::env::remove_var("POSTGRES_TEST_URL");
+    set_var("POSTGRES_TEST_URL", "postgres://example");
+    remove_var("POSTGRES_TEST_URL");
+
+#[cfg(feature = "postgres")]
+fn set_var(key: &str, value: &str) {
+    unsafe { std::env::set_var(key, value) }
+}
+
+#[cfg(feature = "postgres")]
+fn remove_var(key: &str) {
+    unsafe { std::env::remove_var(key) }
+}
 /// ```
 /// // This test is intended to be run with the "postgres" feature enabled.
 /// external_postgres_is_used().unwrap();

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -3,12 +3,8 @@ use test_util::setup_postgres_for_test;
 
 #[cfg(feature = "postgres")]
 #[test]
-/// Tests that an external Postgres URL from the `POSTGRES_TEST_URL` environment variable is used instead of creating an internal Postgres instance.
-///
-/// This test sets the `POSTGRES_TEST_URL` environment variable, invokes `setup_postgres_for_test`, and verifies that the returned URL matches the environment variable and that no internal Postgres instance is created. The environment variable is cleaned up after the test.
-///
-/// # Examples
-///
+    std::env::set_var("POSTGRES_TEST_URL", "postgres://example");
+    std::env::remove_var("POSTGRES_TEST_URL");
 /// ```
 /// // This test is intended to be run with the "postgres" feature enabled.
 /// external_postgres_is_used().unwrap();


### PR DESCRIPTION
## Summary
- allow tests to reuse a running PostgreSQL instance via `POSTGRES_TEST_URL`
- avoid creating a temporary directory when using that external DB
- make the temp directory optional inside `TestServer`
- document cleaning the reused database between test runs
- enforce mutually exclusive back-end features and add a regression test

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --no-default-features --features postgres --test postgres_env`
- `npx markdownlint-cli2 '**/*.md' '#node_modules'`
- `nixie docs/chat-schema.md docs/news-schema.md docs/file-sharing-design.md docs/fuzzing.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_684abdf1fd7c83228ebcfd3622ab5c44

## Summary by Sourcery

Enable tests to reuse external PostgreSQL instances via POSTGRES_TEST_URL, refactor database setup to make temporary storage optional, and add validations for mutually exclusive backend features.

New Features:
- Allow tests to connect to an existing PostgreSQL instance via POSTGRES_TEST_URL
- Expose uses_embedded_postgres() on TestServer to distinguish external vs embedded database

Enhancements:
- Make TestServer temporary directory optional when using an external database
- Refactor setup_postgres to return an optional embedded Postgres handle
- Introduce spawn_server helper to launch test server instances on random ports

Build:
- Add temp-env dependency for managing environment variables in tests

Documentation:
- Clarify use of the standalone nixie CLI in AGENTS.md

Tests:
- Add regression test to enforce mutually exclusive backend features and verify external Postgres usage

Chores:
- Remove cfg-if dependency from test-util

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for validating Mermaid diagrams, specifying the use of the nixie CLI as a standalone tool.
- **Chores**
  - Added a new development dependency for improved test environment handling.
  - Removed an unused dependency from test utilities.
- **New Features**
  - Enhanced test utilities to support both SQLite and PostgreSQL backends, with improved feature selection, error handling, and server launch methods.
  - Added a method to determine if an embedded PostgreSQL instance is used.
- **Tests**
  - Introduced a new test to verify the use of an external PostgreSQL URL via environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->