### PR TITLE
Ensure Postgres builds retain TOML configuration support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ postgres = [
     "diesel_cte_ext/postgres",
     "diesel_cte_ext/async",
     "url",
+    "toml",
     "test-util/postgres",
 ]
 sqlite = [


### PR DESCRIPTION
## Summary
- ensure the `postgres` feature continues to enable the `toml` provider so Postgres-only builds can read `.mxd.toml`

## Testing
- make check-fmt *(fails: repository contains pre-existing formatting differences in news-related tests)*
- make lint
- make test *(fails: existing news_path SQL string tests expect different whitespace formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68e82c7c049083229a299eb058e9e6ca