### PR TITLE
Fix Postgres test util warnings

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -164,7 +164,7 @@ where
             temp_dir: tmp,
         })
     };
-    let mut embedded = match tokio::runtime::Handle::try_current() {
+    let embedded = match tokio::runtime::Handle::try_current() {
         Ok(handle) => handle.block_on(fut)?,
         Err(_) => tokio::runtime::Runtime::new()?.block_on(fut)?,
     };
@@ -275,7 +275,7 @@ pub struct PostgresTestDb {
     /// database specified via `POSTGRES_TEST_URL`.
     pg: Option<PostgreSQL>,
     /// Hold the data directory alive until after the embedded server stops.
-    temp_dir: Option<TempDir>,
+    _temp_dir: Option<TempDir>,
 }
 
 #[cfg(feature = "postgres")]
@@ -287,7 +287,7 @@ impl PostgresTestDb {
             return Ok(Self {
                 url,
                 pg: None,
-                temp_dir: None,
+                _temp_dir: None,
             });
         }
 
@@ -296,7 +296,7 @@ impl PostgresTestDb {
         Ok(Self {
             url,
             pg: Some(pg),
-            temp_dir: Some(temp_dir),
+            _temp_dir: Some(temp_dir),
         })
     }
 


### PR DESCRIPTION
## Summary
- avoid unnecessary `mut` binding in embedded postgres helper
- rename unused `temp_dir` field to `_temp_dir`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685206b3e34883228d99be2272dc837a

## Summary by Sourcery

Remove compiler warnings in the Postgres test utility by eliminating an unnecessary `mut` binding and renaming an unused field.

Enhancements:
- Remove unnecessary `mut` binding in embedded Postgres helper
- Rename unused `temp_dir` field to `_temp_dir` to suppress unused-field warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code clarity by renaming an internal field and updating variable mutability in the PostgreSQL test database setup. No changes to functionality or user-facing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->