### PR TITLE
Fix doc comment order

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -29,12 +29,11 @@ cfg_if! {
 
 /// Create a pooled connection to the configured database.
 ///
+/// Asynchronously establishes a database connection pool for the configured
+/// backend.
+///
 /// # Panics
 /// Panics if the connection pool cannot be created.
-#[must_use = "handle the pool"]
-/// Asynchronously establishes a database connection pool for the configured backend.
-///
-/// Panics if the pool cannot be created.
 ///
 /// # Examples
 ///
@@ -42,6 +41,7 @@ cfg_if! {
 /// use mxd::db::establish_pool;
 /// async fn example() { let pool = establish_pool("sqlite::memory:").await; }
 /// ```
+#[must_use = "handle the pool"]
 pub async fn establish_pool(database_url: &str) -> DbPool {
     let config = AsyncDieselConnectionManager::<DbConnection>::new(database_url);
     Pool::builder()
@@ -143,8 +143,7 @@ pub async fn audit_sqlite_features(conn: &mut DbConnection) -> QueryResult<()> {
 /// # Errors
 /// Returns any error produced by the version query or if the version string
 /// cannot be parsed.
-#[cfg(feature = "postgres")]
-#[must_use = "handle the result"]
+///
 /// Checks that the connected `PostgreSQL` server version is at least 14.
 ///
 /// Executes a version query and parses the result, returning an error if the version is unsupported
@@ -164,6 +163,8 @@ pub async fn audit_sqlite_features(conn: &mut DbConnection) -> QueryResult<()> {
 /// assert!(result.is_ok());
 /// # }
 /// ```
+#[cfg(feature = "postgres")]
+#[must_use = "handle the result"]
 pub async fn audit_postgres_features(
     conn: &mut diesel_async::AsyncPgConnection,
 ) -> QueryResult<()> {

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -66,7 +66,6 @@ where
     Ok((url, pg))
 }
 
-#[cfg(feature = "postgres")]
 /// Resets a PostgreSQL database by dropping and recreating the public schema.
 ///
 /// This function ensures a completely clean database state by removing all tables,
@@ -103,6 +102,7 @@ where
 /// reset_postgres_db(db_url)?;
 /// // Database now has a clean public schema
 /// ```
+#[cfg(feature = "postgres")]
 fn reset_postgres_db(url: &str) -> Result<(), Box<dyn std::error::Error>> {
     use postgres::{Client, NoTls};
 
@@ -111,7 +111,6 @@ fn reset_postgres_db(url: &str) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(feature = "postgres")]
 /// RAII-style PostgreSQL test database fixture that ensures clean schema state.
 ///
 /// This struct manages the lifecycle of a PostgreSQL database for testing, automatically
@@ -157,6 +156,7 @@ fn reset_postgres_db(url: &str) -> Result<(), Box<dyn std::error::Error>> {
 ///     // ... test implementation
 /// }
 /// ```
+#[cfg(feature = "postgres")]
 pub struct PostgresTestDb {
     /// PostgreSQL connection URL for the test database.
     ///
@@ -195,8 +195,6 @@ impl Drop for PostgresTestDb {
     }
 }
 
-#[cfg(feature = "postgres")]
-#[fixture]
 /// Test fixture that provides a clean PostgreSQL database for each test.
 ///
 /// This fixture creates a `PostgresTestDb` instance that manages database lifecycle
@@ -221,7 +219,7 @@ impl Drop for PostgresTestDb {
 ///
 /// ```rust
 /// use rstest::rstest;
-/// use test_util::{postgres_db, PostgresTestDb};
+/// use test_util::{PostgresTestDb, postgres_db};
 ///
 /// #[rstest]
 /// fn my_test(postgres_db: PostgresTestDb) {
@@ -234,6 +232,8 @@ impl Drop for PostgresTestDb {
 /// ## Panics
 ///
 /// Panics if database setup fails, which indicates a fundamental testing environment issue.
+#[cfg(feature = "postgres")]
+#[fixture]
 pub fn postgres_db() -> PostgresTestDb {
     PostgresTestDb::new().expect("Failed to prepare Postgres test database")
 }

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -66,7 +66,6 @@ fn list_categories(
     Ok((reply_tx.header, names))
 }
 
-#[test]
 /// Tests that listing news categories at the root path returns all root-level bundles and
 /// categories.
 ///
@@ -77,6 +76,7 @@ fn list_categories(
 /// # Errors
 ///
 /// Returns an error if the test server setup, TCP communication, or protocol validation fails.
+#[test]
 fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_root_db)?;
 
@@ -87,7 +87,6 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[test]
 /// Tests that listing news categories with no path parameter returns all root-level bundles and
 /// categories.
 ///
@@ -105,6 +104,7 @@ fn list_news_categories_root() -> Result<(), Box<dyn std::error::Error>> {
 /// ```
 /// list_news_categories_no_path().unwrap(); 
 /// ```
+#[test]
 fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_root_db)?;
 
@@ -115,7 +115,6 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[test]
 /// Tests that requesting news categories with an invalid path returns the expected unsupported path
 /// error.
 ///
@@ -124,6 +123,7 @@ fn list_news_categories_no_path() -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// # Returns
 /// Returns `Ok(())` if the test passes; otherwise, returns an error if any step fails.
+#[test]
 fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
@@ -147,7 +147,6 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
     assert_eq!(hdr.error, NEWS_ERR_PATH_UNSUPPORTED);
     Ok(())
 }
-#[test]
 /// Tests that requesting a list of news categories from an empty database returns no categories.
 ///
 /// This test sets up a test server with an empty database, performs a TCP handshake,
@@ -163,6 +162,7 @@ fn list_news_categories_invalid_path() -> Result<(), Box<dyn std::error::Error>>
 /// ```
 /// list_news_categories_empty().unwrap(); 
 /// ```
+#[test]
 fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", |db| {
         let rt = tokio::runtime::Runtime::new()?;
@@ -179,7 +179,6 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[test]
 /// Tests that requesting news categories at a nested bundle path returns only the categories within
 /// that sub-bundle.
 ///
@@ -191,6 +190,7 @@ fn list_news_categories_empty() -> Result<(), Box<dyn std::error::Error>> {
 ///
 /// Returns an error if the test server setup, database operations, TCP communication, or protocol
 /// decoding fails.
+#[test]
 fn list_news_categories_nested() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start_with_setup("./Cargo.toml", setup_news_categories_nested_db)?;
 


### PR DESCRIPTION
## Summary
- ensure doc comments appear before attributes in source and tests

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68508a3247048322bec740859f63c8c7