### PR TITLE
Fix Postgres test helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,6 +1707,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "postgres"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363e6dfbdd780d3aa3597b6eb430db76bb315fa9bad7fae595bb8def808b8470"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2580,7 @@ dependencies = [
  "futures-util",
  "mxd",
  "nix",
+ "postgres",
  "postgresql_embedded",
  "rstest",
  "tempfile",

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -16,6 +16,7 @@ argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
 rstest = "0.18"
+postgres = { version = "0.19", optional = true }
 
 [features]
 default = ["sqlite"]
@@ -25,6 +26,7 @@ postgres = [
     "mxd/postgres",
     "postgresql_embedded",
     "diesel_migrations/postgres",
+    "dep:postgres",
 ]
 sqlite = [
     "diesel/sqlite",

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -9,7 +9,7 @@ fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
     with_var("POSTGRES_TEST_URL", Some("postgres://example"), || {
         let db = PostgresTestDb::new()?;
         assert_eq!(db.url, "postgres://example");
-        assert!(db.pg.is_none());
+        assert!(!db.uses_embedded());
         Ok::<_, Box<dyn std::error::Error>>(())
     })
 }


### PR DESCRIPTION
## Summary
- fix branch using embedded Postgres when POSTGRES_TEST_URL not set
- gate reset_postgres_db by postgres feature
- expose PostgresTestDb::new and add uses_embedded helper
- use uses_embedded in postgres_env test
- include postgres crate for postgres feature

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --tests --workspace --features sqlite`
- `RUSTFLAGS="-D warnings" cargo test --tests --workspace --no-default-features --features postgres` *(fails: preparing embedded PostgreSQL: cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68508ad87408832295482e2f9dfd0281

## Summary by Sourcery

Fix and enhance the PostgreSQL test helper by exposing constructors, adding an embedded-usage helper, gating feature-specific code, updating tests, and adding the required build dependency.

New Features:
- Expose PostgresTestDb::new publicly
- Add uses_embedded() method to indicate embedded PostgreSQL usage

Bug Fixes:
- Correct branch logic to use embedded PostgreSQL when POSTGRES_TEST_URL is not set

Enhancements:
- Gate reset_postgres_db() and related code behind the postgres feature
- Refactor TestServer startup to correctly handle optional embedded Postgres

Build:
- Add optional postgres dependency and include it in the postgres feature

Tests:
- Update postgres_env.rs test to use uses_embedded() helper for assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to determine if an embedded PostgreSQL server is being used during testing.
- **Bug Fixes**
	- Improved conditional compilation for PostgreSQL-related test utilities, ensuring features are only available when enabled.
- **Tests**
	- Updated tests to use the new public method for checking embedded PostgreSQL usage, rather than accessing internal fields directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->