### PR TITLE
Update documentation ellipsis

### DIFF
--- a/diesel_cte_ext/README.md
+++ b/diesel_cte_ext/README.md
@@ -32,7 +32,7 @@ The resulting CTE `t` contains the following rows:
 | 1 |
 | 2 |
 | 3 |
-| ... |
+| … |
 
 When the `async` feature is enabled, import `diesel_async::RunQueryDsl` and await
 the query as follows:


### PR DESCRIPTION
## Summary
- correct the ellipsis in diesel_cte_ext README

## Testing
- `cargo +nightly-2025-06-10 fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint diesel_cte_ext/README.md`
- `nixie diesel_cte_ext/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68517cbe2c34832293437c75a9491814

## Summary by Sourcery

Documentation:
- Replace three dots in example table with a typographic ellipsis character