### PR TITLE
Ensure Postgres tests use isolated databases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,7 @@ dependencies = [
  "rstest",
  "tempfile",
  "tokio",
+ "tracing",
  "url",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,7 @@ dependencies = [
  "rstest",
  "tempfile",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1325,4 +1325,5 @@ database for each invocation using a time-based UUID v7 suffix. The helper that
 creates these names accepts a custom prefix, making the logic reusable. Each
 fixture creates and later drops its own database—even when `POSTGRES_TEST_URL`
 points to an existing server—allowing parallel tests without leaving orphaned
-databases behind.
+databases behind. The setup and cleanup steps perform CREATE/DROP commands with
+a small exponential backoff to avoid transient locks during parallel runs.

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1322,6 +1322,7 @@ software.
 
 The `test_util` crate's `PostgresTestDb` fixture now generates a uniquely named
 database for each invocation using a time-based UUID v7 suffix. The helper that
-creates these names accepts a custom prefix, making the logic reusable. The
-database is dropped when the fixture is cleaned up, allowing parallel tests
-without leaving orphaned databases behind.
+creates these names accepts a custom prefix, making the logic reusable. Each
+fixture creates and later drops its own database—even when `POSTGRES_TEST_URL`
+points to an existing server—allowing parallel tests without leaving orphaned
+databases behind.

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -21,6 +21,7 @@ rstest = "0.18"
 postgres = { version = "0.19", optional = true }
 uuid = { version = "1", features = ["v7"], optional = true }
 url = { version = "2", optional = true }
+tracing = "0.1"
 
 [features]
 default = ["sqlite"]

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = "0.3"
 rstest = "0.18"
 postgres = { version = "0.19", optional = true }
 uuid = { version = "1", features = ["v7"], optional = true }
+url = { version = "2", optional = true }
 
 [features]
 default = ["sqlite"]
@@ -31,6 +32,7 @@ postgres = [
     "diesel_migrations/postgres",
     "dep:postgres",
     "dep:uuid",
+    "dep:url",
 ]
 sqlite = [
     "diesel/sqlite",

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -255,6 +255,12 @@ fn reset_postgres_db(url: &str) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(feature = "postgres")]
+/// Retry a PostgreSQL operation with exponential backoff.
+///
+/// The closure is executed up to five times, doubling the delay
+/// between attempts from 50ms to a maximum of one second. This
+/// mitigates transient lock or contention errors that may occur
+/// when tests run concurrently.
 fn retry_postgres<F>(mut op: F) -> Result<(), postgres::Error>
 where
     F: FnMut() -> Result<(), postgres::Error>,

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -8,7 +8,7 @@ use test_util::PostgresTestDb;
 fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
     with_var("POSTGRES_TEST_URL", Some("postgres://example"), || {
         let db = PostgresTestDb::new()?;
-        assert_eq!(db.url, "postgres://example");
+        assert!(db.url.starts_with("postgres://example/"));
         assert!(!db.uses_embedded());
         Ok::<_, Box<dyn std::error::Error>>(())
     })


### PR DESCRIPTION
## Summary
- always create a new database in `PostgresTestDb`
- use the `postgres` crate to create and drop databases
- document per-fixture database lifecycle
- adjust `postgres_env` test expectation

## Testing
- `markdownlint '**/*.md'`
- `nixie '**/*.md'` *(failed: No such file or directory)*
- `nixie **/*.md`
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` *(failed: list_files_acl, list_files_reject_payload)*

------
https://chatgpt.com/codex/tasks/task_e_68542f0fa2948322954f2fc4c58b8634

## Summary by Sourcery

Ensure Postgres tests run against isolated databases by always creating and dropping a unique database per fixture, whether using embedded or external servers.

Enhancements:
- Introduce create_external_db and drop_external_db functions to manage external Postgres databases.
- Configure PostgresTestDb to generate, connect to, and later drop a unique database for each test when POSTGRES_TEST_URL is set.
- Revise documentation to describe the per-fixture external database lifecycle.

Build:
- Add optional url crate dependency for admin URL parsing.

Tests:
- Update postgres_env test to expect the database URL to include the generated database name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved management of PostgreSQL test databases, including robust retry logic for creation and deletion with exponential backoff to handle transient locking issues.
  - Enhanced support for creating and dropping temporary databases on external PostgreSQL servers for each test fixture.

- **Bug Fixes**
  - More reliable cleanup of test databases, reducing the risk of orphaned databases during parallel test runs.

- **Documentation**
  - Updated documentation to clarify test database lifecycle and behaviour when using external PostgreSQL servers.

- **Chores**
  - Added new dependencies to support improved database management and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->