### PR TITLE
Enforce nightly formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           url: postgres://postgres:password@localhost/test
       - name: Format
-        run: rustup component add rustfmt --toolchain nightly-2025-06-10 && cargo +nightly fmt --all -- --check
+        run: rustup component add rustfmt --toolchain nightly-2025-06-10 && cargo +nightly-2025-06-10 fmt --all -- --check
       - name: Lint
         run: cargo clippy --no-default-features --features ${{ matrix.feature }} -- -D warnings
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           url: postgres://postgres:password@localhost/test
       - name: Format
-        run: cargo fmt --all -- --check
+        run: rustup component add rustfmt --toolchain nightly-2025-06-10 && cargo +nightly fmt --all -- --check
       - name: Lint
         run: cargo clippy --no-default-features --features ${{ matrix.feature }} -- -D warnings
       - name: Test

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,14 @@
+unstable_features = true
+comment_width = 100
+format_code_in_doc_comments = true
+imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
+wrap_comments = true
+group_imports = "StdExternalCrate"
+use_try_shorthand = true
+hex_literal_case = "Lower"
+format_strings = true
+format_macro_matchers = true
+fn_single_line = true
+condense_wildcard_suffixes = true
+use_field_init_shorthand = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,8 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `cargo fmt`, `cargo clippy -- -D warnings`, and
+- Run `cargo +nightly fmt` after making any change, and run
+  `cargo clippy -- -D warnings` and
   `RUSTFLAGS="-D warnings" cargo test` before committing.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in the code itself rather than

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `cargo +nightly fmt` after making any change, and run
+- Run `cargo +nightly-2025-06-10 fmt` after making any change, and run
   `cargo clippy -- -D warnings` and
   `RUSTFLAGS="-D warnings" cargo test` before committing.
 - Clippy warnings MUST be disallowed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `cargo +nightly-2025-06-10 fmt` after making any change, and run
+- Run `cargo +nightly-2025-06-10 fmt --all` after making any change, and run
   `cargo clippy -- -D warnings` and
   `RUSTFLAGS="-D warnings" cargo test` before committing.
 - Clippy warnings MUST be disallowed.

--- a/diesel_cte_ext/src/builders.rs
+++ b/diesel_cte_ext/src/builders.rs
@@ -1,5 +1,6 @@
-use crate::cte::{RecursiveBackend, WithRecursive};
 use diesel::query_builder::QueryFragment;
+
+use crate::cte::{RecursiveBackend, WithRecursive};
 
 /// Build a recursive CTE query.
 

--- a/diesel_cte_ext/src/cte.rs
+++ b/diesel_cte_ext/src/cte.rs
@@ -1,6 +1,8 @@
-use diesel::backend::Backend;
-use diesel::query_builder::{AstPass, Query, QueryFragment, QueryId};
-use diesel::result::QueryResult;
+use diesel::{
+    backend::Backend,
+    query_builder::{AstPass, Query, QueryFragment, QueryId},
+    result::QueryResult,
+};
 
 fn push_identifiers<DB>(out: &mut AstPass<'_, '_, DB>, ids: &[&'static str]) -> QueryResult<()>
 where

--- a/diesel_cte_ext/tests/cte.rs
+++ b/diesel_cte_ext/tests/cte.rs
@@ -1,11 +1,8 @@
-use diesel::Connection;
-use diesel::dsl::sql;
-use diesel::sql_types::Integer;
+use diesel::{Connection, dsl::sql, sql_types::Integer};
 use diesel_cte_ext::with_recursive;
 
 fn sqlite_sync() -> Vec<i32> {
-    use diesel::RunQueryDsl;
-    use diesel::sqlite::SqliteConnection;
+    use diesel::{RunQueryDsl, sqlite::SqliteConnection};
     let mut conn = SqliteConnection::establish(":memory:").unwrap();
     with_recursive::<diesel::sqlite::Sqlite, _, _, _>(
         "t",
@@ -20,8 +17,11 @@ fn sqlite_sync() -> Vec<i32> {
 
 async fn sqlite_async() -> Vec<i32> {
     use diesel::sqlite::SqliteConnection;
-    use diesel_async::sync_connection_wrapper::SyncConnectionWrapper;
-    use diesel_async::{AsyncConnection, RunQueryDsl};
+    use diesel_async::{
+        AsyncConnection,
+        RunQueryDsl,
+        sync_connection_wrapper::SyncConnectionWrapper,
+    };
     let mut conn = SyncConnectionWrapper::<SqliteConnection>::establish(":memory:")
         .await
         .unwrap();
@@ -38,8 +38,7 @@ async fn sqlite_async() -> Vec<i32> {
 }
 
 async fn pg_async() -> Vec<i32> {
-    use diesel_async::AsyncPgConnection;
-    use diesel_async::{AsyncConnection, RunQueryDsl};
+    use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
     use postgresql_embedded::PostgreSQL;
 
     let mut pg = PostgreSQL::default();
@@ -63,8 +62,7 @@ async fn pg_async() -> Vec<i32> {
 }
 
 fn pg_sync() -> Vec<i32> {
-    use diesel::RunQueryDsl;
-    use diesel::pg::PgConnection;
+    use diesel::{RunQueryDsl, pg::PgConnection};
     use postgresql_embedded::blocking::PostgreSQL;
 
     let mut pg = PostgreSQL::default();

--- a/src/bin/gen_corpus.rs
+++ b/src/bin/gen_corpus.rs
@@ -1,10 +1,14 @@
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::Path;
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
 
-use mxd::field_id::FieldId;
-use mxd::transaction::{FrameHeader, Transaction, encode_params};
-use mxd::transaction_type::TransactionType;
+use mxd::{
+    field_id::FieldId,
+    transaction::{FrameHeader, Transaction, encode_params},
+    transaction_type::TransactionType,
+};
 
 const CORPUS_DIR: &str = "fuzz/corpus";
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,16 +1,27 @@
 use std::net::SocketAddr;
 
-use crate::db::{DbConnection, DbPool, PathLookupError, list_article_titles, list_names_at_path};
-use crate::field_id::FieldId;
-use crate::header_util::reply_header;
-use crate::login::handle_login;
-use crate::transaction::{
-    FrameHeader, Transaction, decode_params, decode_params_map, encode_params, encode_vec_params,
-    first_param_i32, first_param_string, required_param_i32, required_param_string,
-};
-use crate::transaction_type::TransactionType;
 use futures_util::future::BoxFuture;
 use tracing::error;
+
+use crate::{
+    db::{DbConnection, DbPool, PathLookupError, list_article_titles, list_names_at_path},
+    field_id::FieldId,
+    header_util::reply_header,
+    login::handle_login,
+    transaction::{
+        FrameHeader,
+        Transaction,
+        decode_params,
+        decode_params_map,
+        encode_params,
+        encode_vec_params,
+        first_param_i32,
+        first_param_string,
+        required_param_i32,
+        required_param_string,
+    },
+    transaction_type::TransactionType,
+};
 
 /// Error code used when the requested news path is unsupported.
 pub const NEWS_ERR_PATH_UNSUPPORTED: u32 = 1;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,8 +1,10 @@
 use std::net::SocketAddr;
 
-use crate::commands::Command;
-use crate::db::DbPool;
-use crate::transaction::{Transaction, parse_transaction};
+use crate::{
+    commands::Command,
+    db::DbPool,
+    transaction::{Transaction, parse_transaction},
+};
 
 /// Per-connection context used by `handle_request`.
 pub struct Context {
@@ -18,9 +20,7 @@ pub struct Session {
 
 impl Context {
     #[must_use]
-    pub fn new(peer: SocketAddr, pool: DbPool) -> Self {
-        Self { peer, pool }
-    }
+    pub fn new(peer: SocketAddr, pool: DbPool) -> Self { Self { peer, pool } }
 }
 
 /// Parse and handle a single request frame without performing network I/O.

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,11 +1,14 @@
 use std::net::SocketAddr;
 
-use crate::db::{DbPool, get_user_by_name};
-use crate::field_id::FieldId;
-use crate::header_util::reply_header;
-use crate::transaction::{FrameHeader, Transaction, encode_params};
-use crate::users::verify_password;
 use tracing::{info, warn};
+
+use crate::{
+    db::{DbPool, get_user_by_name},
+    field_id::FieldId,
+    header_util::reply_header,
+    transaction::{FrameHeader, Transaction, encode_params},
+    users::verify_password,
+};
 
 /// Handle a user login request.
 ///

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,8 @@
-use crate::schema::{file_acl, files};
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
+
+use crate::schema::{file_acl, files};
 
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 pub struct User {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,11 +1,12 @@
-use std::collections::HashSet;
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use thiserror::Error;
-use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::{
+    io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    time::timeout,
+};
 
 use crate::field_id::FieldId;
-use tokio::time::timeout;
 
 /// Length of a transaction frame header in bytes.
 pub const HEADER_LEN: usize = 20;
@@ -62,14 +63,10 @@ pub fn read_u16(buf: &[u8]) -> Result<u16, TransactionError> {
 }
 
 /// Write a big-endian u16 to the provided byte slice.
-pub fn write_u16(buf: &mut [u8], val: u16) {
-    buf.copy_from_slice(&val.to_be_bytes());
-}
+pub fn write_u16(buf: &mut [u8], val: u16) { buf.copy_from_slice(&val.to_be_bytes()); }
 
 /// Write a big-endian u32 to the provided byte slice.
-pub fn write_u32(buf: &mut [u8], val: u32) {
-    buf.copy_from_slice(&val.to_be_bytes());
-}
+pub fn write_u32(buf: &mut [u8], val: u32) { buf.copy_from_slice(&val.to_be_bytes()); }
 
 /// Parsed frame header according to the protocol specification.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/users.rs
+++ b/src/users.rs
@@ -1,7 +1,13 @@
 use argon2::{
     Argon2,
-    password_hash::Error,
-    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
+    password_hash::{
+        Error,
+        PasswordHash,
+        PasswordHasher,
+        PasswordVerifier,
+        SaltString,
+        rand_core::OsRng,
+    },
 };
 
 /// Hash a password using the provided Argon2 instance.
@@ -23,8 +29,9 @@ pub(crate) fn verify_password(hash: &str, pw: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{hash_password, verify_password};
     use argon2::Argon2;
+
+    use super::{hash_password, verify_password};
 
     #[test]
     fn test_hash_password() {

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -1,15 +1,15 @@
-use std::io::{BufRead, BufReader};
-use std::net::TcpListener;
-use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
-
-use tempfile::TempDir;
-
 #[cfg(feature = "postgres")]
 use std::error::Error as StdError;
+use std::{
+    io::{BufRead, BufReader},
+    net::TcpListener,
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant},
+};
 
 #[cfg(feature = "postgres")]
 use postgresql_embedded::PostgreSQL;
+use tempfile::TempDir;
 
 #[cfg(all(feature = "sqlite", feature = "postgres"))]
 compile_error!("Choose either sqlite or postgres, not both");
@@ -110,7 +110,8 @@ where
 /// let db_url = setup_sqlite(&temp_dir, |path| {
 ///     // Custom setup logic, e.g., run migrations
 ///     Ok(())
-/// }).unwrap();
+/// })
+/// .unwrap();
 /// assert!(db_url.ends_with("mxd.db"));
 /// ```
 #[cfg(feature = "sqlite")]
@@ -175,7 +176,9 @@ impl TestServer {
 
     /// Starts the test server after running a setup function on a temporary database.
     ///
-    /// The setup function is called with the database URL before the server is launched, allowing initialisation or seeding of the database for integration tests. The server is started on a random available port.
+    /// The setup function is called with the database URL before the server is launched, allowing
+    /// initialisation or seeding of the database for integration tests. The server is started on a
+    /// random available port.
     ///
     /// # Parameters
     /// - `manifest_path`: Path to the Cargo manifest for the server binary.
@@ -185,7 +188,8 @@ impl TestServer {
     /// Returns a `TestServer` instance managing the server process and test database.
     ///
     /// # Errors
-    /// Returns an error if temporary directory creation, database setup, server startup, or protocol handshake fails.
+    /// Returns an error if temporary directory creation, database setup, server startup, or
+    /// protocol handshake fails.
     ///
     /// # Examples
     ///
@@ -216,9 +220,12 @@ impl TestServer {
     }
 
     #[cfg(feature = "sqlite")]
-    /// Launches the `mxd` server on a random available port with the specified database URL for integration testing.
+    /// Launches the `mxd` server on a random available port with the specified database URL for
+    /// integration testing.
     ///
-    /// Binds a TCP listener to obtain a free port, starts the server process with the given manifest path and database URL, waits for the server to become ready, and returns a `TestServer` instance managing the process and optional temporary directory.
+    /// Binds a TCP listener to obtain a free port, starts the server process with the given
+    /// manifest path and database URL, waits for the server to become ready, and returns a
+    /// `TestServer` instance managing the process and optional temporary directory.
     ///
     /// # Returns
     ///
@@ -226,13 +233,19 @@ impl TestServer {
     ///
     /// # Errors
     ///
-    /// Returns an error if binding the port, spawning the server process, or waiting for server readiness fails.
+    /// Returns an error if binding the port, spawning the server process, or waiting for server
+    /// readiness fails.
     ///
     /// # Examples
     ///
     /// ```
     /// let temp_dir = tempfile::TempDir::new().unwrap();
-    /// let server = TestServer::launch("path/to/Cargo.toml", "sqlite://test.db".to_string(), Some(temp_dir)).unwrap();
+    /// let server = TestServer::launch(
+    ///     "path/to/Cargo.toml",
+    ///     "sqlite://test.db".to_string(),
+    ///     Some(temp_dir),
+    /// )
+    /// .unwrap();
     /// assert!(server.port() > 0);
     /// ```
     fn launch(
@@ -259,7 +272,10 @@ impl TestServer {
     #[cfg(feature = "postgres")]
     /// Launches a test instance of the `mxd` server using the specified database and configuration.
     ///
-    /// Binds the server to a random available local port, starts the server process with the provided manifest path and database URL, and waits for the server to become ready. Optionally manages a temporary directory for SQLite and an embedded PostgreSQL instance if used.
+    /// Binds the server to a random available local port, starts the server process with the
+    /// provided manifest path and database URL, and waits for the server to become ready.
+    /// Optionally manages a temporary directory for SQLite and an embedded PostgreSQL instance if
+    /// used.
     ///
     /// # Returns
     ///
@@ -267,7 +283,8 @@ impl TestServer {
     ///
     /// # Errors
     ///
-    /// Returns an error if binding the port, spawning the server process, or waiting for server readiness fails.
+    /// Returns an error if binding the port, spawning the server process, or waiting for server
+    /// readiness fails.
     ///
     /// # Examples
     ///
@@ -299,9 +316,7 @@ impl TestServer {
     }
 
     /// Return the port the server is bound to.
-    pub fn port(&self) -> u16 {
-        self.port
-    }
+    pub fn port(&self) -> u16 { self.port }
 
     /// Return the database connection URL used by the server.
     ///
@@ -317,11 +332,9 @@ impl TestServer {
     #[cfg(feature = "postgres")]
     /// Returns true if the server is using an embedded PostgreSQL instance.
     ///
-    /// This indicates that the test server started and manages its own embedded PostgreSQL database.
-    /// Returns false if an external PostgreSQL instance is used instead.
-    pub fn uses_embedded_postgres(&self) -> bool {
-        self.pg.is_some()
-    }
+    /// This indicates that the test server started and manages its own embedded PostgreSQL
+    /// database. Returns false if an external PostgreSQL instance is used instead.
+    pub fn uses_embedded_postgres(&self) -> bool { self.pg.is_some() }
 }
 
 impl Drop for TestServer {
@@ -343,8 +356,10 @@ impl Drop for TestServer {
     }
 }
 
-use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
 
 /// Send a valid protocol handshake and read the server reply.
 pub fn handshake(stream: &mut TcpStream) -> std::io::Result<()> {
@@ -367,18 +382,18 @@ pub fn handshake(stream: &mut TcpStream) -> std::io::Result<()> {
 }
 
 use chrono::{DateTime, Utc};
-
 use diesel_async::{AsyncConnection, RunQueryDsl};
 use futures_util::future::BoxFuture;
-use mxd::db::{
-    DbConnection, add_file_acl, apply_migrations, create_category, create_file, create_user,
+use mxd::{
+    db::{DbConnection, add_file_acl, apply_migrations, create_category, create_file, create_user},
+    models::{NewArticle, NewCategory, NewFileAcl, NewFileEntry, NewUser},
+    users::hash_password,
 };
-use mxd::models::{NewArticle, NewCategory, NewFileAcl, NewFileEntry, NewUser};
-use mxd::users::hash_password;
 
 /// Executes an asynchronous database setup function within a temporary Tokio runtime.
 ///
-/// Establishes a database connection, runs migrations, and invokes the provided async closure with the connection. Suitable for preparing test databases synchronously from non-async contexts.
+/// Establishes a database connection, runs migrations, and invokes the provided async closure with
+/// the connection. Suitable for preparing test databases synchronously from non-async contexts.
 ///
 /// # Parameters
 /// - `db`: Database connection string.
@@ -537,8 +552,10 @@ pub fn setup_news_categories_root_db(db: &str) -> Result<(), Box<dyn std::error:
 pub fn setup_news_categories_nested_db(db: &str) -> Result<(), Box<dyn std::error::Error>> {
     with_db(db, |conn| {
         Box::pin(async move {
-            use mxd::db::{create_bundle, create_category};
-            use mxd::models::NewBundle;
+            use mxd::{
+                db::{create_bundle, create_category},
+                models::NewBundle,
+            };
 
             let root_id = insert_root_bundle(conn).await?;
 
@@ -565,8 +582,7 @@ pub fn setup_news_categories_nested_db(db: &str) -> Result<(), Box<dyn std::erro
 }
 
 async fn insert_root_bundle(conn: &mut DbConnection) -> Result<i32, Box<dyn std::error::Error>> {
-    use mxd::db::create_bundle;
-    use mxd::models::NewBundle;
+    use mxd::{db::create_bundle, models::NewBundle};
 
     let id = create_bundle(
         conn,

--- a/tests/file_list.rs
+++ b/tests/file_list.rs
@@ -1,10 +1,13 @@
-use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
 
-use mxd::field_id::FieldId;
-
-use mxd::transaction::{FrameHeader, Transaction, decode_params, encode_params};
-use mxd::transaction_type::TransactionType;
+use mxd::{
+    field_id::FieldId,
+    transaction::{FrameHeader, Transaction, decode_params, encode_params},
+    transaction_type::TransactionType,
+};
 use test_util::{TestServer, handshake, setup_files_db};
 
 #[test]

--- a/tests/handshake.rs
+++ b/tests/handshake.rs
@@ -1,5 +1,7 @@
-use std::io::{Read, Write};
-use std::net::{Shutdown, TcpStream};
+use std::{
+    io::{Read, Write},
+    net::{Shutdown, TcpStream},
+};
 
 use test_util::TestServer;
 

--- a/tests/handshake_invalid.rs
+++ b/tests/handshake_invalid.rs
@@ -1,5 +1,7 @@
-use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
 
 use test_util::TestServer;
 

--- a/tests/handshake_unsupported_version.rs
+++ b/tests/handshake_unsupported_version.rs
@@ -1,5 +1,7 @@
-use std::io::{BufRead, BufReader, Read, Write};
-use std::net::TcpStream;
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    net::TcpStream,
+};
 
 use test_util::TestServer;
 

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -1,16 +1,18 @@
-use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
 
 use diesel::prelude::*;
-use diesel_async::AsyncConnection;
-use diesel_async::RunQueryDsl;
-use mxd::commands::NEWS_ERR_PATH_UNSUPPORTED;
-use mxd::db::DbConnection;
-use mxd::db::create_category;
-use mxd::field_id::FieldId;
-use mxd::models::NewCategory;
-use mxd::transaction::{FrameHeader, Transaction, decode_params, encode_params};
-use mxd::transaction_type::TransactionType;
+use diesel_async::{AsyncConnection, RunQueryDsl};
+use mxd::{
+    commands::NEWS_ERR_PATH_UNSUPPORTED,
+    db::{DbConnection, create_category},
+    field_id::FieldId,
+    models::NewCategory,
+    transaction::{FrameHeader, Transaction, decode_params, encode_params},
+    transaction_type::TransactionType,
+};
 use test_util::{TestServer, handshake, setup_news_db, with_db};
 
 #[test]

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -1,16 +1,22 @@
-use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
 
 use diesel_async::AsyncConnection;
-use mxd::commands::NEWS_ERR_PATH_UNSUPPORTED;
-use mxd::db::{DbConnection, apply_migrations, create_category};
-use mxd::field_id::FieldId;
-use mxd::models::NewCategory;
-use mxd::transaction::encode_params;
-use mxd::transaction::{FrameHeader, Transaction, decode_params};
-use mxd::transaction_type::TransactionType;
+use mxd::{
+    commands::NEWS_ERR_PATH_UNSUPPORTED,
+    db::{DbConnection, apply_migrations, create_category},
+    field_id::FieldId,
+    models::NewCategory,
+    transaction::{FrameHeader, Transaction, decode_params, encode_params},
+    transaction_type::TransactionType,
+};
 use test_util::{
-    TestServer, handshake, setup_news_categories_nested_db, setup_news_categories_root_db,
+    TestServer,
+    handshake,
+    setup_news_categories_nested_db,
+    setup_news_categories_root_db,
 };
 
 fn list_categories(
@@ -61,10 +67,12 @@ fn list_categories(
 }
 
 #[test]
-/// Tests that listing news categories at the root path returns all root-level bundles and categories.
+/// Tests that listing news categories at the root path returns all root-level bundles and
+/// categories.
 ///
-/// Sets up a test server with one bundle ("Bundle") and two categories ("General", "Updates") at the root level.
-/// Sends a transaction requesting news categories at the root path ("/") and verifies that the response contains all expected category names.
+/// Sets up a test server with one bundle ("Bundle") and two categories ("General", "Updates") at
+/// the root level. Sends a transaction requesting news categories at the root path ("/") and
+/// verifies that the response contains all expected category names.
 ///
 /// # Errors
 ///
@@ -80,18 +88,22 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-/// Tests that listing news categories with no path parameter returns all root-level bundles and categories.
+/// Tests that listing news categories with no path parameter returns all root-level bundles and
+/// categories.
 ///
-/// Sets up a database with one bundle ("Bundle") and two categories ("General", "Updates") not associated with any bundle. Sends a transaction request without a path parameter and verifies that the response contains all three names.
+/// Sets up a database with one bundle ("Bundle") and two categories ("General", "Updates") not
+/// associated with any bundle. Sends a transaction request without a path parameter and verifies
+/// that the response contains all three names.
 ///
 /// # Errors
 ///
-/// Returns an error if the test server setup, database operations, TCP communication, or protocol decoding fails.
+/// Returns an error if the test server setup, database operations, TCP communication, or protocol
+/// decoding fails.
 ///
 /// # Examples
 ///
 /// ```
-/// list_news_categories_no_path().unwrap();
+/// list_news_categories_no_path().unwrap(); 
 /// ```
 fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_root_db)?;
@@ -104,9 +116,11 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-/// Tests that requesting news categories with an invalid path returns the expected unsupported path error.
+/// Tests that requesting news categories with an invalid path returns the expected unsupported path
+/// error.
 ///
-/// Sets up a database with a single category, sends a transaction with an invalid path parameter, and asserts that the server responds with the `NEWS_ERR_PATH_UNSUPPORTED` error code.
+/// Sets up a database with a single category, sends a transaction with an invalid path parameter,
+/// and asserts that the server responds with the `NEWS_ERR_PATH_UNSUPPORTED` error code.
 ///
 /// # Returns
 /// Returns `Ok(())` if the test passes; otherwise, returns an error if any step fails.
@@ -137,7 +151,8 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
 /// Tests that requesting a list of news categories from an empty database returns no categories.
 ///
 /// This test sets up a test server with an empty database, performs a TCP handshake,
-/// sends a news category listing transaction, and asserts that the response contains no category names.
+/// sends a news category listing transaction, and asserts that the response contains no category
+/// names.
 ///
 /// # Errors
 ///
@@ -146,7 +161,7 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
 /// # Examples
 ///
 /// ```
-/// list_news_categories_empty().unwrap();
+/// list_news_categories_empty().unwrap(); 
 /// ```
 fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
@@ -165,13 +180,17 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-/// Tests that requesting news categories at a nested bundle path returns only the categories within that sub-bundle.
+/// Tests that requesting news categories at a nested bundle path returns only the categories within
+/// that sub-bundle.
 ///
-/// Sets up a nested bundle structure with a root bundle and a sub-bundle containing a single category. Sends a transaction requesting categories at the nested path and verifies that only the expected category is returned.
+/// Sets up a nested bundle structure with a root bundle and a sub-bundle containing a single
+/// category. Sends a transaction requesting categories at the nested path and verifies that only
+/// the expected category is returned.
 ///
 /// # Errors
 ///
-/// Returns an error if the test server setup, database operations, TCP communication, or protocol decoding fails.
+/// Returns an error if the test server setup, database operations, TCP communication, or protocol
+/// decoding fails.
 fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_nested_db)?;
 

--- a/tests/payload_reject.rs
+++ b/tests/payload_reject.rs
@@ -1,9 +1,13 @@
-use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
 
-use mxd::field_id::FieldId;
-use mxd::transaction::{FrameHeader, Transaction, encode_params};
-use mxd::transaction_type::TransactionType;
+use mxd::{
+    field_id::FieldId,
+    transaction::{FrameHeader, Transaction, encode_params},
+    transaction_type::TransactionType,
+};
 use test_util::TestServer;
 
 fn handshake(stream: &mut TcpStream) -> std::io::Result<()> {

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -1,13 +1,11 @@
-use mxd::field_id;
-use mxd::transaction::*;
-use mxd::transaction_type;
+use mxd::{field_id, transaction::*, transaction_type};
 use tokio::io::{AsyncWriteExt, duplex};
 
 fn build_tx() -> Transaction {
     let mut payload = Vec::new();
     payload.extend_from_slice(&[0x00, 0x02]);
-    payload.extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0xFF]);
-    payload.extend_from_slice(&[0x00, 0x02, 0x00, 0x02, 0xAA, 0xBB]);
+    payload.extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0xff]);
+    payload.extend_from_slice(&[0x00, 0x02, 0x00, 0x02, 0xaa, 0xbb]);
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -102,7 +100,7 @@ async fn mismatched_sizes() {
 async fn duplicate_field_error() {
     let mut tx = build_tx();
     tx.payload
-        .extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0xEE]);
+        .extend_from_slice(&[0x00, 0x01, 0x00, 0x01, 0xee]);
     tx.payload[0] = 0x00;
     tx.payload[1] = 0x03;
     tx.header.total_size = tx.payload.len() as u32;
@@ -131,8 +129,8 @@ async fn writer_payload_too_large() {
     payload.extend_from_slice(&count.to_be_bytes());
     for i in 0..count {
         payload.extend_from_slice(&(i + 1).to_be_bytes());
-        payload.extend_from_slice(&0xFFFFu16.to_be_bytes());
-        payload.extend(vec![0u8; 0xFFFF]);
+        payload.extend_from_slice(&0xffffu16.to_be_bytes());
+        payload.extend(vec![0u8; 0xffff]);
     }
     let header = FrameHeader {
         flags: 0,


### PR DESCRIPTION
## Summary
- document nightly formatting requirement in `AGENTS.md`
- run nightly rustfmt in CI workflow

## Testing
- `cargo +nightly fmt`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint '**/*.md'`
- `nixie docs`


------
https://chatgpt.com/codex/tasks/task_e_684f5713abd88322a20cce8a36297ba2

## Summary by Sourcery

Enforce nightly Rust formatting standards by introducing a dedicated rustfmt configuration, updating documentation, and running nightly format checks in CI.

Enhancements:
- Reformat entire codebase to comply with the new nightly rustfmt rules

CI:
- Install nightly rustfmt and enforce `cargo +nightly fmt -- --check` in the CI workflow

Documentation:
- Document the nightly formatting requirement in AGENTS.md

Chores:
- Add a .rustfmt.toml configuration file for nightly formatting