### PR TITLE
Pin nightly toolchain

### DIFF
--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -21,7 +21,7 @@ runs:
     - run: |
         set -euo pipefail
         args=(--workspace)
-        if ! ${{ !! inputs.with-default-features }}; then
+        if [[ "${{ inputs.with-default-features }}" == "false" ]]; then
           args+=(--no-default-features)
         fi
         if [ -n "${{ inputs.features }}" ]; then

--- a/.github/actions/generate-coverage/action.yml
+++ b/.github/actions/generate-coverage/action.yml
@@ -1,0 +1,33 @@
+name: Generate coverage
+description: Run cargo llvm-cov with configurable features
+inputs:
+  features:
+    description: Cargo features to enable
+    required: false
+  with-default-features:
+    description: Enable default features
+    required: false
+    default: true
+  output-path:
+    description: Output file path
+    required: true
+  format:
+    description: Coverage format
+    required: false
+    default: lcov
+runs:
+  using: composite
+  steps:
+    - run: |
+        set -euo pipefail
+        args=(--workspace)
+        if ! ${{ !! inputs.with-default-features }}; then
+          args+=(--no-default-features)
+        fi
+        if [ -n "${{ inputs.features }}" ]; then
+          args+=(--features "${{ inputs.features }}")
+        fi
+        args+=(--${{ inputs.format }})
+        args+=(--output-path "${{ inputs.output-path }}")
+        cargo llvm-cov "${args[@]}"
+      shell: bash

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,29 @@
+name: Setup Rust
+description: Install Rust and cache cargo registry
+inputs:
+  with-postgres:
+    description: Install PostgreSQL system dependencies
+    required: false
+    default: false
+runs:
+  using: composite
+  steps:
+    - name: Install rust
+      uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
+      with:
+        override: true
+        components: rustfmt, clippy, llvm-tools-preview
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target/${{ env.BUILD_PROFILE }}
+        key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
+    - name: Install system dependencies
+      if: ${{ inputs.with-postgres }}
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+      shell: bash

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,7 +1,7 @@
 name: Setup Rust
 description: Install Rust and cache cargo registry
 inputs:
-  with-postgres:
+  install-postgres-deps:
     description: Install PostgreSQL system dependencies
     required: false
     default: false
@@ -24,6 +24,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
     - name: Install system dependencies
-      if: ${{ inputs.with-postgres }}
+      if: ${{ inputs.install-postgres-deps }}
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,12 @@ jobs:
       fail-fast: false
     env:
       CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
-          with-postgres: ${{ matrix.feature == 'postgres' }}
+          install-postgres-deps: ${{ matrix.feature == 'postgres' }}
       - name: Export POSTGRES_TEST_URL
         if: matrix.feature == 'postgres'
         uses: ./.github/actions/export-postgres-url
@@ -63,11 +64,12 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       CODESCENE_CLI_SHA256: "a1c38415c5978908283c0608b648b27e954c93882b15d8b91d052d846c3eabd8"
+      BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
-          with-postgres: true
+          install-postgres-deps: true
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+      - uses: ./.github/actions/setup-rust
+        with:
+          with-postgres: ${{ matrix.feature == 'postgres' }}
       - name: Export POSTGRES_TEST_URL
         if: matrix.feature == 'postgres'
         uses: ./.github/actions/export-postgres-url
         with:
           url: postgres://postgres:password@localhost/test
       - name: Format
-        run: rustup component add rustfmt --toolchain nightly-2025-06-10 && cargo +nightly-2025-06-10 fmt --all -- --check
+        run: cargo fmt --all -- --check
       - name: Lint
         run: cargo clippy --no-default-features --features ${{ matrix.feature }} -- -D warnings
       - name: Test
@@ -65,24 +65,27 @@ jobs:
       CODESCENE_CLI_SHA256: "a1c38415c5978908283c0608b648b27e954c93882b15d8b91d052d846c3eabd8"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
         with:
-          components: llvm-tools-preview
+          with-postgres: true
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
       - uses: oven-sh/setup-bun@v2
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
       - uses: ./.github/actions/export-postgres-url
         with:
           url: postgres://postgres:password@localhost/test
       - name: Generate coverage for SQLite
-        run: |
-          cargo llvm-cov --workspace --features sqlite --lcov --output-path lcov-sqlite.info
+        uses: ./.github/actions/generate-coverage
+        with:
+          features: sqlite
+          output-path: lcov-sqlite.info
       - name: Generate coverage for Postgres
-        run: |
-          cargo llvm-cov --workspace --no-default-features --features postgres --lcov --output-path lcov-postgres.info
+        uses: ./.github/actions/generate-coverage
+        with:
+          with-default-features: false
+          features: postgres
+          output-path: lcov-postgres.info
       - name: Merge coverage results
         run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
       - name: Install CodeScene coverage tool

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
 
       - name: Build fuzzing container
         run: docker build -t mxd-fuzz -f fuzz/Dockerfile .

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 360
     env:
       FUZZ_HARNESS: /usr/local/bin/fuzz
+      BUILD_PROFILE: debug
 
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `cargo +nightly-2025-06-10 fmt --all` after making any change, and run
+- Run `cargo fmt --all` after making any change, and run
   `cargo clippy -- -D warnings` and
   `RUSTFLAGS="-D warnings" cargo test` before committing.
 - Clippy warnings MUST be disallowed.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-06-10"
+components = ["rustfmt", "clippy", "llvm-tools-preview"]

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -221,7 +221,7 @@ impl Drop for PostgresTestDb {
 ///
 /// ```rust
 /// use rstest::rstest;
-/// use test_util::{postgres_db, PostgresTestDb};
+/// use test_util::{PostgresTestDb, postgres_db};
 ///
 /// #[rstest]
 /// fn my_test(postgres_db: PostgresTestDb) {


### PR DESCRIPTION
## Summary
- pin nightly Rust toolchain with clippy and rustfmt
- remove explicit `+nightly` in contributor instructions
- update CI to use pinned toolchain and cache cargo registry
- DRY up CI with reusable actions
- accept boolean input for coverage action
- make system dependency installation optional
- add llvm-tools-preview component to setup action

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint --version`
- `nixie docs`


------
https://chatgpt.com/codex/tasks/task_e_6850888db0608322820afa5e58174354

## Summary by Sourcery

Pin the Rust nightly toolchain and streamline CI by introducing reusable composite actions, updating workflows to leverage the pinned toolchain with caching and optional dependencies, and simplifying contributor instructions.

New Features:
- Add composite GitHub Action setup-rust for toolchain setup and cargo registry caching
- Add composite GitHub Action generate-coverage to standardize llvm-cov coverage generation

Enhancements:
- Pin nightly-2025-06-10 toolchain in rust-toolchain.toml with rustfmt, clippy, and llvm-tools-preview
- Remove explicit +nightly invocations from CI workflows and contributor docs

CI:
- Refactor CI workflows to use setup-rust and generate-coverage actions
- Cache cargo registry and make PostgreSQL/system dependency installation optional
- DRY up coverage steps for SQLite and Postgres

Documentation:
- Remove explicit nightly commands from contributor guidelines

Chores:
- Standardize import order in test-util example