### PR TITLE
Fix build_path_cte compiler error

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -282,7 +282,7 @@ async fn bundle_id_from_path(
     let len_i32: i32 = i32::try_from(len).map_err(|_| PathLookupError::InvalidPath)?;
     let body = sql_query(BUNDLE_BODY_SQL).bind::<Integer, _>(len_i32);
 
-    let query = build_path_cte(conn, step, body);
+    let query = build_path_cte::<DbConnection, _, _>(step, body);
 
     let res: Option<BunId> = query.get_result(conn).await.optional()?;
     match res.and_then(|b| b.id) {
@@ -436,7 +436,7 @@ async fn category_id_from_path(
         .bind::<Integer, _>(len_minus_one)
         .bind::<Integer, _>(len_minus_one);
 
-    let query = build_path_cte(conn, step, body);
+    let query = build_path_cte::<DbConnection, _, _>(step, body);
 
     let res: Option<CatId> = query.get_result(conn).await.optional()?;
     res.map(|c| c.id).ok_or(PathLookupError::InvalidPath)

--- a/src/db.rs
+++ b/src/db.rs
@@ -245,7 +245,7 @@ use crate::news_path::{
     BUNDLE_STEP_SQL,
     CATEGORY_BODY_SQL,
     CATEGORY_STEP_SQL,
-    build_path_cte,
+    build_path_cte_with_conn,
     prepare_path,
 };
 
@@ -282,7 +282,7 @@ async fn bundle_id_from_path(
     let len_i32: i32 = i32::try_from(len).map_err(|_| PathLookupError::InvalidPath)?;
     let body = sql_query(BUNDLE_BODY_SQL).bind::<Integer, _>(len_i32);
 
-    let query = build_path_cte::<DbConnection, _, _>(step, body);
+    let query = build_path_cte_with_conn(conn, step, body);
 
     let res: Option<BunId> = query.get_result(conn).await.optional()?;
     match res.and_then(|b| b.id) {
@@ -436,7 +436,7 @@ async fn category_id_from_path(
         .bind::<Integer, _>(len_minus_one)
         .bind::<Integer, _>(len_minus_one);
 
-    let query = build_path_cte::<DbConnection, _, _>(step, body);
+    let query = build_path_cte_with_conn(conn, step, body);
 
     let res: Option<CatId> = query.get_result(conn).await.optional()?;
     res.map(|c| c.id).ok_or(PathLookupError::InvalidPath)

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,9 +1,8 @@
-//! Database connection management and queries.
+//! Manage database connections and domain queries.
 //!
-//! Provides Diesel-based helpers for creating connection pools, running
-//! migrations and executing queries for users and news articles. The
-//! implementation supports both `SQLite` and `PostgreSQL` backends via feature
-//! flags.
+//! This module exposes helpers for creating pooled Diesel connections,
+//! running embedded migrations, and executing application queries.  It
+//! supports both `SQLite` and `PostgreSQL` backends, selected via feature flags.
 use cfg_if::cfg_if;
 use diesel::prelude::*;
 #[cfg(feature = "sqlite")]

--- a/src/news_path.rs
+++ b/src/news_path.rs
@@ -1,7 +1,9 @@
-//! Helpers for traversing news bundle paths.
+//! Utilities for traversing news bundle paths.
 //!
-//! This module builds SQL snippets for recursive CTE queries that walk the
-//! hierarchical news structure stored in the database.
+//! This module constructs SQL fragments used in recursive CTEs to walk the
+//! hierarchical bundle and category structure stored in the database.
+//! It also provides helpers for preparing path parameters and executing the
+//! recursive queries via Diesel.
 /// Generate the recursive CTE step SQL used for traversing news bundle paths.
 ///
 /// The `$jt` argument specifies the join type (`"JOIN"` or `"LEFT JOIN"`) used

--- a/src/news_path.rs
+++ b/src/news_path.rs
@@ -73,6 +73,22 @@ where
     )
 }
 
+/// Convenience wrapper that infers the connection type from `conn`.
+pub fn build_path_cte_with_conn<C, Step, Body>(
+    conn: &mut C,
+    step: Step,
+    body: Body,
+) -> WithRecursive<C::Backend, diesel::query_builder::SqlQuery, Step, Body>
+where
+    C: RecursiveCTEExt,
+    C::Backend: RecursiveBackend + diesel::backend::DieselReserveSpecialization,
+    Step: QueryFragment<C::Backend>,
+    Body: QueryFragment<C::Backend>,
+{
+    let _ = conn; // type inference only
+    build_path_cte::<C, Step, Body>(step, body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/news_path.rs
+++ b/src/news_path.rs
@@ -51,8 +51,11 @@ use diesel_cte_ext::{
 };
 
 /// Construct a recursive CTE for traversing bundle paths.
+///
+/// The connection type `C` is only used for backend inference; a concrete
+/// connection value is unnecessary. The step and body parameters are generic
+/// because their query types change once bindings are applied.
 pub(crate) fn build_path_cte<C, Step, Body>(
-    conn: &mut C,
     step: Step,
     body: Body,
 ) -> WithRecursive<C::Backend, diesel::query_builder::SqlQuery, Step, Body>
@@ -63,7 +66,7 @@ where
     Body: QueryFragment<C::Backend>,
 {
     let seed = sql_query(CTE_SEED_SQL);
-    conn.with_recursive(
+    C::with_recursive(
         "tree",
         &["idx", "id"],
         RecursiveParts::new(seed, step, body),


### PR DESCRIPTION
## Summary
- call `RecursiveCTEExt::with_recursive` without a connection value
- adjust callers accordingly and clarify docs
- explain generic parameters in `build_path_cte`

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685183fe8b1c8322a2b328cebbd437f8

## Summary by Sourcery

Refactor build_path_cte to eliminate the need for a concrete connection instance, adjust its callers accordingly, and clarify its documentation.

Enhancements:
- Remove the conn parameter from build_path_cte in favor of C::with_recursive for backend type inference
- Update all build_path_cte invocations in db.rs to pass explicit type parameters instead of a connection value

Documentation:
- Enhance build_path_cte doc comments to explain that the connection value is unnecessary and describe its generic parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated function signatures and usage to simplify how recursive queries are constructed, removing the need to pass a connection value.
  - Improved documentation for better clarity on function usage and type parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->