### PR TITLE
Update Makefile tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,8 @@ project:
 
 - Run `cargo fmt --all` after making any change, and run
   `cargo clippy -- -D warnings` and
-  `RUSTFLAGS="-D warnings" cargo test` before committing. Tests can also be
-  executed using `make test`.
+  - Run `RUSTFLAGS="-D warnings" cargo test` before committing. Tests can also
+    be executed using `make test`.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in the code itself rather than
   silencing them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ project:
 
 - Run `cargo fmt --all` after making any change, and run
   `cargo clippy -- -D warnings` and
-  `RUSTFLAGS="-D warnings" cargo test` before committing.
+  `RUSTFLAGS="-D warnings" cargo test` before committing. Tests can also be
+  executed using `make test`.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in the code itself rather than
   silencing them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,11 +98,9 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `cargo fmt --all` after making any change, and run
-  `cargo clippy -- -D warnings` and
-  - Run `RUSTFLAGS="-D warnings" cargo test` before committing. Tests can also
-    be executed using `make test`.
-- Clippy warnings MUST be disallowed.
+- Run `cargo fmt --all`, and `cargo clippy -- -D warnings` after making any
+  change.
+- Run `make test` before committing, in addition to the above.
 - Fix any warnings emitted during tests in the code itself rather than
   silencing them.
 - Where a function is too long, extract meaningfully named helper functions

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: test-postgres test-sqlite
 test-postgres:
 	@RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres --quiet
 test-sqlite:
-	RUSTFLAGS="-D warnings" cargo test --features sqlite
+	@RUSTFLAGS="-D warnings" cargo test --features sqlite --quiet
 
 target/debug/mxd:
 	cargo build --bin mxd --features sqlite

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test corpus sqlite postgres sqlite-release postgres-release
+.PHONY: all clean test test-postgres test-sqlite corpus sqlite postgres sqlite-release postgres-release
 
 corpus:
 	cargo run --bin gen_corpus
@@ -14,8 +14,13 @@ clean:
 	cargo clean
 	rm -rf target/postgres
 
-test:
-	cargo test --quiet
+test: test-postgres test-sqlite
+
+test-postgres:
+	RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
+
+test-sqlite:
+	RUSTFLAGS="-D warnings" cargo test --features sqlite
 
 target/debug/mxd:
 	cargo build --bin mxd --features sqlite

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ clean:
 test: test-postgres test-sqlite
 
 test-postgres:
-	RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
-
+	@RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres --quiet
 test-sqlite:
 	RUSTFLAGS="-D warnings" cargo test --features sqlite
 


### PR DESCRIPTION
## Summary
- add separate sqlite/postgres test targets
- make `test` depend on these new targets
- document `make test` in contributor instructions

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --features sqlite --quiet`
- `markdownlint AGENTS.md`
- `nixie **/*.md`
- `make test -n`


------
https://chatgpt.com/codex/tasks/task_e_68529b4fe60c8322acdf49bc45591dad

## Summary by Sourcery

Split the Makefile's test rule into separate SQLite and Postgres targets, make the default 'test' target run both, and update contributor documentation accordingly.

Build:
- Add Makefile targets 'test-postgres' and 'test-sqlite' and update 'test' to depend on both

Documentation:
- Document the new 'make test' command and sub-targets in AGENTS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guidance to mention that tests can also be run using the `make test` command in addition to the previously recommended method.

- **Chores**
  - Enhanced test automation by splitting the test process into two separate targets for Postgres and SQLite, ensuring feature-specific test runs with stricter warning checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->