### PR TITLE
Fix postgres test setup

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -143,6 +143,10 @@ where
         settings.installation_dir = runtime_dir.clone();
 
         let mut pg = if geteuid().is_root() {
+            // Ensure the runtime directory exists before attempting to
+            // acquire the lock. `postgres-setup-unpriv` expects this
+            // directory to be present for installing the binaries.
+            std::fs::create_dir_all(&runtime_dir)?;
             let bin = HELPER_BIN
                 .clone()
                 .map_err(|e| -> Box<dyn StdError> { e.into() })?;


### PR DESCRIPTION
## Summary
- create the postgres runtime directory before locking it

## Testing
- `cargo test list_files_acl -- --nocapture`
- `cargo test list_files_reject_payload -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6854353c0d90832289093920368b340b

## Summary by Sourcery

Bug Fixes:
- Create the Postgres runtime directory with `create_dir_all` before locking to satisfy `postgres-setup-unpriv` requirements in tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the runtime directory is created before starting embedded PostgreSQL as root, improving reliability during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->