### PR TITLE
Configure PostgreSQL env var in CI

### DIFF
--- a/.github/actions/export-postgres-url/action.yml
+++ b/.github/actions/export-postgres-url/action.yml
@@ -1,0 +1,11 @@
+name: Export Postgres URL
+description: Set POSTGRES_TEST_URL environment variable
+inputs:
+  url:
+    description: Database connection string
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: echo "POSTGRES_TEST_URL=${{ inputs.url }}" >> "$GITHUB_ENV"
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     services:
-      postgres: &postgres-service
+      postgres:
         image: postgres:15
         env:
           POSTGRES_USER: postgres
@@ -47,7 +47,19 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     services:
-      postgres: *postgres-service
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       CARGO_TERM_COLOR: always
       CODESCENE_CLI_SHA256: "a1c38415c5978908283c0608b648b27e954c93882b15d8b91d052d846c3eabd8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         feature: [sqlite, postgres]
+      fail-fast: false
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,13 @@ jobs:
       - name: Start PostgreSQL
         if: matrix.feature == 'postgres'
         run: |
-          docker run --rm --name pg -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=test -p 5432:5432 -d postgres:15
+          docker run --rm --name pg \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=password \
+            -e POSTGRES_DB=test \
+            -p 5432:5432 -d postgres:15
           until docker exec pg pg_isready -U postgres; do sleep 1; done
+          echo "POSTGRES_TEST_URL=postgres://postgres:password@localhost/test" >> "$GITHUB_ENV"
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lint
@@ -43,6 +48,17 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - uses: oven-sh/setup-bun@v2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
+      - name: Start PostgreSQL
+        run: |
+          docker run --rm --name pg \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=password \
+            -e POSTGRES_DB=test \
+            -p 5432:5432 -d postgres:15
+          until docker exec pg pg_isready -U postgres; do sleep 1; done
+          echo "POSTGRES_TEST_URL=postgres://postgres:password@localhost/test" >> "$GITHUB_ENV"
       - name: Generate coverage for SQLite
         run: |
           cargo llvm-cov --workspace --features sqlite --lcov --output-path lcov-sqlite.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    services:
+      postgres: &postgres-service
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       matrix:
         feature: [sqlite, postgres]
@@ -16,17 +30,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
-      - name: Start PostgreSQL
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+      - name: Export POSTGRES_TEST_URL
         if: matrix.feature == 'postgres'
-        run: |
-          docker run --rm --name pg \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=password \
-            -e POSTGRES_DB=test \
-            -p 5432:5432 -d postgres:15
-          until docker exec pg pg_isready -U postgres; do sleep 1; done
-          echo "POSTGRES_TEST_URL=postgres://postgres:password@localhost/test" >> "$GITHUB_ENV"
+        uses: ./.github/actions/export-postgres-url
+        with:
+          url: postgres://postgres:password@localhost/test
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lint
@@ -36,6 +45,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    services:
+      postgres: *postgres-service
     env:
       CARGO_TERM_COLOR: always
       CODESCENE_CLI_SHA256: "a1c38415c5978908283c0608b648b27e954c93882b15d8b91d052d846c3eabd8"
@@ -49,16 +60,10 @@ jobs:
           tool: cargo-llvm-cov
       - uses: oven-sh/setup-bun@v2
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
-      - name: Start PostgreSQL
-        run: |
-          docker run --rm --name pg \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=password \
-            -e POSTGRES_DB=test \
-            -p 5432:5432 -d postgres:15
-          until docker exec pg pg_isready -U postgres; do sleep 1; done
-          echo "POSTGRES_TEST_URL=postgres://postgres:password@localhost/test" >> "$GITHUB_ENV"
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+      - uses: ./.github/actions/export-postgres-url
+        with:
+          url: postgres://postgres:password@localhost/test
       - name: Generate coverage for SQLite
         run: |
           cargo llvm-cov --workspace --features sqlite --lcov --output-path lcov-sqlite.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,6 @@ dependencies = [
 name = "test-util"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "argon2",
  "chrono",
  "diesel",

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -9,9 +9,6 @@ use tempfile::TempDir;
 use anyhow::{Context, Error};
 
 #[cfg(feature = "postgres")]
-use anyhow::{Context, Error};
-
-#[cfg(feature = "postgres")]
 use postgresql_embedded::PostgreSQL;
 
 #[cfg(all(feature = "sqlite", feature = "postgres"))]

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -46,9 +46,7 @@ fn external_postgres_url() -> Option<String> {
 }
 
 #[cfg(feature = "postgres")]
-fn start_embedded_postgres<F>(
-    setup: F,
-) -> Result<(String, PostgreSQL), Box<dyn std::error::Error>>
+fn start_embedded_postgres<F>(setup: F) -> Result<(String, PostgreSQL), Box<dyn std::error::Error>>
 where
     F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
 {
@@ -176,7 +174,6 @@ fn build_server_command(manifest_path: &str, port: u16, db_url: &str) -> Command
     .stderr(Stdio::inherit());
     cmd
 }
-
 
 impl TestServer {
     /// Start the server using the given Cargo manifest path.


### PR DESCRIPTION
## Summary
- set `POSTGRES_TEST_URL` when starting Postgres service
- start Postgres for coverage job as well

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684c0cf9a5908322898022b85cbe4725

## Summary by Sourcery

Use GitHub Actions service containers to run Postgres in CI, replace manual Docker setup with a composite action to export POSTGRES_TEST_URL, and apply consistent environment setup across both build and coverage workflows.

Build:
- Add composite GitHub Action to export POSTGRES_TEST_URL environment variable

CI:
- Configure Postgres service container with health checks in build-test and coverage workflows
- Start Postgres service and export POSTGRES_TEST_URL using the composite action in both workflows
- Install libpq-dev with --no-install-recommends in CI steps
- Disable fail-fast for the feature matrix

Chores:
- Remove an extra blank line in the start_embedded_postgres function signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the setup and configuration of the PostgreSQL service in continuous integration workflows for better consistency and reliability.
  - Ensured required system dependencies are installed before starting PostgreSQL in all relevant jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->