### PR TITLE
Fix CI workflow to use shared Rust setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
+      - uses: leynos/shared-actions/.github/actions/setup-rust@v1
         with:
           install-postgres-deps: ${{ matrix.feature == 'postgres' }}
       - name: Export POSTGRES_TEST_URL
@@ -56,7 +56,7 @@ jobs:
       BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
+      - uses: leynos/shared-actions/.github/actions/setup-rust@v1
       - name: Add Windows GNU target
         run: rustup target add x86_64-pc-windows-gnu
       - name: Format
@@ -90,7 +90,7 @@ jobs:
       BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
+      - uses: leynos/shared-actions/.github/actions/setup-rust@v1
         with:
           install-postgres-deps: true
       - uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- use `leynos/shared-actions/.github/actions/setup-rust@v1` in CI jobs

## Testing
- `cargo clippy -- -D warnings`
- `make test` *(fails: postgresql_embedded::setup() Permission denied)*
- `markdownlint '**/*.md'`
- `nixie **/*.md`


------
https://chatgpt.com/codex/tasks/task_e_685669fd6940832288f09a0e83c1fca8