### PR TITLE
Fix formatting for test-util

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -34,7 +34,6 @@ pub struct TestServer {
     pg: Option<PostgreSQL>,
 }
 
-
 #[cfg(feature = "postgres")]
 fn start_embedded_postgres<F>(setup: F) -> Result<(String, PostgreSQL), Box<dyn std::error::Error>>
 where


### PR DESCRIPTION
## Summary
- run `cargo fmt` to fix formatting in test-util

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c6b2863808322bac1eb4f253fc218

## Summary by Sourcery

Chores:
- Run cargo fmt to fix formatting in test-util