### PR TITLE
Improve Postgres test isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,7 @@ dependencies = [
  "rstest",
  "tempfile",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,16 @@
 
 corpus:
 	cargo run --bin gen_corpus
-
+	
 sqlite: target/debug/mxd
 postgres: target/postgres/debug/mxd
 sqlite-release: target/release/mxd
 postgres-release: target/postgres/release/mxd
+
+POSTGRES_SETUP_SRCS := $(wildcard postgres_setup_unpriv/src/*.rs)
+
+target/debug/postgres-setup-unpriv: $(POSTGRES_SETUP_SRCS) postgres_setup_unpriv/Cargo.toml
+	cargo build --bin postgres-setup-unpriv --manifest-path postgres_setup_unpriv/Cargo.toml --target-dir target
 
 all: sqlite-release
 
@@ -16,9 +21,9 @@ clean:
 
 test: test-postgres test-sqlite
 
-test-postgres:
+test-postgres: target/debug/postgres-setup-unpriv
 	RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
-test-sqlite:
+test-sqlite: target/debug/postgres-setup-unpriv
 	RUSTFLAGS="-D warnings" cargo test --features sqlite
 
 target/debug/mxd:

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1324,7 +1324,9 @@ The `test_util` crate's `PostgresTestDb` fixture now generates a uniquely named
 database for each invocation using a time-based UUID v7 suffix. The helper that
 creates these names accepts a custom prefix, making the logic reusable. The
 database is dropped when the fixture is cleaned up, allowing parallel tests
-without leaving orphaned databases behind.
+without leaving orphaned databases behind. This happens even when
+`POSTGRES_TEST_URL` points at an external server—the fixture connects to that
+server, creates a temporary database, and removes it again on drop.
 
 ### D. Preventing Concurrent Embedded PostgreSQL Installs
 

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = "0.3"
 rstest = "0.18"
 postgres = { version = "0.19", optional = true }
 uuid = { version = "1", features = ["v7"], optional = true }
+url = { version = "2", optional = true }
 
 [features]
 default = ["sqlite"]
@@ -31,6 +32,7 @@ postgres = [
     "diesel_migrations/postgres",
     "dep:postgres",
     "dep:uuid",
+    "dep:url",
 ]
 sqlite = [
     "diesel/sqlite",

--- a/test-util/src/postgres.rs
+++ b/test-util/src/postgres.rs
@@ -161,8 +161,32 @@ fn drop_embedded_db(pg: &PostgreSQL, db_name: &str) {
     }
 }
 
+fn create_external_db(base_url: &str) -> Result<(String, String), Box<dyn StdError>> {
+    use postgres::{Client, NoTls};
+    use url::Url;
+
+    let mut url = Url::parse(base_url)?;
+    let db_name = generate_db_name("test_");
+    let admin_url = url.to_string();
+    let mut client = Client::connect(&admin_url, NoTls)?;
+    let query = format!("CREATE DATABASE \"{}\"", db_name);
+    client.batch_execute(&query)?;
+    url.set_path(&db_name);
+    Ok((url.to_string(), db_name))
+}
+
+fn drop_external_db(admin_url: &str, db_name: &str) {
+    if let Ok(mut client) = postgres::Client::connect(admin_url, postgres::NoTls) {
+        let query = format!("DROP DATABASE IF EXISTS \"{}\"", db_name);
+        if let Err(e) = client.batch_execute(&query) {
+            eprintln!("error dropping database {}: {}", db_name, e);
+        }
+    }
+}
+
 pub struct PostgresTestDb {
     pub url: String,
+    admin_url: Option<String>,
     pg: Option<PostgreSQL>,
     db_name: Option<String>,
     _temp_dir: Option<TempDir>,
@@ -171,12 +195,13 @@ pub struct PostgresTestDb {
 impl PostgresTestDb {
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
         if let Some(value) = std::env::var_os("POSTGRES_TEST_URL") {
-            let url = value.to_string_lossy().into_owned();
-            reset_postgres_db(&url)?;
+            let admin_url = value.to_string_lossy().into_owned();
+            let (url, db_name) = create_external_db(&admin_url)?;
             return Ok(Self {
                 url,
+                admin_url: Some(admin_url),
                 pg: None,
-                db_name: None,
+                db_name: Some(db_name),
                 _temp_dir: None,
             });
         }
@@ -190,6 +215,7 @@ impl PostgresTestDb {
         } = start_embedded_postgres(|url| reset_postgres_db(url))?;
         Ok(Self {
             url,
+            admin_url: None,
             pg: Some(pg),
             db_name: Some(db_name),
             _temp_dir: Some(temp_dir),
@@ -201,8 +227,9 @@ impl PostgresTestDb {
 
 impl Drop for PostgresTestDb {
     fn drop(&mut self) {
-        match (&self.pg, &self.db_name) {
-            (Some(pg), Some(name)) => drop_embedded_db(pg, name),
+        match (&self.pg, &self.db_name, &self.admin_url) {
+            (Some(pg), Some(name), _) => drop_embedded_db(pg, name),
+            (None, Some(name), Some(admin)) => drop_external_db(admin, name),
             _ => {
                 let _ = reset_postgres_db(&self.url);
             }

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -6,10 +6,15 @@ use test_util::PostgresTestDb;
 #[cfg(feature = "postgres")]
 #[test]
 fn external_postgres_is_used() -> Result<(), Box<dyn std::error::Error>> {
-    with_var("POSTGRES_TEST_URL", Some("postgres://example"), || {
+    let base = std::env::var("POSTGRES_TEST_URL")
+        .unwrap_or_else(|_| String::from("postgres://postgres:password@localhost/test"));
+    let idx = base.rfind('/').expect("url has path");
+    let prefix = &base[..=idx];
+    with_var("POSTGRES_TEST_URL", Some(&base), || {
         let db = PostgresTestDb::new()?;
-        assert_eq!(db.url, "postgres://example");
         assert!(!db.uses_embedded());
+        assert!(db.url.starts_with(prefix));
+        assert_ne!(db.url, base);
         Ok::<_, Box<dyn std::error::Error>>(())
     })
 }


### PR DESCRIPTION
## Summary
- always create a temporary PostgreSQL database for `PostgresTestDb`
- drop created databases on fixture cleanup
- clarify behaviour in testing docs
- update environment test
- build `postgres-setup-unpriv` via Makefile

## Testing
- `markdownlint '**/*.md'`
- `bash -lc 'shopt -s globstar; nixie **/*.md'`
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` *(fails: Error: Os { code: 2, kind: NotFound, message: "No such file or directory" })*

------
https://chatgpt.com/codex/tasks/task_e_6854a5914d1883229faef89e9f56b56d