### PR TITLE
Fix doctest import

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -162,7 +162,7 @@ pub async fn audit_sqlite_features(conn: &mut DbConnection) -> QueryResult<()> {
 /// # Examples
 ///
 /// ```
-/// # use your_crate::audit_postgres_features;
+/// # use mxd::db::audit_postgres_features;
 /// # async fn check(conn: &mut diesel_async::AsyncPgConnection) {
 /// let result = audit_postgres_features(conn).await;
 /// assert!(result.is_ok());


### PR DESCRIPTION
## Summary
- fix incorrect crate name in audit_postgres_features doctest

## Testing
- `cargo clippy -- -D warnings`
- `make test` *(fails: postgresql_embedded::setup() Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6855a3c399388322810289c617e3f97d

## Summary by Sourcery

Documentation:
- Correct the crate import in the audit_postgres_features documentation example to use 'mxd::db' instead of 'your_crate'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation example to reflect the correct import path for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->