### PR TITLE
Fix runtime dir creation for embedded Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ clean:
 test: test-postgres test-sqlite
 
 test-postgres: target/debug/postgres-setup-unpriv
-       RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres -- --nocapture
+	RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres -- --nocapture
+
 test-sqlite:
 	RUSTFLAGS="-D warnings" cargo test --features sqlite
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 test: test-postgres test-sqlite
 
 test-postgres: target/debug/postgres-setup-unpriv
-	RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
+       RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres -- --nocapture
 test-sqlite:
 	RUSTFLAGS="-D warnings" cargo test --features sqlite
 

--- a/postgres_setup_unpriv/Cargo.lock
+++ b/postgres_setup_unpriv/Cargo.lock
@@ -280,6 +280,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +479,16 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -954,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1071,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1285,6 +1334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,8 +1444,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 name = "postgres-setup-unpriv"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
+ "color-eyre",
  "figment",
  "nix",
  "ortho_config",
@@ -1926,6 +1981,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2506,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2505,6 +2600,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/postgres_setup_unpriv/Cargo.toml
+++ b/postgres_setup_unpriv/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 postgresql_embedded = { version = "0.18", features = ["tokio"] }
 nix = { version = "0.28", default-features = false, features = ["user", "fs"] }
-anyhow = "1"
+color-eyre = "0.6"
 tokio = { version = "1", features = ["rt", "macros"] }
 serde = { version = "1", features = ["derive"] }
 ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.2.0" }
@@ -24,3 +24,4 @@ yaml = []
 rstest = "0.18"
 temp-env = "0.3"
 tempfile = "3"
+color-eyre = "0.6"

--- a/postgres_setup_unpriv/src/main.rs
+++ b/postgres_setup_unpriv/src/main.rs
@@ -4,11 +4,6 @@
 //! [`OrthoConfig`](https://github.com/leynos/ortho-config). The binary exits
 //! with status code `0` on success and `1` on error.
 
-use std::process::exit;
-
-fn main() {
-    if let Err(e) = postgres_setup_unpriv::run() {
-        eprintln!("postgres-setup-unpriv: {e:#}");
-        exit(1);
-    }
+fn main() -> color_eyre::eyre::Result<()> {
+    postgres_setup_unpriv::run()
 }

--- a/postgres_setup_unpriv/tests/settings.rs
+++ b/postgres_setup_unpriv/tests/settings.rs
@@ -9,14 +9,14 @@ use rstest::rstest;
 /// and that all relevant fields and configuration values are preserved.
 ///
 /// # Returns
-/// An `anyhow::Result` indicating success or failure of the round-trip conversion.
+/// A `color_eyre::Result` indicating success or failure of the round-trip conversion.
 ///
 /// # Examples
 /// ```no_run
 /// to_settings_roundtrip()?;
 /// ```
 #[rstest]
-fn to_settings_roundtrip() -> anyhow::Result<()> {
+fn to_settings_roundtrip() -> color_eyre::Result<()> {
     let cfg = PgEnvCfg {
         version_req: Some("=16.4.0".into()),
         port: Some(5433),
@@ -49,7 +49,7 @@ fn to_settings_default_config() {
 #[cfg(unix)]
 #[rstest]
 /// Verify that the effective uid is changed within the passed block
-fn with_temp_euid_changes_uid() -> anyhow::Result<()> {
+fn with_temp_euid_changes_uid() -> color_eyre::Result<()> {
     if !geteuid().is_root() {
         eprintln!("skipping root-dependent test");
         return Ok(());
@@ -74,7 +74,7 @@ mod dir_accessible_tests {
     use tempfile::tempdir;
 
     #[rstest]
-    fn make_dir_accessible_allows_nobody() -> anyhow::Result<()> {
+    fn make_dir_accessible_allows_nobody() -> color_eyre::Result<()> {
         if !geteuid().is_root() {
             eprintln!("skipping root-dependent test");
             return Ok(());
@@ -92,7 +92,7 @@ mod dir_accessible_tests {
 
 #[cfg(unix)]
 #[rstest]
-fn run_requires_root() -> anyhow::Result<()> {
+fn run_requires_root() -> color_eyre::Result<()> {
     if !geteuid().is_root() {
         eprintln!("skipping root-dependent test");
         return Ok(());

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 tempfile = "3"
-nix = { version = "0.28", default-features = false, features = ["signal", "user"] }
+nix = { version = "0.28", default-features = false, features = ["signal", "user", "fs"] }
 once_cell = "1"
 mxd = { path = "..", default-features = false }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/test-util/src/postgres.rs
+++ b/test-util/src/postgres.rs
@@ -15,6 +15,9 @@ const NOBODY_UID: u32 = 65_534;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatabaseUrl(String);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DatabaseName(String);
+
 impl DatabaseUrl {
     pub fn parse(url: &str) -> Result<Self, url::ParseError> {
         Url::parse(url)?;
@@ -32,6 +35,19 @@ impl AsRef<str> for DatabaseUrl {
 }
 
 impl std::fmt::Display for DatabaseUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) }
+}
+
+impl Deref for DatabaseName {
+    type Target = str;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl AsRef<str> for DatabaseName {
+    fn as_ref(&self) -> &str { &self.0 }
+}
+
+impl std::fmt::Display for DatabaseName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) }
 }
 

--- a/test-util/src/postgres.rs
+++ b/test-util/src/postgres.rs
@@ -133,18 +133,28 @@ async fn prepare_postgres(
         let lock_path = runtime_dir.join(".install_lock");
         let _lock = InstallLock::new(&lock_path)?;
 
-        let run_status = std::process::Command::new(bin)
+        let output = std::process::Command::new(bin)
             .env("PG_DATA_DIR", data_dir)
             .env("PG_RUNTIME_DIR", runtime_dir)
             .env("PG_PORT", settings.port.to_string())
             .env("PG_VERSION_REQ", settings.version.to_string())
             .env("PG_SUPERUSER", &settings.username)
             .env("PG_PASSWORD", &settings.password)
-            .status()
+            .output()
             .map_err(|e| format!("running postgres-setup-unpriv: {e}"))?;
 
-        if !run_status.success() {
-            return Err("postgres-setup-unpriv failed".into());
+        if !output.status.success() {
+            let code = output
+                .status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "signal".into());
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            return Err(format!(
+                "postgres-setup-unpriv failed (exit {code})\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+            .into());
         }
 
         PostgreSQL::new(settings)


### PR DESCRIPTION
## Summary
- ensure the runtime directory exists before acquiring the install lock
- chown runtime directory to `nobody`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` *(fails: postgres-setup-unpriv failed)*
- `markdownlint '**/*.md'`
- `nixie '**/*.md'` *(no output)*
- `strace -f -e openat,creat,open make test` *(fails: postgres-setup-unpriv failed)*


------
https://chatgpt.com/codex/tasks/task_e_6854b994c4e88322b1e5a223017844f7

## Summary by Sourcery

Ensure the Postgres runtime directory is created and owned by the unprivileged user before setup, enhance error reporting, migrate unprivileged setup to use color-eyre for richer errors, and update related dependencies and test configurations.

Bug Fixes:
- Create the Postgres runtime directory before acquiring the installation lock to avoid missing directory errors

Enhancements:
- Chown the runtime directory to the “nobody” user when running as root
- Include the helper’s exit code in the failure message for clearer diagnostics
- Migrate the unprivileged setup crate from anyhow to color-eyre for improved error reporting
- Simplify the main binary to return a color-eyre Result instead of manual exit

Build:
- Replace anyhow with color-eyre in postgres_setup_unpriv’s Cargo.toml
- Enable the “fs” feature on nix and update dependencies in test-util

CI:
- Adjust Makefile to run Postgres tests with --nocapture

Tests:
- Update unprivileged setup tests to return color-eyre Results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved setup process for PostgreSQL when running as the root user by ensuring the runtime directory exists and has correct ownership.
  - Enhanced error reporting during PostgreSQL setup with detailed exit status information.
- **Chores**
  - Updated dependencies to include additional features for improved filesystem operations.
  - Refined error handling and reporting by adopting a new error management system for clearer diagnostics.
  - Adjusted test execution to display output immediately during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->