### PR TITLE
Add cargo cache step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           install-postgres-deps: ${{ matrix.feature == 'postgres' }}
           install-sqlite-deps: ${{ matrix.feature == 'sqlite' }}
-      # Cache ~/.cargo and target/
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo directories
+        uses: Swatinem/rust-cache@v2
       - name: Export POSTGRES_TEST_URL
         if: matrix.feature == 'postgres'
         uses: ./.github/actions/export-postgres-url
@@ -62,8 +62,8 @@ jobs:
       - uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
         with:
           install-sqlite-deps: true
-      # Cache ~/.cargo and target/
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo directories
+        uses: Swatinem/rust-cache@v2
       - name: Add Windows GNU target
         run: rustup target add x86_64-pc-windows-gnu
       - name: Format
@@ -100,8 +100,8 @@ jobs:
       - uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
         with:
           install-postgres-deps: true
-      # Cache ~/.cargo and target/
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo directories
+        uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           install-postgres-deps: ${{ matrix.feature == 'postgres' }}
           install-sqlite-deps: ${{ matrix.feature == 'sqlite' }}
+      # Cache ~/.cargo and target/
+      - uses: Swatinem/rust-cache@v2
       - name: Export POSTGRES_TEST_URL
         if: matrix.feature == 'postgres'
         uses: ./.github/actions/export-postgres-url
@@ -60,6 +62,8 @@ jobs:
       - uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
         with:
           install-sqlite-deps: true
+      # Cache ~/.cargo and target/
+      - uses: Swatinem/rust-cache@v2
       - name: Add Windows GNU target
         run: rustup target add x86_64-pc-windows-gnu
       - name: Format
@@ -96,6 +100,8 @@ jobs:
       - uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
         with:
           install-postgres-deps: true
+      # Cache ~/.cargo and target/
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           install-postgres-deps: ${{ matrix.feature == 'postgres' }}
           install-sqlite-deps: ${{ matrix.feature == 'sqlite' }}
       - name: Cache Cargo directories
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - name: Export POSTGRES_TEST_URL
         if: matrix.feature == 'postgres'
         uses: ./.github/actions/export-postgres-url
@@ -63,7 +63,7 @@ jobs:
         with:
           install-sqlite-deps: true
       - name: Cache Cargo directories
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - name: Add Windows GNU target
         run: rustup target add x86_64-pc-windows-gnu
       - name: Format
@@ -101,7 +101,7 @@ jobs:
         with:
           install-postgres-deps: true
       - name: Cache Cargo directories
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
       - name: Cache Cargo directories
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Build fuzzing container
         run: docker build -t mxd-fuzz -f fuzz/Dockerfile .

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
-      # Cache ~/.cargo and target/
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo directories
+        uses: Swatinem/rust-cache@v2
 
       - name: Build fuzzing container
         run: docker build -t mxd-fuzz -f fuzz/Dockerfile .

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
+      # Cache ~/.cargo and target/
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build fuzzing container
         run: docker build -t mxd-fuzz -f fuzz/Dockerfile .


### PR DESCRIPTION
## Summary
- enable cargo caching in CI workflows to speed builds

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `make test` *(fails: postgresql_embedded::setup() permission denied)*
- `markdownlint '**/*.md'`
- `nixie **/*.md'

------
https://chatgpt.com/codex/tasks/task_e_685c84aed33083229855c8b8b98ae982

## Summary by Sourcery

Enable cargo caching in GitHub Actions workflows to accelerate Rust build times.

Enhancements:
- Speed up Rust build times by caching dependencies and build artifacts.

CI:
- Cache ~/.cargo and target directories using Swatinem/rust-cache@v2 in all CI and fuzz workflows.