### PR TITLE
Fail early if postgres setup unprivileged is not run as root

### DIFF
--- a/postgres_setup_unpriv/src/lib.rs
+++ b/postgres_setup_unpriv/src/lib.rs
@@ -145,6 +145,11 @@ pub fn nobody_uid() -> Uid {
 }
 
 pub fn run() -> Result<()> {
+    // Running as non-root can't change ownership of installation/data
+    // directories. Fail fast instead of attempting setup and confusing users.
+    if !geteuid().is_root() {
+        bail!("must be run as root");
+    }
     let cfg = PgEnvCfg::load().context("failed to load configuration via OrthoConfig")?;
     let settings = cfg.to_settings()?;
 


### PR DESCRIPTION
## Summary
- check for root privileges in `postgres_setup_unpriv::run`
- test that `run` fails when executed as a non-root user

## Testing
- `cargo clippy -- -D warnings`
- `make test` *(fails: `list_files_reject_payload` and `list_files_acl` could not find required files)*
- `cargo test --manifest-path postgres_setup_unpriv/Cargo.toml run_requires_root -- --quiet`
- `markdownlint '**/*.md'`
- `nixie '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68542524b28883228285c3068abbd815

## Summary by Sourcery

Enforce root-only execution in postgres_setup_unpriv::run and add a test to verify failure for non-root users

Enhancements:
- Add an early privilege check in run() to bail if not executed as root

Tests:
- Introduce run_requires_root test to ensure run() fails when invoked with a non-root effective UID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to ensure setup fails immediately with a clear message if not run as root, preventing confusing behaviour during installation.

- **Tests**
  - Added a new test to verify that the setup process correctly requires root privileges and provides an appropriate error message if not run as root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->