### PR TITLE
Fix config warning

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
-[unstable]
-check-cfg = true
-
 [check-cfg]
 features = ["json5", "yaml", "toml"]


### PR DESCRIPTION
## Summary
- remove obsolete check-cfg setting

## Testing
- `cargo check --quiet`
- `cargo clippy -- -D warnings`
- `make test` *(fails: postgresql_embedded Permission denied)*
- `markdownlint '**/*.md'`
- `nixie **/*.md`


------
https://chatgpt.com/codex/tasks/task_e_68535532c0bc8322a3f2b04f3d40ced0

## Summary by Sourcery

Bug Fixes:
- Remove obsolete `unstable` check-cfg setting from Cargo config to suppress warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified configuration settings by removing an unused section from the configuration file. No impact on visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->