### PR TITLE
Add query wrapper macros for recursive CTEs

### DIFF
--- a/diesel_cte_ext/README.md
+++ b/diesel_cte_ext/README.md
@@ -26,7 +26,8 @@ let rows: Vec<i32> = SqliteConnection::with_recursive(
 
 The `seed_query!` and `step_query!` macros wrap regular Diesel expressions so
 they can be embedded in the recursive CTE builder without implementing
-`QueryFragment` manually.
+`QueryFragment` manually. Alternatively, call `.into()` on the expression to
+convert it into a `QueryPart`.
 
 `Columns<T>` couples the runtime column names with a compile-time tuple of
 Diesel column types. For ad-hoc CTEs use a string slice directly or

--- a/diesel_cte_ext/src/lib.rs
+++ b/diesel_cte_ext/src/lib.rs
@@ -8,6 +8,7 @@ pub mod builders;
 pub mod columns;
 pub mod connection_ext;
 pub mod cte;
+pub mod macros;
 
 pub use builders::RecursiveParts;
 #[deprecated(note = "Use `RecursiveCTEExt::with_recursive` instead")]
@@ -15,3 +16,4 @@ pub use builders::with_recursive;
 pub use columns::Columns;
 pub use connection_ext::RecursiveCTEExt;
 pub use cte::RecursiveBackend;
+pub use macros::QueryPart;

--- a/diesel_cte_ext/src/macros.rs
+++ b/diesel_cte_ext/src/macros.rs
@@ -1,0 +1,36 @@
+use diesel::{
+    backend::Backend,
+    query_builder::{AstPass, QueryFragment},
+    result::QueryResult,
+};
+
+/// Wrapper for Diesel expressions used in recursive CTEs.
+#[derive(Debug, Clone)]
+pub struct QueryPart<T>(pub T);
+
+impl<T> QueryPart<T> {
+    /// Wrap a Diesel expression for use with `with_recursive`.
+    pub fn new(expr: T) -> Self { Self(expr) }
+}
+
+impl<DB, T> QueryFragment<DB> for QueryPart<T>
+where
+    DB: Backend,
+    T: QueryFragment<DB>,
+{
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> { self.0.walk_ast(out) }
+}
+
+#[macro_export]
+macro_rules! seed_query {
+    ($expr:expr $(,)?) => {
+        $crate::macros::QueryPart::new($expr)
+    };
+}
+
+#[macro_export]
+macro_rules! step_query {
+    ($expr:expr $(,)?) => {
+        $crate::macros::QueryPart::new($expr)
+    };
+}

--- a/diesel_cte_ext/src/macros.rs
+++ b/diesel_cte_ext/src/macros.rs
@@ -14,6 +14,10 @@ impl<T> QueryPart<T> {
     pub fn new(expr: T) -> Self { Self(expr) }
 }
 
+impl<T> From<T> for QueryPart<T> {
+    fn from(expr: T) -> Self { Self(expr) }
+}
+
 impl<DB, T> QueryFragment<DB> for QueryPart<T>
 where
     DB: Backend,
@@ -35,6 +39,17 @@ macro_rules! cte_query {
 }
 
 #[macro_export]
+#[doc = "Wrap a Diesel expression to use as the seed query in a recursive CTE."]
+#[doc = ""]
+#[doc = "# Example"]
+#[doc = ""]
+#[doc = "```"]
+#[doc = "use diesel::dsl::sql;"]
+#[doc = "use diesel::sql_types::Integer;"]
+#[doc = "use diesel_cte_ext::seed_query;"]
+#[doc = ""]
+#[doc = "let part = seed_query!(sql::<Integer>(\"SELECT 1\"));"]
+#[doc = "```"]
 macro_rules! seed_query {
     ($expr:expr $(,)?) => {
         $crate::cte_query!($expr)
@@ -42,6 +57,17 @@ macro_rules! seed_query {
 }
 
 #[macro_export]
+#[doc = "Wrap a Diesel expression to use as a step query within a recursive CTE."]
+#[doc = ""]
+#[doc = "# Example"]
+#[doc = ""]
+#[doc = "```"]
+#[doc = "use diesel::dsl::sql;"]
+#[doc = "use diesel::sql_types::Integer;"]
+#[doc = "use diesel_cte_ext::step_query;"]
+#[doc = ""]
+#[doc = "let part = step_query!(sql::<Integer>(\"SELECT n + 1 FROM t\"));"]
+#[doc = "```"]
 macro_rules! step_query {
     ($expr:expr $(,)?) => {
         $crate::cte_query!($expr)

--- a/diesel_cte_ext/src/macros.rs
+++ b/diesel_cte_ext/src/macros.rs
@@ -1,6 +1,7 @@
+//! Macros and helpers for embedding Diesel expressions inside recursive CTEs.
 use diesel::{
     backend::Backend,
-    query_builder::{AstPass, QueryFragment},
+    query_builder::{AstPass, QueryFragment, QueryId},
     result::QueryResult,
 };
 
@@ -21,16 +22,28 @@ where
     fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> { self.0.walk_ast(out) }
 }
 
+impl<T> QueryId for QueryPart<T> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+#[macro_export]
+macro_rules! cte_query {
+    ($expr:expr $(,)?) => {
+        $crate::QueryPart::new($expr)
+    };
+}
+
 #[macro_export]
 macro_rules! seed_query {
     ($expr:expr $(,)?) => {
-        $crate::macros::QueryPart::new($expr)
+        $crate::cte_query!($expr)
     };
 }
 
 #[macro_export]
 macro_rules! step_query {
     ($expr:expr $(,)?) => {
-        $crate::macros::QueryPart::new($expr)
+        $crate::cte_query!($expr)
     };
 }

--- a/diesel_cte_ext/tests/macros.rs
+++ b/diesel_cte_ext/tests/macros.rs
@@ -1,6 +1,13 @@
 //! Compile-time tests verifying the columns macros build valid queries.
 use diesel::{dsl::sql, sql_types::Integer, sqlite::SqliteConnection};
-use diesel_cte_ext::{RecursiveCTEExt, RecursiveParts, columns, table_columns};
+use diesel_cte_ext::{
+    RecursiveCTEExt,
+    RecursiveParts,
+    columns,
+    seed_query,
+    step_query,
+    table_columns,
+};
 
 #[test]
 fn table_columns_compile() {
@@ -30,4 +37,52 @@ fn columns_macro_compile() {
         ),
     )
     .load::<i32>(&mut conn);
+}
+
+#[test]
+fn query_macros_sqlite() {
+    let mut conn = SqliteConnection::establish(":memory:").unwrap();
+    let rows: Vec<i32> = SqliteConnection::with_recursive(
+        "t",
+        &["n"],
+        RecursiveParts::new(
+            seed_query!(sql::<Integer>("SELECT 1")),
+            step_query!(sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5")),
+            step_query!(sql::<Integer>("SELECT n FROM t")),
+        ),
+    )
+    .load(&mut conn)
+    .unwrap();
+    assert_eq!(rows, vec![1, 2, 3, 4, 5]);
+}
+
+// TODO: re-enable once embedded Postgres works in CI
+#[tokio::test]
+#[ignore]
+async fn query_macros_postgres() {
+    use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+    use postgresql_embedded::PostgreSQL;
+
+    let mut pg = PostgreSQL::default();
+    pg.setup().await.unwrap();
+    pg.start().await.unwrap();
+    pg.create_database("test").await.unwrap();
+    let url = pg.settings().url("test");
+    let res = {
+        let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+        AsyncPgConnection::with_recursive(
+            "t",
+            &["n"],
+            RecursiveParts::new(
+                seed_query!(sql::<Integer>("SELECT 1")),
+                step_query!(sql::<Integer>("SELECT n + 1 FROM t WHERE n < 5")),
+                step_query!(sql::<Integer>("SELECT n FROM t")),
+            ),
+        )
+        .load(&mut conn)
+        .await
+        .unwrap()
+    };
+    pg.stop().await.unwrap();
+    assert_eq!(res, vec![1, 2, 3, 4, 5]);
 }


### PR DESCRIPTION
## Summary
- provide `seed_query!` and `step_query!` macros in `diesel_cte_ext`
- re-export helper struct and update examples to use the macros
- test new macros on SQLite and PostgreSQL
- mark Postgres CTE tests as ignored until the environment works

## Testing
- `cargo clippy -- -D warnings`
- `markdownlint '**/*.md'`
- `nixie docs/*.md diesel_cte_ext/README.md`
- `make test` *(fails: postgres-setup-unpriv failed)*

------
https://chatgpt.com/codex/tasks/task_e_6853da19c5b083229ebdc70c39c4d3b9

## Summary by Sourcery

Introduce wrapper macros for constructing recursive CTE queries with Diesel, expose them via the public API, and update documentation and tests accordingly.

New Features:
- Add `seed_query!` and `step_query!` macros to wrap Diesel expressions for recursive CTEs

Enhancements:
- Expose a new `macros` module and re-export `QueryPart` in the public API

Documentation:
- Update README with examples demonstrating the use of `seed_query!` and `step_query!` macros

Tests:
- Add SQLite tests for the new query macros and an ignored async PostgreSQL test for recursive CTEs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced macros for constructing recursive CTE queries, allowing use of Diesel's query DSL without manual SQL.
- **Documentation**
  - Updated documentation to include usage examples and explanations for the new macros.
- **Tests**
  - Added tests demonstrating the new macros with both SQLite and PostgreSQL (the latter currently disabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->