### PR TITLE
Add external Postgres option for tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,9 @@ top-level `tests/` directory (not under `validator/tests`).**
 ## Markdown Guidance
 
 - Validate Markdown files using `markdownlint`.
-- Validate Markdown Mermaid diagrams using `nixie`.
+- Validate Markdown Mermaid diagrams using the `nixie` CLI.
+  `nixie` is a standalone command-line tool, not an npm package, so invoke it
+  directly rather than via `npx`.
 
 **These practices will help maintain a high-quality codebase and make
 collaboration easier**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "temp-env",
  "test-util",
  "thiserror 1.0.69",
  "tokio",
@@ -2436,6 +2437,15 @@ name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot 0.12.4",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ toml = []
 [dev-dependencies]
 test-util = { path = "test-util", default-features = false }
 postgresql_embedded = { version = "0.18.5", features = ["tokio"] }
+temp-env = "0.3"
 
 [lints.clippy]
 pedantic = "warn"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ cargo test
 
 Integration tests live in the repository's `tests/` directory.
 
+When the `postgres` feature is enabled, tests normally spin up an embedded
+PostgreSQL server. Set the `POSTGRES_TEST_URL` environment variable to reuse an
+existing database URL instead of starting the embedded server. The referenced
+database must be emptied between runs as the suite assumes a pristine schema.
+
 ## Validation harness
 
 The `validator` crate provides a compatibility check using the `hx` client and

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -1,0 +1,15 @@
+#[cfg(feature = "postgres")]
+use temp_env::with_var;
+#[cfg(feature = "postgres")]
+use test_util::setup_postgres_for_test;
+
+#[cfg(feature = "postgres")]
+#[test]
+fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
+    with_var("POSTGRES_TEST_URL", Some("postgres://example"), || {
+        let (url, pg) = setup_postgres_for_test(|_| Ok(()))?;
+        assert_eq!(url, "postgres://example");
+        assert!(pg.is_none());
+        Ok::<_, Box<dyn std::error::Error>>(())
+    })
+}


### PR DESCRIPTION
## Summary
- allow tests to reuse a running PostgreSQL instance via `POSTGRES_TEST_URL`
- avoid creating a temporary directory when using that external DB
- make the temp directory optional inside `TestServer`
- document cleaning the reused database between test runs
- enforce mutually exclusive back-end features and add a regression test
- remove unused `cfg-if` dependency and share launch helper
- refine regression test setup to avoid unsafe blocks
- extracted helpers to reduce nesting in Postgres setup
- clarify in the agent instructions that `nixie` is a standalone CLI
- document `start` as a wrapper around `start_with_setup`
- clarify `POSTGRES_TEST_URL` usage in README

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`
- `npx -y markdownlint-cli2 '**/*.md' '#node_modules'`
- `nixie docs/chat-schema.md docs/news-schema.md docs/file-sharing-design.md docs/fuzzing.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_684abdf1fd7c83228ebcfd3622ab5c44