### PR TITLE
Fix Windows workflow installation condition

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,6 +24,6 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
     - name: Install system dependencies
-      if: ${{ inputs.install-postgres-deps }}
+      if: ${{ inputs.install-postgres-deps == 'true' && runner.os == 'Linux' }}
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
       shell: bash


### PR DESCRIPTION
## Summary
- ensure the setup-rust action only installs Postgres dependencies on Linux when explicitly requested

## Testing
- `cargo clippy -- -D warnings`
- `make test-postgres` *(fails: `file_list` tests report `No such file or directory`)*
- `make test-sqlite`
- `markdownlint '**/*.md'`
- `nixie **/*.md`

------
https://chatgpt.com/codex/tasks/task_e_6854330d44648322804e87ab393a262d

## Summary by Sourcery

CI:
- Add condition to only install libpq-dev on Linux and when install-postgres-deps input is true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to install system dependencies only when explicitly requested and running on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->