### PR TITLE
Update markdown lint instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,13 @@ top-level `tests/` directory (not under `validator/tests`).**
 
 ## Markdown Guidance
 
-- Validate Markdown files using `markdownlint`.
+- Validate Markdown files using the provided `markdownlint` executable.
+  This wrapper already configures `markdownlint-cli2` so run it directly.
+
+  ```bash
+  markdownlint '**/*.md'
+  ```
+
 - Validate Markdown Mermaid diagrams using the `nixie` CLI. `nixie` is a
   standalone command-line tool, not an npm package. Invoke it directly with
   Markdown paths:

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -36,7 +36,7 @@ nixie --concurrency 8 docs/*.md
 The script extracts each `mermaid` block and attempts to render it using an
 embedded Mermaid renderer. Any syntax errors cause `nixie` to exit with a
 non-zero status. The failing diagram's line and a pointer to the error location
-are printed to help you fix the issue.
+are printed to aid in fixing the issue.
 
 If `nixie` is not found on your `PATH` the validator explains how to install it.
 

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -33,10 +33,9 @@ in parallel:
 nixie --concurrency 8 docs/*.md
 ```
 
-The script extracts each `mermaid` block and attempts to render it using an
-embedded Mermaid renderer. Any syntax errors cause `nixie` to exit with a
-non-zero status. The failing diagram's line and a pointer to the error location
-are printed to aid in fixing the issue.
+The script extracts each `mermaid` block, attempts rendering with an embedded
+Mermaid renderer, exits with a non-zero status on syntax errors, and prints the
+failing diagram's line with an error pointer.
 
 If `nixie` is not found on your `PATH` the validator explains how to install it.
 

--- a/docs/mermaid-validation.md
+++ b/docs/mermaid-validation.md
@@ -33,11 +33,10 @@ in parallel:
 nixie --concurrency 8 docs/*.md
 ```
 
-The script extracts each
-\`\`\`mermaid` block and attempts to render it using an embedded Mermaid
-renderer. Any syntax errors cause `nixie` to exit with a non-zero status. The
-failing diagram's line and a pointer to the error location are printed to help
-you fix the issue.
+The script extracts each `mermaid` block and attempts to render it using an
+embedded Mermaid renderer. Any syntax errors cause `nixie` to exit with a
+non-zero status. The failing diagram's line and a pointer to the error location
+are printed to help you fix the issue.
 
 If `nixie` is not found on your `PATH` the validator explains how to install it.
 


### PR DESCRIPTION
## Summary
- clarify how to run markdownlint via the local helper script
- clean up mermaid validation docs

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint '**/*.md'`
- `nixie docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_6852a266e79483229f08de0f4c161bc9

## Summary by Sourcery

Clarify markdown linting instructions and improve Mermaid validation documentation

Enhancements:
- Update Markdown guidance to use the provided markdownlint wrapper with an example invocation
- Refine wording in mermaid-validation.md for consistency and clearer error description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance on using the `markdownlint` tool, specifying the use of a preconfigured executable and providing a command example.
  - Condensed and clarified the description of the `nixie` validation script for Mermaid diagrams, improving brevity while retaining essential information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->