### PR TITLE
Introduce RAII Postgres fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +876,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -1924,10 +1945,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -2031,10 +2087,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2473,6 +2567,7 @@ dependencies = [
  "mxd",
  "nix",
  "postgresql_embedded",
+ "rstest",
  "tempfile",
  "tokio",
 ]

--- a/README.md
+++ b/README.md
@@ -86,12 +86,8 @@ Integration tests live in the repository's `tests/` directory.
 
 When the `postgres` feature is enabled, tests normally spin up an embedded
 PostgreSQL server. Set `POSTGRES_TEST_URL` to reuse an existing database URL
-instead of starting the embedded server.
-
-`postgres_db` **fixture (test-util)**
-
 - Inject `postgres_db` into any test that needs Postgres.
-- If `POSTGRES_TEST_URL` is set, the fixture uses that database; otherwise it
+- If `POSTGRES_TEST_URL` is set, the fixture uses that database; otherwise, it
   starts an embedded Postgres server.
 - The `public` schema is dropped and recreated **before** each test and again on
   teardown, so every test runs against a pristine schema regardless of reuse.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,15 @@ Integration tests live in the repository's `tests/` directory.
 
 When the `postgres` feature is enabled, tests normally spin up an embedded
 PostgreSQL server. Set `POSTGRES_TEST_URL` to reuse an existing database URL
-instead of starting the embedded server. The referenced database must be
-emptied between runs as the suite assumes a pristine schema.
+instead of starting the embedded server.
+
+`postgres_db` **fixture (test-util)**
+
+- Inject `postgres_db` into any test that needs Postgres.
+- If `POSTGRES_TEST_URL` is set, the fixture uses that database; otherwise it
+  starts an embedded Postgres server.
+- The `public` schema is dropped and recreated **before** each test and again on
+  teardown, so every test runs against a pristine schema regardless of reuse.
 
 ## Validation harness
 

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,6 +15,7 @@ postgresql_embedded = { version = "0.18.5", features = ["tokio"], optional = tru
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
+rstest = "0.18"
 
 [features]
 default = ["sqlite"]

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -1,15 +1,15 @@
 #[cfg(feature = "postgres")]
 use temp_env::with_var;
 #[cfg(feature = "postgres")]
-use test_util::setup_postgres_for_test;
+use test_util::PostgresTestDb;
 
 #[cfg(feature = "postgres")]
 #[test]
 fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
     with_var("POSTGRES_TEST_URL", Some("postgres://example"), || {
-        let (url, pg) = setup_postgres_for_test(|_| Ok(()))?;
-        assert_eq!(url, "postgres://example");
-        assert!(pg.is_none());
+        let db = PostgresTestDb::new()?;
+        assert_eq!(db.url, "postgres://example");
+        assert!(db.pg.is_none());
         Ok::<_, Box<dyn std::error::Error>>(())
     })
 }


### PR DESCRIPTION
## Summary
- manage Postgres integration DB with a `PostgresTestDb` fixture
- reset schema before and after each test
- remove old `setup_postgres` helper
- document the new fixture in README
- update environment variable test

## Testing
- `cargo +nightly-2025-06-10 fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md`
- `nixie docs/*.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_685072aa77948322bd1f17afa9fdbcb8

## Summary by Sourcery

Provide a RAII-style Postgres test fixture that auto-starts or reuses a database, resets the schema around each test, and deprecates the old setup helper.

New Features:
- Introduce PostgresTestDb struct providing RAII management of embedded or external test Postgres instances
- Expose a `postgres_db` rstest fixture to inject PostgresTestDb into tests

Enhancements:
- Remove legacy `setup_postgres` helper and simplify TestServer startup to use the new fixture
- Reset the public schema before and after each test to guarantee a pristine database state

Documentation:
- Document the new `postgres_db` fixture and its schema reset behavior in README

Tests:
- Update external Postgres environment test to use PostgresTestDb
- Add `rstest` dependency to enable the new fixture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded instructions for running tests with PostgreSQL, including details on the test database fixture and schema reset behaviour.

- **Refactor**
  - Improved PostgreSQL test database management by introducing a dedicated struct and fixture for cleaner lifecycle and schema handling.
  - Updated tests to use the new test database struct and fixture.

- **Chores**
  - Added a new test dependency to the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->