### PR TITLE
Update tmp dir logic in tests

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -90,8 +90,7 @@ where
 {
     let fut = async {
         let mut settings = Settings::default();
-        let (tmp, data_dir) = tempfile::tempdir()?.keep()?;
-        std::mem::forget(tmp);
+        let data_dir = tempfile::tempdir()?.into_path();
         settings.data_dir = data_dir.clone();
 
         let mut pg = if geteuid().is_root() {


### PR DESCRIPTION
## Summary
- simplify creation of embedded postgres data directory
- use tempfile's `into_path` instead of `keep`

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6851b22bd5a48322a8cf98635aef53bd

## Summary by Sourcery

Simplify test utility by refactoring temporary data directory creation to use `tempfile::tempdir().into_path()`

Enhancements:
- Replace `tempdir()?.keep()` and manual `mem::forget` with `tempdir()?.into_path()` for embedded Postgres data directory

Tests:
- Verify no Clippy warnings and pass all tests under strict warnings flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the process for creating a persistent temporary directory path for PostgreSQL embedded settings, making the logic simpler and more efficient. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->