### PR TITLE
Fix postgres test helper

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -82,6 +82,22 @@ where
     Ok((url, Some(pg)))
 }
 
+#[cfg(feature = "postgres")]
+/// Configure a PostgreSQL database for tests.
+///
+/// This checks the `POSTGRES_TEST_URL` environment variable. If set, the
+/// provided URL is used and no embedded server is started. Otherwise an
+/// embedded PostgreSQL instance is spun up. The given setup callback receives
+/// the connection URL.
+pub fn setup_postgres_for_test<F>(
+    setup: F,
+) -> Result<(String, Option<PostgreSQL>), Box<dyn std::error::Error>>
+where
+    F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,
+{
+    setup_postgres(setup)
+}
+
 ///
 /// Returns the SQLite database URL as a string on success, or an error if setup fails.
 ///
@@ -97,6 +113,7 @@ where
 /// }).unwrap();
 /// assert!(db_url.ends_with("mxd.db"));
 /// ```
+#[cfg(feature = "sqlite")]
 fn setup_sqlite<F>(temp: &TempDir, setup: F) -> Result<String, Box<dyn std::error::Error>>
 where
     F: FnOnce(&str) -> Result<(), Box<dyn std::error::Error>>,


### PR DESCRIPTION
## Summary
- expose `setup_postgres_for_test` for integration tests
- guard `setup_sqlite` behind a feature flag

## Testing
- `cargo clippy --no-default-features --features postgres -- -D warnings`
- `cargo clippy --features sqlite -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --features sqlite`
- `RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres` *(fails: preparing embedded PostgreSQL requires non-root user)*

------
https://chatgpt.com/codex/tasks/task_e_684c8fb24168832299a44da775ba6b60

## Summary by Sourcery

Expose the PostgreSQL test setup function and conditionally enable the SQLite setup helper using feature flags.

New Features:
- Expose a `setup_postgres_for_test` helper function when the `postgres` feature is enabled

Enhancements:
- Guard the existing `setup_sqlite` helper behind the `sqlite` feature flag