### PR TITLE
Pin nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,21 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
+        with:
+          override: true
+          components: rustfmt, clippy
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/${{ env.BUILD_PROFILE }}
+          key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
       - name: Export POSTGRES_TEST_URL
@@ -38,7 +52,7 @@ jobs:
         with:
           url: postgres://postgres:password@localhost/test
       - name: Format
-        run: rustup component add rustfmt --toolchain nightly-2025-06-10 && cargo +nightly-2025-06-10 fmt --all -- --check
+        run: cargo fmt --all -- --check
       - name: Lint
         run: cargo clippy --no-default-features --features ${{ matrix.feature }} -- -D warnings
       - name: Test
@@ -65,9 +79,21 @@ jobs:
       CODESCENE_CLI_SHA256: "a1c38415c5978908283c0608b648b27e954c93882b15d8b91d052d846c3eabd8"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
         with:
-          components: llvm-tools-preview
+          override: true
+          components: rustfmt, clippy
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/${{ env.BUILD_PROFILE }}
+          key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `cargo +nightly-2025-06-10 fmt --all` after making any change, and run
+- Run `cargo fmt --all` after making any change, and run
   `cargo clippy -- -D warnings` and
   `RUSTFLAGS="-D warnings" cargo test` before committing.
 - Clippy warnings MUST be disallowed.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-06-10"
+components = ["rustfmt", "clippy"]

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -221,7 +221,7 @@ impl Drop for PostgresTestDb {
 ///
 /// ```rust
 /// use rstest::rstest;
-/// use test_util::{postgres_db, PostgresTestDb};
+/// use test_util::{PostgresTestDb, postgres_db};
 ///
 /// #[rstest]
 /// fn my_test(postgres_db: PostgresTestDb) {


### PR DESCRIPTION
## Summary
- pin nightly Rust toolchain with clippy and rustfmt
- remove explicit `+nightly` in contributor instructions
- update CI to use pinned toolchain and cache cargo registry
- run `cargo fmt`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850888db0608322820afa5e58174354