### PR TITLE
Update rust cache paths

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -19,9 +19,7 @@ runs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          target/${{ env.BUILD_PROFILE }}
-          target/x86_64-unknown-linux-musl/${{ env.BUILD_PROFILE }}
-          target/x86_64-pc-windows-gnu/${{ env.BUILD_PROFILE }}
+          target/**/${{ env.BUILD_PROFILE }}
         key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,27 @@ jobs:
       - name: Test
         run: cargo test --no-default-features --features ${{ matrix.feature }}
 
+  windows-build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        feature: [sqlite]
+      fail-fast: false
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+      - name: Add Windows GNU target
+        run: rustup target add x86_64-pc-windows-gnu
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Lint
+        run: cargo clippy --no-default-features --features ${{ matrix.feature }} -- -D warnings
+      - name: Build for Windows GNU
+        run: cargo build --target x86_64-pc-windows-gnu --no-default-features --features ${{ matrix.feature }}
+
   coverage:
     runs-on: ubuntu-latest
     services:

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -33,11 +33,10 @@ in parallel:
 nixie --concurrency 8 docs/*.md
 ```
 
-The script extracts each
-\`\`\`mermaid` block and attempts to render it using an embedded Mermaid
-renderer. Any syntax errors cause `nixie` to exit with a non-zero status. The
-failing diagram's line and a pointer to the error location are printed to help
-you fix the issue.
+The script extracts each `mermaid` code block and attempts to render it using an
+embedded Mermaid renderer. Any syntax errors cause `nixie` to exit with a
+non-zero status. The failing diagram's line and a pointer to the error location
+are printed to help you fix the issue.
 
 If `nixie` is not found on your `PATH` the validator explains how to install it.
 


### PR DESCRIPTION
## Summary
- cache compiled artifacts for any Rust target
- run build steps on Windows runners
- clarify mermaid validator docs

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint '**/*.md'`
- `nixie '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68529805c71c832292204f5382905675

## Summary by Sourcery

Expand Rust CI caching to cover all targets, introduce a Windows build workflow, and refine the mermaid validation documentation

Enhancements:
- Unify cache paths in setup-rust action to cache compiled artifacts for any target and build profile

CI:
- Add a Windows build job to run formatting, linting, and building on windows-latest runners

Documentation:
- Clarify the mermaid validator guide to better describe code block rendering and error reporting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Windows build job to the continuous integration workflow, enabling automated builds for the Windows GNU platform with the `sqlite` feature.

- **Chores**
  - Improved caching strategy for Rust build artefacts to enhance build efficiency across different target directories.

- **Documentation**
  - Refined wording in the Mermaid validation documentation for greater clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->