### PR TITLE
Add caching for cross targets

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -20,6 +20,8 @@ runs:
           ~/.cargo/registry
           ~/.cargo/git
           target/${{ env.BUILD_PROFILE }}
+          target/x86_64-unknown-linux-musl/${{ env.BUILD_PROFILE }}
+          target/x86_64-pc-windows-gnu/${{ env.BUILD_PROFILE }}
         key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-


### PR DESCRIPTION
## Summary
- cache musl and Windows-gnu targets in the setup action

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `npx markdownlint-cli2 '**/*.md'` *(failed: npm error canceled)*
- `nixie **/*.md`

------
https://chatgpt.com/codex/tasks/task_e_685287583fe48322b7f961d11b5ff87b

## Summary by Sourcery

Enhancements:
- Cache build artifacts for x86_64-unknown-linux-musl and x86_64-pc-windows-gnu targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated caching in the build process to include additional target directories for improved efficiency during continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->