### PR TITLE
Fix compile check in columns

### DIFF
--- a/diesel_cte_ext/src/columns.rs
+++ b/diesel_cte_ext/src/columns.rs
@@ -38,9 +38,6 @@ const fn assert_column_names_impl<T: ColumnNames>() {}
 
 impl Columns<()> {
     /// Construct column names from a Diesel table definition.
-        // Provide a clear compile-time error if the table's column tuple
-        // lacks a `ColumnNames` implementation.
-        assert_column_names_impl::<Tbl::AllColumns>();
     ///
     /// # Note
     ///
@@ -52,13 +49,9 @@ impl Columns<()> {
         Tbl: Table,
         <Tbl as Table>::AllColumns: ColumnNames,
     {
-        // This static assertion provides a clearer error message if the macro limit is exceeded.
-        // If you hit this, your table likely has more than 16 columns.
-        const _: () = {
-            // This will fail to compile if ColumnNames is not implemented (i.e., >16 columns)
-            fn assert_column_names_impl<T: ColumnNames>() {}
-            let _ = assert_column_names_impl::<Tbl::AllColumns>;
-        };
+        // Touch the helper to surface a clearer error if `ColumnNames` is missing.
+        // Fails to compile for tables with more than 16 columns supported by the macro.
+        let _ = assert_column_names_impl::<Tbl::AllColumns>;
         Columns::<Tbl::AllColumns>::default()
     }
 }


### PR DESCRIPTION
## Summary
- fix stray compile check in `Columns::for_table`
- remove invalid static assert and use helper in function body

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68529204fae4832293db0025c97694b7

## Summary by Sourcery

Simplify and clarify compile-time checks in `Columns::for_table` by removing a stray assert and replacing the static assertion block with a direct helper invocation to enforce `ColumnNames` implementation errors.

Enhancements:
- Remove stray compile-time check in `Columns` initial implementation.
- Replace invalid `static_assert` block with direct call to `assert_column_names_impl` for clearer error messages when `ColumnNames` is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal compile-time checks for column trait implementation, with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->