### PR TITLE
Add connection extension for recursive CTEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -519,6 +519,7 @@ name = "diesel_cte_ext"
 version = "0.1.0"
 dependencies = [
  "diesel",
+ "diesel-async",
 ]
 
 [[package]]
@@ -1256,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "liblzma"
@@ -1288,7 +1289,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
 ]
 
 [[package]]
@@ -1356,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "migrations_internals"
@@ -1625,7 +1626,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1836,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "pq-sys"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c852911b98f5981956037b2ca976660612e548986c30af075e753107bc3400"
+checksum = "dfd6cf44cca8f9624bc19df234fc4112873432f5fda1caff174527846d026fa9"
 dependencies = [
  "libc",
  "vcpkg",
@@ -1877,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1951,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -2077,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-tracing"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0eee96990cfb4c09545847385e89b2d2d2e571143d55264a05d77c713780"
+checksum = "d70ea85f131b2ee9874f0b160ac5976f8af75f3c9badfe0d955880257d10bd83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2324,12 +2325,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -2500,9 +2498,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3118,7 +3116,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
  "wasite",
  "web-sys",
 ]
@@ -3182,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -3504,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153a6fff49d264c4babdcfa6b4d534747f520e56e8f0f384f3b808c4b64cc1fd"
+checksum = "af7dcdb4229c0e79c2531a24de7726a0e980417a74fb4d030a35f535665439a0"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Integration tests live in the repository's `tests/` directory.
 
 When the `postgres` feature is enabled, tests normally spin up an embedded
 PostgreSQL server. Set `POSTGRES_TEST_URL` to reuse an existing database URL
+
 - Inject `postgres_db` into any test that needs Postgres.
 - If `POSTGRES_TEST_URL` is set, the fixture uses that database; otherwise, it
   starts an embedded Postgres server.

--- a/diesel_cte_ext/Cargo.toml
+++ b/diesel_cte_ext/Cargo.toml
@@ -6,11 +6,13 @@ publish = false
 
 [dependencies]
 diesel = { version = "2", default-features = false }
+diesel-async = { version = "0.5", default-features = false }
 
 [features]
-default = ["sqlite", "postgres"]
-sqlite = ["diesel/sqlite"]
-postgres = ["diesel/postgres"]
+default = ["sqlite", "postgres", "diesel-async"]
+sqlite = ["diesel/sqlite", "diesel-async/sqlite"]
+postgres = ["diesel/postgres", "diesel-async/postgres"]
+diesel-async = []
 
 [dev-dependencies]
 diesel = { version = "2", default-features = false, features = ["sqlite", "postgres", "chrono"] }

--- a/diesel_cte_ext/README.md
+++ b/diesel_cte_ext/README.md
@@ -2,22 +2,24 @@
 
 `diesel_cte_ext` adds a small helper for building recursive
 [Common Table Expressions](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-RECURSIVE)
-with Diesel. The crate exports the `with_recursive` function which constructs a
-query representing a `WITH RECURSIVE` block.
+with Diesel. The crate exports a connection extension trait providing
+`with_recursive` which constructs a query representing a `WITH RECURSIVE`
+block.
 
 ```rust
 use diesel::dsl::sql;
 use diesel::sql_types::Integer;
-use diesel_cte_ext::with_recursive;
+use diesel_cte_ext::RecursiveCTEExt;
 
-let rows: Vec<i32> = with_recursive::<diesel::sqlite::Sqlite, _, _, _>(
-    "t",
-    &["n"],
-    sql::<Integer>("SELECT 1"),
-    sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5"),
-    sql::<Integer>("SELECT n FROM t"),
-)
-.load(&mut conn)?;
+let rows: Vec<i32> = conn
+    .with_recursive(
+        "t",
+        &["n"],
+        sql::<Integer>("SELECT 1"),
+        sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5"),
+        sql::<Integer>("SELECT n FROM t"),
+    )
+    .load(&mut conn)?;
 ```
 
 The builder works with either SQLite or PostgreSQL depending on the enabled

--- a/diesel_cte_ext/src/connection_ext.rs
+++ b/diesel_cte_ext/src/connection_ext.rs
@@ -1,0 +1,120 @@
+use diesel::query_builder::QueryFragment;
+
+use crate::{
+    builders,
+    cte::{RecursiveBackend, WithRecursive},
+};
+
+/// Extension trait providing a convenient `with_recursive` method on
+/// connection types.
+///
+/// The backend is inferred from the connection, so callers do not need to
+/// specify it explicitly.
+pub trait RecursiveCTEExt {
+    /// Backend associated with the connection.
+    type Backend: RecursiveBackend;
+
+    /// Create a [`WithRecursive`] builder for this connection's backend.
+    ///
+    /// See [`builders::with_recursive`] for parameter details.
+    fn with_recursive<Seed, Step, Body>(
+        &self,
+        cte_name: &'static str,
+        columns: &'static [&'static str],
+        seed: Seed,
+        step: Step,
+        body: Body,
+    ) -> WithRecursive<Self::Backend, Seed, Step, Body>
+    where
+        Seed: QueryFragment<Self::Backend>,
+        Step: QueryFragment<Self::Backend>,
+        Body: QueryFragment<Self::Backend>;
+}
+
+#[cfg(feature = "sqlite")]
+impl RecursiveCTEExt for diesel::sqlite::SqliteConnection {
+    type Backend = diesel::sqlite::Sqlite;
+
+    fn with_recursive<Seed, Step, Body>(
+        &self,
+        cte_name: &'static str,
+        columns: &'static [&'static str],
+        seed: Seed,
+        step: Step,
+        body: Body,
+    ) -> WithRecursive<Self::Backend, Seed, Step, Body>
+    where
+        Seed: QueryFragment<Self::Backend>,
+        Step: QueryFragment<Self::Backend>,
+        Body: QueryFragment<Self::Backend>,
+    {
+        builders::with_recursive::<Self::Backend, _, _, _>(cte_name, columns, seed, step, body)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl RecursiveCTEExt for diesel::pg::PgConnection {
+    type Backend = diesel::pg::Pg;
+
+    fn with_recursive<Seed, Step, Body>(
+        &self,
+        cte_name: &'static str,
+        columns: &'static [&'static str],
+        seed: Seed,
+        step: Step,
+        body: Body,
+    ) -> WithRecursive<Self::Backend, Seed, Step, Body>
+    where
+        Seed: QueryFragment<Self::Backend>,
+        Step: QueryFragment<Self::Backend>,
+        Body: QueryFragment<Self::Backend>,
+    {
+        builders::with_recursive::<Self::Backend, _, _, _>(cte_name, columns, seed, step, body)
+    }
+}
+
+#[cfg(all(feature = "diesel-async", feature = "sqlite"))]
+impl RecursiveCTEExt
+    for diesel_async::sync_connection_wrapper::SyncConnectionWrapper<
+        diesel::sqlite::SqliteConnection,
+    >
+{
+    type Backend = diesel::sqlite::Sqlite;
+
+    fn with_recursive<Seed, Step, Body>(
+        &self,
+        cte_name: &'static str,
+        columns: &'static [&'static str],
+        seed: Seed,
+        step: Step,
+        body: Body,
+    ) -> WithRecursive<Self::Backend, Seed, Step, Body>
+    where
+        Seed: QueryFragment<Self::Backend>,
+        Step: QueryFragment<Self::Backend>,
+        Body: QueryFragment<Self::Backend>,
+    {
+        builders::with_recursive::<Self::Backend, _, _, _>(cte_name, columns, seed, step, body)
+    }
+}
+
+#[cfg(all(feature = "diesel-async", feature = "postgres"))]
+impl RecursiveCTEExt for diesel_async::AsyncPgConnection {
+    type Backend = diesel::pg::Pg;
+
+    fn with_recursive<Seed, Step, Body>(
+        &self,
+        cte_name: &'static str,
+        columns: &'static [&'static str],
+        seed: Seed,
+        step: Step,
+        body: Body,
+    ) -> WithRecursive<Self::Backend, Seed, Step, Body>
+    where
+        Seed: QueryFragment<Self::Backend>,
+        Step: QueryFragment<Self::Backend>,
+        Body: QueryFragment<Self::Backend>,
+    {
+        builders::with_recursive::<Self::Backend, _, _, _>(cte_name, columns, seed, step, body)
+    }
+}

--- a/diesel_cte_ext/src/lib.rs
+++ b/diesel_cte_ext/src/lib.rs
@@ -1,10 +1,13 @@
 //! Diesel extension crate providing support for recursive CTEs.
 //!
-//! The [`with_recursive`] function builds a Diesel query representing a
-//! `WITH RECURSIVE` block that can be executed like any other query.
+//! The [`RecursiveCTEExt::with_recursive`] method builds a Diesel query
+//! representing a `WITH RECURSIVE` block that can be executed like any other
+//! query.
 
 pub mod builders;
+pub mod connection_ext;
 pub mod cte;
 
 pub use builders::with_recursive;
+pub use connection_ext::RecursiveCTEExt;
 pub use cte::RecursiveBackend;

--- a/diesel_cte_ext/tests/cte.rs
+++ b/diesel_cte_ext/tests/cte.rs
@@ -1,10 +1,10 @@
 use diesel::{Connection, dsl::sql, sql_types::Integer};
-use diesel_cte_ext::with_recursive;
+use diesel_cte_ext::RecursiveCTEExt;
 
 fn sqlite_sync() -> Vec<i32> {
     use diesel::{RunQueryDsl, sqlite::SqliteConnection};
     let mut conn = SqliteConnection::establish(":memory:").unwrap();
-    with_recursive::<diesel::sqlite::Sqlite, _, _, _>(
+    conn.with_recursive(
         "t",
         &["n"],
         sql::<Integer>("SELECT 1"),
@@ -25,7 +25,7 @@ async fn sqlite_async() -> Vec<i32> {
     let mut conn = SyncConnectionWrapper::<SqliteConnection>::establish(":memory:")
         .await
         .unwrap();
-    with_recursive::<diesel::sqlite::Sqlite, _, _, _>(
+    conn.with_recursive(
         "t",
         &["n"],
         sql::<Integer>("SELECT 1"),
@@ -47,16 +47,17 @@ async fn pg_async() -> Vec<i32> {
     pg.create_database("test").await.unwrap();
     let url = pg.settings().url("test");
     let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
-    let res = with_recursive::<diesel::pg::Pg, _, _, _>(
-        "t",
-        &["n"],
-        sql::<Integer>("SELECT 1"),
-        sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5"),
-        sql::<Integer>("SELECT n FROM t"),
-    )
-    .load(&mut conn)
-    .await
-    .unwrap();
+    let res = conn
+        .with_recursive(
+            "t",
+            &["n"],
+            sql::<Integer>("SELECT 1"),
+            sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5"),
+            sql::<Integer>("SELECT n FROM t"),
+        )
+        .load(&mut conn)
+        .await
+        .unwrap();
     pg.stop().await.unwrap();
     res
 }
@@ -71,15 +72,16 @@ fn pg_sync() -> Vec<i32> {
     pg.create_database("test").unwrap();
     let url = pg.settings().url("test");
     let mut conn = PgConnection::establish(&url).unwrap();
-    let res = with_recursive::<diesel::pg::Pg, _, _, _>(
-        "t",
-        &["n"],
-        sql::<Integer>("SELECT 1"),
-        sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5"),
-        sql::<Integer>("SELECT n FROM t"),
-    )
-    .load(&mut conn)
-    .unwrap();
+    let res = conn
+        .with_recursive(
+            "t",
+            &["n"],
+            sql::<Integer>("SELECT 1"),
+            sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5"),
+            sql::<Integer>("SELECT n FROM t"),
+        )
+        .load(&mut conn)
+        .unwrap();
     pg.stop().unwrap();
     res
 }


### PR DESCRIPTION
## Summary
- add `RecursiveCTEExt` to infer backend from connection
- support synchronous and async connections in diesel_cte_ext
- update tests and docs to use the new extension
- fix markdownlint issue in README

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `yes | npx markdownlint-cli2 '**/*.md' '#node_modules'`
- `find . -name '*.md' -print0 | xargs -0 nixie`

------
https://chatgpt.com/codex/tasks/task_e_68512f9896e48322b555a386fe7fac05