### PR TITLE
Add Windows test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: cargo clippy --no-default-features --features ${{ matrix.feature }} -- -D warnings
       - name: Build for Windows GNU
         run: cargo build --target x86_64-pc-windows-gnu --no-default-features --features ${{ matrix.feature }}
+      - name: Test for Windows GNU
+        run: cargo test --target x86_64-pc-windows-gnu --no-default-features --features ${{ matrix.feature }}
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure Windows GNU build runs `cargo test`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `make test` *(fails: could not compile `postgres-setup-unpriv`)*

------
https://chatgpt.com/codex/tasks/task_e_6852a7dc71fc83229b0c9d9102c278d9

## Summary by Sourcery

CI:
- Add a 'Test for Windows GNU' step running `cargo test` in the GitHub Actions CI configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated tests for the Windows GNU platform in the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->