### PR TITLE
Remove Windows test workflow and Codescene upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,33 +48,6 @@ jobs:
       - name: Test
         run: cargo test --no-default-features --features ${{ matrix.feature }}
 
-  windows-build:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        feature: [sqlite]
-      fail-fast: false
-    env:
-      CARGO_TERM_COLOR: always
-      BUILD_PROFILE: debug
-    steps:
-      - uses: actions/checkout@v5
-      - uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
-        with:
-          install-sqlite-deps: true
-      - name: Cache Cargo directories
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-      - name: Add Windows GNU target
-        run: rustup target add x86_64-pc-windows-gnu
-      - name: Format
-        run: cargo fmt --all -- --check
-      - name: Lint
-        run: cargo clippy --no-default-features --features ${{ matrix.feature }} -- -D warnings
-      - name: Build for Windows GNU
-        run: cargo build --target x86_64-pc-windows-gnu --no-default-features --features ${{ matrix.feature }}
-      - name: Test for Windows GNU
-        run: cargo test --target x86_64-pc-windows-gnu --no-default-features --features ${{ matrix.feature }}
-
   coverage:
     runs-on: ubuntu-latest
     services:
@@ -93,7 +66,6 @@ jobs:
           --health-retries 5
     env:
       CARGO_TERM_COLOR: always
-      CODESCENE_CLI_SHA256: "a1c38415c5978908283c0608b648b27e954c93882b15d8b91d052d846c3eabd8"
       BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v5
@@ -122,12 +94,3 @@ jobs:
           output-path: lcov-postgres.info
       - name: Merge coverage results
         run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@f9f1c863c8a5bef64aa6779caa746e1a4a6c1ad4
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary
- Remove Windows-specific CI test workflow and CodeScene coverage upload
- Clean up related environment variable usage in CI

## Changes
### CI Workflow
- Deleted the windows-build job from .github/workflows/ci.yml (windows-latest, sqlite feature matrix, and all Windows-specific steps)
- Removed CodeScene coverage upload step from the coverage workflow
- Removed CODESCENE_CLI_SHA256 from the env in the coverage job

### Other
- Linux/Ubuntu coverage flow remains intact

## Why
- Windows CI tests are no longer required and CodeScene coverage uploads are deprecated/removed to simplify CI and reduce run time

## Testing
- [x] CI runs on Linux as before and tests pass
- [x] No Windows job is executed in CI
- [x] CodeScene upload step is no longer executed and no CodeScene tokens are used

## Notes
- If CodeScene integration needs to be reintroduced in the future, re-add the upload step and corresponding env vars
- Branch: terragon/ci-remove-windows-test-codescene-sxm63w

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/21bc85f3-5f54-444e-a212-d33f088afc2d

## Summary by Sourcery

Remove Windows-specific CI workflow and deprecated CodeScene coverage upload to streamline continuous integration.

CI:
- Delete the Windows-specific build and test job from the CI workflow
- Remove the CodeScene coverage upload step from the coverage job

Chores:
- Clean up unused CI environment variables related to CodeScene (CODESCENE_CLI_SHA256)