### PR TITLE
Remove auth method configuration

### DIFF
--- a/postgres_setup_unpriv/Cargo.toml
+++ b/postgres_setup_unpriv/Cargo.toml
@@ -17,6 +17,8 @@ uncased = "0.9"
 
 [features]
 toml = []
+json5 = []
+yaml = []
 
 [dev-dependencies]
 rstest = "0.18"

--- a/postgres_setup_unpriv/src/lib.rs
+++ b/postgres_setup_unpriv/src/lib.rs
@@ -23,7 +23,13 @@ pub struct PgEnvCfg {
 }
 
 impl PgEnvCfg {
-    /// Convert into a fully‑formed `postgresql_embedded::Settings`.
+    /// Converts the configuration into a complete `postgresql_embedded::Settings` object.
+    ///
+    /// Applies version, connection, path, and locale settings from the current configuration.
+    /// Returns an error if the version requirement is invalid.
+    ///
+    /// # Returns
+    /// A fully configured `Settings` instance on success, or an error if configuration fails.
     pub fn to_settings(&self) -> Result<Settings> {
         let mut s = Settings::default();
 
@@ -64,6 +70,11 @@ impl PgEnvCfg {
         }
     }
 
+    /// Applies locale and encoding settings to the PostgreSQL configuration if specified
+    /// in the environment.
+    ///
+    /// Inserts the `locale` and `encoding` values into the settings configuration map when
+    /// present in the environment configuration.
     fn apply_locale(&self, settings: &mut Settings) {
         if let Some(ref loc) = self.locale {
             settings.configuration.insert("locale".into(), loc.clone());

--- a/postgres_setup_unpriv/src/lib.rs
+++ b/postgres_setup_unpriv/src/lib.rs
@@ -1,9 +1,10 @@
 // Library for postgres_setup_unpriv
+#![allow(non_snake_case)]
 
 use anyhow::{bail, Context, Result};
 use nix::unistd::{getresuid, geteuid, setresuid, Uid};
 use ortho_config::OrthoConfig;
-use postgresql_embedded::{settings::AuthMethod, PostgreSQL, Settings, VersionReq};
+use postgresql_embedded::{PostgreSQL, Settings, VersionReq};
 use serde::{Deserialize, Serialize};
 
 #[allow(non_snake_case)]
@@ -19,7 +20,6 @@ pub struct PgEnvCfg {
     pub runtime_dir: Option<std::path::PathBuf>,
     pub locale: Option<String>,
     pub encoding: Option<String>,
-    pub auth_method: Option<String>,
 }
 
 impl PgEnvCfg {
@@ -31,7 +31,6 @@ impl PgEnvCfg {
         self.apply_connection(&mut s);
         self.apply_paths(&mut s);
         self.apply_locale(&mut s);
-        self.apply_auth(&mut s)?;
 
         Ok(s)
     }
@@ -74,18 +73,6 @@ impl PgEnvCfg {
         }
     }
 
-    fn apply_auth(&self, settings: &mut Settings) -> Result<()> {
-        if let Some(ref am) = self.auth_method {
-            settings.auth_method = match am.to_ascii_lowercase().as_str() {
-                "trust" => AuthMethod::Trust,
-                "password" => AuthMethod::Password,
-                "md5" => AuthMethod::Md5,
-                "scram-sha-256" => AuthMethod::ScramSha256,
-                other => bail!("unknown PG_AUTH_METHOD '{other}'"),
-            };
-        }
-        Ok(())
-    }
 }
 
 /// Temporary privilege drop helper (process‑wide!)

--- a/postgres_setup_unpriv/tests/settings.rs
+++ b/postgres_setup_unpriv/tests/settings.rs
@@ -5,6 +5,16 @@ use postgresql_embedded::VersionReq;
 use nix::unistd::{geteuid, Uid};
 use rstest::rstest;
 
+/// Tests that a `PgEnvCfg` with specific settings is correctly converted to a `settings` object,
+/// and that all relevant fields and configuration values are preserved.
+///
+/// # Returns
+/// An `anyhow::Result` indicating success or failure of the round-trip conversion.
+///
+/// # Examples
+/// ```no_run
+/// to_settings_roundtrip()?;
+/// ```
 #[rstest]
 fn to_settings_roundtrip() -> anyhow::Result<()> {
     let cfg = PgEnvCfg {
@@ -29,6 +39,7 @@ fn to_settings_roundtrip() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that the default `PgEnvCfg` configuration can be converted to settings without error.
 #[rstest]
 fn to_settings_default_config() {
     let cfg = PgEnvCfg::default();
@@ -37,6 +48,7 @@ fn to_settings_default_config() {
 
 #[cfg(unix)]
 #[rstest]
+/// Verify that the effective uid is changed within the passed block
 fn with_temp_euid_changes_uid() -> anyhow::Result<()> {
     if !geteuid().is_root() {
         eprintln!("skipping root-dependent test");

--- a/postgres_setup_unpriv/tests/settings.rs
+++ b/postgres_setup_unpriv/tests/settings.rs
@@ -30,7 +30,7 @@ fn to_settings_roundtrip() -> anyhow::Result<()> {
 }
 
 #[rstest]
-fn to_settings_invalid_auth() {
+fn to_settings_default_config() {
     let cfg = PgEnvCfg::default();
     assert!(cfg.to_settings().is_ok());
 }


### PR DESCRIPTION
## Summary
- drop `auth_method` field from `PgEnvCfg`
- delete unused authentication logic
- clean up tests for removed field
- expose optional config features in helper crate

## Testing
- `cargo clippy -- -D warnings`
- `make test` *(fails: postgres-setup-unpriv failed to run)*
- `markdownlint '**/*.md'`
- `nixie $(git ls-files '*.md')`

------
https://chatgpt.com/codex/tasks/task_e_6853009dba3083229f1b4dda0c2e1f56

## Summary by Sourcery

Remove authentication configuration support from PgEnvCfg, clean up related tests, and add JSON5 and YAML feature flags to the helper crate

Enhancements:
- Remove auth_method field and related apply_auth logic from PgEnvCfg
- Expose optional JSON5 and YAML configuration support in the helper crate

Build:
- Add json5 and yaml feature flags to postgres_setup_unpriv Cargo.toml

Tests:
- Clean up and simplify tests by removing authentication-specific assertions and invalid auth cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional support for `json5` and `yaml` features.

- **Bug Fixes**
  - Removed the `auth_method` field and related logic from configuration, simplifying environment setup.

- **Tests**
  - Updated tests to reflect the removal of the `auth_method` field and ensure correct behaviour with the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->