### PR TITLE
Switch to trait-based recursion builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.1.0" 
 argon2 = { version = "0.5", features = ["std"] }
 rand = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-diesel_cte_ext = { path = "diesel_cte_ext" }
+diesel_cte_ext = { path = "diesel_cte_ext", default-features = false, features = ["async"] }
 futures-util = "0.3"
 tracing = "0.1"
 figment = { version = "0.10", features = ["toml", "env", "test"] }
@@ -40,6 +40,8 @@ postgres = [
     "diesel/postgres",
     "diesel_migrations/postgres",
     "diesel-async/postgres",
+    "diesel_cte_ext/postgres",
+    "diesel_cte_ext/async",
     "url",
     "test-util/postgres",
 ]
@@ -48,6 +50,8 @@ sqlite = [
     "diesel/returning_clauses_for_sqlite_3_35",
     "diesel_migrations/sqlite",
     "diesel-async/sqlite",
+    "diesel_cte_ext/sqlite",
+    "diesel_cte_ext/async",
     "test-util/sqlite",
 ]
 returning_clauses_for_sqlite_3_35 = ["diesel/returning_clauses_for_sqlite_3_35"]

--- a/diesel_cte_ext/src/connection_ext.rs
+++ b/diesel_cte_ext/src/connection_ext.rs
@@ -31,6 +31,7 @@ pub trait RecursiveCTEExt {
 
 /// Blanket implementation of [`RecursiveCTEExt`] for synchronous Diesel
 /// connections.
+#[cfg(not(feature = "async"))]
 impl<C> RecursiveCTEExt for C
 where
     C: diesel::connection::Connection,

--- a/src/db.rs
+++ b/src/db.rs
@@ -282,7 +282,7 @@ async fn bundle_id_from_path(
     let len_i32: i32 = i32::try_from(len).map_err(|_| PathLookupError::InvalidPath)?;
     let body = sql_query(BUNDLE_BODY_SQL).bind::<Integer, _>(len_i32);
 
-    let query = build_path_cte::<Backend, _, _>(step, body);
+    let query = build_path_cte(conn, step, body);
 
     let res: Option<BunId> = query.get_result(conn).await.optional()?;
     match res.and_then(|b| b.id) {
@@ -436,7 +436,7 @@ async fn category_id_from_path(
         .bind::<Integer, _>(len_minus_one)
         .bind::<Integer, _>(len_minus_one);
 
-    let query = build_path_cte::<Backend, _, _>(step, body);
+    let query = build_path_cte(conn, step, body);
 
     let res: Option<CatId> = query.get_result(conn).await.optional()?;
     res.map(|c| c.id).ok_or(PathLookupError::InvalidPath)


### PR DESCRIPTION
## Summary
- migrate to the `RecursiveCTEExt` trait method for building recursive CTEs
- propagate Diesel CTE feature flags and enable async usage
- guard synchronous trait implementation when async is enabled

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68517c708a608322bd8452d167af8f60

## Summary by Sourcery

Migrate to trait-based recursive CTE builder with async support and update CTE feature flags

Enhancements:
- Migrate to the RecursiveCTEExt trait for building recursive CTEs
- Enable async support and propagate CTE feature flags in Cargo.toml
- Update build_path_cte calls to accept the connection instead of type parameters
- Guard synchronous RecursiveCTEExt implementation behind the async feature

Build:
- Disable default features and enable async feature for diesel_cte_ext in Cargo.toml
- Add diesel_cte_ext entries under Postgres and SQLite features