### PR TITLE
Use unique DB name for Postgres test fixture

### DIFF
--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -33,11 +33,10 @@ in parallel:
 nixie --concurrency 8 docs/*.md
 ```
 
-The script extracts each
-\`\`\`mermaid` block and attempts to render it using an embedded Mermaid
-renderer. Any syntax errors cause `nixie` to exit with a non-zero status. The
-failing diagram's line and a pointer to the error location are printed to help
-you fix the issue.
+The script extracts each `mermaid` code block and attempts to render it using an
+embedded Mermaid renderer. Any syntax errors cause `nixie` to exit with a
+non-zero status. The failing diagram's line and a pointer to the error location
+are printed to help you fix the issue.
 
 If `nixie` is not found on your `PATH` the validator explains how to install it.
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1317,3 +1317,9 @@ provided by `rstest`:
 By mastering `rstest`, Rust developers can significantly elevate the quality and
 efficiency of their testing practices, leading to more reliable and maintainable
 software.
+
+### C. Project-Specific Fixtures
+
+The `test_util` crate's `PostgresTestDb` fixture now generates a uniquely named
+database for each invocation. This ensures tests can run in parallel without
+database name conflicts.

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -153,11 +153,17 @@ where
             let _ = pg.stop().await;
             return Err(format!("starting embedded PostgreSQL: {e}").into());
         }
-        if let Err(e) = pg.create_database("test").await {
+        let db_name = format!(
+            "test_{}",
+            chrono::Utc::now()
+                .timestamp_nanos_opt()
+                .expect("valid timestamp")
+        );
+        if let Err(e) = pg.create_database(&db_name).await {
             let _ = pg.stop().await;
             return Err(format!("creating test database: {e}").into());
         }
-        let url = pg.settings().url("test");
+        let url = pg.settings().url(&db_name);
         Ok::<_, Box<dyn StdError>>(EmbeddedPg {
             url,
             pg,


### PR DESCRIPTION
## Summary
- generate unique DB names for embedded Postgres databases
- document that PostgresTestDb uses per-test database names
- clarify mermaid validation instructions

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `cargo clippy --no-default-features --features postgres -- -D warnings` *(fails: could not compile `postgres-setup-unpriv`)*
- `RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres` *(fails: could not compile `postgres-setup-unpriv`)*
- `markdownlint '**/*.md'`
- `nixie **/*.md`


------
https://chatgpt.com/codex/tasks/task_e_685299d37b00832283b9fa013c62b53a