### PR TITLE
Add connection timeouts to server tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "ortho_config",
  "postgresql_embedded",
  "rand 0.8.5",
+ "rstest",
  "serde",
  "serde_json",
  "temp-env",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ toml = []
 test-util = { path = "test-util", default-features = false }
 postgresql_embedded = { version = "0.18.5", features = ["tokio"] }
 temp-env = "0.3"
+rstest = "0.18"
 
 [lints.clippy]
 pedantic = "warn"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 test: test-postgres test-sqlite
 
 test-postgres: target/debug/postgres-setup-unpriv
-        RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
+<tab>RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
 test-sqlite:
 # File: Makefile
 # (around line 27)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ test: test-postgres test-sqlite
 test-postgres: target/debug/postgres-setup-unpriv
         RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
 test-sqlite:
-        RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --features sqlite
+# File: Makefile
+# (around line 27)
+
+	RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --features sqlite
 
 target/debug/mxd:
 	cargo build --bin mxd --features sqlite

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ clean:
 test: test-postgres test-sqlite
 
 test-postgres: target/debug/postgres-setup-unpriv
-	RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
+        RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres
 test-sqlite:
-	RUSTFLAGS="-D warnings" cargo test --features sqlite
+        RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --features sqlite
 
 target/debug/mxd:
 	cargo build --bin mxd --features sqlite

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -832,6 +832,9 @@ A default timeout for all `rstest` async tests can also be set using the
 compile time.10 This built-in timeout support is a practical feature for
 ensuring test suite stability.
 
+The `Makefile` sets `RSTEST_TIMEOUT=20` when running tests so async
+integration tests fail after 20 seconds if they hang.
+
 ## VII. Working with External Resources and Test Data
 
 Tests often need to interact with the filesystem, databases, or network

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -832,7 +832,7 @@ A default timeout for all `rstest` async tests can also be set using the
 compile time.10 This built-in timeout support is a practical feature for
 ensuring test suite stability.
 
-The `Makefile` sets `RSTEST_TIMEOUT=20` when running tests so async
+The `Makefile` sets `RSTEST_TIMEOUT=20` when running tests, so async
 integration tests fail after 20 seconds if they hang.
 
 ## VII. Working with External Resources and Test Data

--- a/tests/file_list.rs
+++ b/tests/file_list.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{Read, Write},
     net::TcpStream,
+    time::Duration,
 };
 
 use mxd::{
@@ -16,6 +17,8 @@ fn list_files_acl() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = server.port();
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
 
     handshake(&mut stream)?;
 
@@ -88,6 +91,8 @@ fn list_files_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start("./Cargo.toml")?;
     let port = server.port();
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
 
     // handshake
     handshake(&mut stream)?;

--- a/tests/handshake.rs
+++ b/tests/handshake.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{Read, Write},
     net::{Shutdown, TcpStream},
+    time::Duration,
 };
 
 use test_util::TestServer;
@@ -11,6 +12,8 @@ fn handshake() -> Result<(), Box<dyn std::error::Error>> {
     let port = server.port();
 
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     let mut handshake = Vec::new();
     handshake.extend_from_slice(b"TRTP");
     handshake.extend_from_slice(&0u32.to_be_bytes());

--- a/tests/handshake_invalid.rs
+++ b/tests/handshake_invalid.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{Read, Write},
     net::TcpStream,
+    time::Duration,
 };
 
 use test_util::TestServer;
@@ -11,6 +12,8 @@ fn handshake_invalid_protocol() -> Result<(), Box<dyn std::error::Error>> {
     let port = server.port();
 
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     let mut handshake = Vec::new();
     handshake.extend_from_slice(b"WRNG");
     handshake.extend_from_slice(&0u32.to_be_bytes());

--- a/tests/handshake_unsupported_version.rs
+++ b/tests/handshake_unsupported_version.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{BufRead, BufReader, Read, Write},
     net::TcpStream,
+    time::Duration,
 };
 
 use test_util::TestServer;
@@ -11,6 +12,8 @@ fn handshake_unsupported_version() -> Result<(), Box<dyn std::error::Error>> {
     let port = server.port();
 
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     let mut handshake = Vec::new();
     handshake.extend_from_slice(b"TRTP");
     handshake.extend_from_slice(&0u32.to_be_bytes());

--- a/tests/news_articles.rs
+++ b/tests/news_articles.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{Read, Write},
     net::TcpStream,
+    time::Duration,
 };
 
 use diesel::prelude::*;
@@ -35,6 +36,8 @@ fn list_news_articles_invalid_path() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = server.port();
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     handshake(&mut stream)?;
 
     let params = vec![(FieldId::NewsPath, b"Missing".as_ref())];
@@ -64,6 +67,8 @@ fn list_news_articles_valid_path() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = server.port();
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     handshake(&mut stream)?;
 
     let params = vec![(FieldId::NewsPath, b"General".as_ref())];
@@ -147,6 +152,8 @@ fn get_news_article_data() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = server.port();
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     handshake(&mut stream)?;
 
     let mut params = Vec::new();
@@ -216,6 +223,8 @@ fn post_news_article_root() -> Result<(), Box<dyn std::error::Error>> {
 
     let port = server.port();
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     handshake(&mut stream)?;
 
     let mut params = Vec::new();

--- a/tests/news_categories.rs
+++ b/tests/news_categories.rs
@@ -24,8 +24,8 @@ fn list_categories(
     path: Option<&str>,
 ) -> Result<(FrameHeader, Vec<String>), Box<dyn std::error::Error>> {
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
-    stream.set_read_timeout(Some(std::time::Duration::from_secs(1)))?;
-    stream.set_write_timeout(Some(std::time::Duration::from_secs(1)))?;
+    stream.set_read_timeout(Some(std::time::Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(std::time::Duration::from_secs(20)))?;
     handshake(&mut stream)?;
     let params = path
         .map(|p| vec![(FieldId::NewsPath, p.as_bytes())])

--- a/tests/payload_reject.rs
+++ b/tests/payload_reject.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{Read, Write},
     net::TcpStream,
+    time::Duration,
 };
 
 use mxd::{
@@ -34,6 +35,10 @@ fn download_banner_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let server = TestServer::start("./Cargo.toml")?;
     let port = server.port();
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     handshake(&mut stream)?;
 
     let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())])?;

--- a/tests/payload_reject.rs
+++ b/tests/payload_reject.rs
@@ -37,8 +37,6 @@ fn download_banner_reject_payload() -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = TcpStream::connect(("127.0.0.1", port))?;
     stream.set_read_timeout(Some(Duration::from_secs(20)))?;
     stream.set_write_timeout(Some(Duration::from_secs(20)))?;
-    stream.set_read_timeout(Some(Duration::from_secs(20)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(20)))?;
     handshake(&mut stream)?;
 
     let params = encode_params(&[(FieldId::Other(1), b"bogus".as_ref())])?;

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use mxd::{field_id, transaction::*, transaction_type};
+use rstest::rstest;
 use tokio::io::{AsyncWriteExt, duplex};
 
 fn build_tx() -> Transaction {
@@ -18,7 +21,9 @@ fn build_tx() -> Transaction {
     Transaction { header, payload }
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn roundtrip_single_frame() {
     let tx = build_tx();
     let (mut a, mut b) = duplex(1024);
@@ -29,7 +34,9 @@ async fn roundtrip_single_frame() {
     assert_eq!(tx, rx);
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn roundtrip_multi_frame() {
     let mut payload = Vec::new();
     payload.extend_from_slice(&[0x00, 0x01]); // one param
@@ -55,7 +62,9 @@ async fn roundtrip_multi_frame() {
     assert_eq!(tx, rx);
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn invalid_flags_error() {
     let mut tx = build_tx();
     tx.header.flags = 1;
@@ -74,7 +83,9 @@ async fn invalid_flags_error() {
     }
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn mismatched_sizes() {
     let tx = build_tx();
     let (mut a, mut b) = duplex(1024);
@@ -96,7 +107,9 @@ async fn mismatched_sizes() {
     }
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn duplicate_field_error() {
     let mut tx = build_tx();
     tx.payload
@@ -122,7 +135,9 @@ async fn duplicate_field_error() {
     }
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn writer_payload_too_large() {
     let count = 16u16;
     let mut payload = Vec::new();
@@ -150,7 +165,9 @@ async fn writer_payload_too_large() {
     }
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn roundtrip_empty_payload() {
     let header = FrameHeader {
         flags: 0,
@@ -174,7 +191,9 @@ async fn roundtrip_empty_payload() {
     assert_eq!(tx, rx);
 }
 
+#[rstest]
 #[tokio::test]
+#[timeout(Duration::from_secs(20))]
 async fn oversized_payload() {
     let mut tx = build_tx();
     tx.payload = vec![0u8; MAX_PAYLOAD_SIZE + 1];


### PR DESCRIPTION
## Summary
- prevent hangs in integration tests by setting 20s timeouts on TCP streams
- ensure all server-starting tests fail fast if the server stalls

## Testing
- `cargo clippy -- -D warnings`
- `markdownlint '**/*.md'`
- `nixie '**/*.md'`
- `RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --features sqlite`
- `RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo test --no-default-features --features postgres` *(fails: cannot find type `DatabaseName`)*

------
https://chatgpt.com/codex/tasks/task_e_6854d7376ff08322b1867da9766f7b45

## Summary by Sourcery

Prevent hangs in async and integration tests by enforcing 20-second timeouts on rstest-powered tests and TCP streams, updating test attributes, environment settings, dependencies, and documentation.

Enhancements:
- Annotate async transaction tests with rstest and apply a 20s timeout attribute
- Set 20s read/write timeouts on TcpStream in various integration tests

Build:
- Update Makefile to export RSTEST_TIMEOUT=20 when running tests
- Add rstest 0.18 dependency in Cargo.toml

Documentation:
- Document the default 20s timeout in the rstest fixtures guide