### PR TITLE
Update coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Merge coverage results
         run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
       - name: Upload coverage data to CodeScene
-        uses: leynos/shared-actions/upload-codescene-coverage@v1
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1
         with:
           path: lcov.info
           format: lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Merge coverage results
         run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
       - name: Upload coverage data to CodeScene
-        uses: leynos/shared-actions/upload-codescene-coverage@v1.0.3
+        uses: leynos/shared-actions/upload-codescene-coverage@v1
         with:
           path: lcov.info
           format: lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,11 @@ jobs:
           output-path: lcov-postgres.info
       - name: Merge coverage results
         run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
-      - name: Install CodeScene coverage tool
-        run: |
-          set -euo pipefail
-          curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
-          echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          bash install-cs-coverage-tool.sh -y
-          rm install-cs-coverage-tool.sh
       - name: Upload coverage data to CodeScene
-        run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
+        uses: leynos/shared-actions/upload-codescene-coverage@v1.0.3
+        with:
+          path: lcov.info
+          format: lcov
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+          CODESCENE_CLI_SHA256: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/docs/codescene-cli.md
+++ b/docs/codescene-cli.md
@@ -1,9 +1,9 @@
 # CodeScene Coverage Tool
 
 This repository uses the CodeScene CLI to report code coverage metrics in CI.
-The CLI is installed from a remote script published by CodeScene. To ensure the
-integrity of the download, the CI workflow verifies the script using a pinned
-SHA-256 checksum.
+A shared GitHub Action (`leynos/shared-actions/upload-codescene-coverage@v1.0.3`)
+handles downloading and caching the CLI before uploading coverage results. The
+action verifies the installer using a pinned SHA-256 checksum.
 
 The expected checksum is stored in the workflow as the environment variable
 `CODESCENE_CLI_SHA256`. The installer is downloaded from


### PR DESCRIPTION
## Summary
- use leynos shared action for uploading coverage
- document the shared action in coverage docs

## Testing
- `cargo clippy -- -D warnings`
- `make test`
- `markdownlint '**/*.md'`
- `nixie docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_6855e8f441fc8322b0de0f275a714b78

## Summary by Sourcery

Adopt a shared GitHub Action for CodeScene coverage uploads and update documentation accordingly

CI:
- Replace manual CodeScene CLI install and upload steps with the leynos/shared-actions/upload-codescene-coverage action in the CI workflow

Documentation:
- Update CodeScene CLI documentation to reference the shared action and its checksum verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to use a shared GitHub Action for uploading CodeScene coverage data, simplifying the CI process.
- **Documentation**
	- Revised documentation to reflect the new method for handling CodeScene coverage uploads via the shared GitHub Action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->