### PR TITLE
Update test warnings policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,11 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` before
-  committing.
+- Run `cargo fmt`, `cargo clippy -- -D warnings`, and
+  `RUSTFLAGS="-D warnings" cargo test` before committing.
 - Clippy warnings MUST be disallowed.
+- Fix any warnings emitted during tests in the code itself rather than
+  silencing them.
 - Where a function is too long, extract meaningfully named helper functions
   adhering to separation of concerns and CQRS.
 - Where a function has too many parameters, group related parameters in

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -34,13 +34,6 @@ pub struct TestServer {
     pg: Option<PostgreSQL>,
 }
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-fn external_postgres_url() -> Option<String> {
-    std::env::var_os("POSTGRES_TEST_URL").and_then(|raw| {
-        let url = raw.to_string_lossy();
-        (!url.trim().is_empty()).then(|| url.into_owned())
-    })
-}
 
 #[cfg(feature = "postgres")]
 fn start_embedded_postgres<F>(setup: F) -> Result<(String, PostgreSQL), Box<dyn std::error::Error>>


### PR DESCRIPTION
## Summary
- enforce running tests with `-D warnings` in `AGENTS.md`
- remove unused helper that caused warnings

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint AGENTS.md`
- `nixie docs`


------
https://chatgpt.com/codex/tasks/task_e_684c65b4d4608322a37640db29364679

## Summary by Sourcery

Enforce a stricter warnings policy for tests and remove the unused helper causing test warnings.

Enhancements:
- Remove unused external_postgres_url helper from test-util to eliminate warnings

Documentation:
- Clarify AGENTS.md to require running tests with `RUSTFLAGS="-D warnings"` and fixing warnings instead of silencing them