### PR TITLE
Share Argon2 instance via Arc across server tasks

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -48,3 +48,65 @@ pub async fn handle_request(
     let reply = cmd.process(ctx.peer, ctx.pool.clone(), session).await?;
     Ok(reply)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use diesel_async::pooled_connection::{AsyncDieselConnectionManager, bb8::Pool};
+
+    use super::*;
+    use crate::db::DbConnection;
+
+    fn dummy_pool() -> DbPool {
+        let manager = AsyncDieselConnectionManager::<DbConnection>::new(
+            "postgres://example.invalid/mxd-test",
+        );
+        Pool::builder()
+            .max_size(1)
+            .min_idle(Some(0))
+            .idle_timeout(None::<Duration>)
+            .max_lifetime(None::<Duration>)
+            .test_on_check_out(false)
+            .build_unchecked(manager)
+    }
+
+    #[tokio::test]
+    async fn context_carries_shared_argon2_reference() {
+        let pool = dummy_pool();
+        let argon2 = Arc::new(Argon2::default());
+        let peer: SocketAddr = "127.0.0.1:9001".parse().expect("loopback address");
+
+        let ctx = Context::new(peer, pool, Arc::clone(&argon2));
+
+        assert!(Arc::ptr_eq(&ctx.argon2, &argon2));
+        assert_eq!(Arc::strong_count(&argon2), 2);
+        assert_eq!(ctx.peer, peer);
+    }
+
+    #[tokio::test]
+    async fn multiple_contexts_share_single_argon2_instance() {
+        let pool = dummy_pool();
+        let argon2 = Arc::new(Argon2::default());
+
+        let ctx_a = Context::new(
+            "127.0.0.1:9002".parse().expect("loopback"),
+            pool.clone(),
+            Arc::clone(&argon2),
+        );
+        let ctx_b = Context::new(
+            "127.0.0.1:9003".parse().expect("loopback"),
+            pool,
+            Arc::clone(&argon2),
+        );
+
+        assert!(Arc::ptr_eq(&ctx_a.argon2, &argon2));
+        assert!(Arc::ptr_eq(&ctx_b.argon2, &argon2));
+        assert_eq!(Arc::strong_count(&argon2), 3);
+
+        drop(ctx_a);
+        assert_eq!(Arc::strong_count(&argon2), 2);
+        drop(ctx_b);
+        assert_eq!(Arc::strong_count(&argon2), 1);
+    }
+}

--- a/src/server/legacy.rs
+++ b/src/server/legacy.rs
@@ -169,7 +169,13 @@ async fn accept_connections(
                 break;
             }
             res = listener.accept() => {
-                handle_accept_result(res, &pool, &argon2, &shutdown_rx, &mut join_set);
+                handle_accept_result(
+                    res,
+                    pool.clone(),
+                    Arc::clone(&argon2),
+                    &shutdown_rx,
+                    &mut join_set,
+                );
             }
         }
     }
@@ -182,16 +188,14 @@ async fn accept_connections(
 
 fn handle_accept_result(
     res: io::Result<(TcpStream, SocketAddr)>,
-    pool: &DbPool,
-    argon2: &Arc<Argon2<'static>>,
+    pool: DbPool,
+    argon2: Arc<Argon2<'static>>,
     shutdown_rx: &watch::Receiver<bool>,
     join_set: &mut JoinSet<()>,
 ) {
     match res {
         Ok((socket, peer)) => {
-            let pool = pool.clone();
             let rx = shutdown_rx.clone();
-            let argon2 = Arc::clone(argon2);
             spawn_client_handler(socket, peer, pool, argon2, rx, join_set);
         }
         Err(e) => eprintln!("accept error: {e}"),
@@ -206,8 +210,9 @@ fn spawn_client_handler(
     mut shutdown_rx: watch::Receiver<bool>,
     join_set: &mut JoinSet<()>,
 ) {
+    let ctx = HandlerContext::new(peer, pool, argon2);
     join_set.spawn(async move {
-        if let Err(e) = handle_client(socket, peer, pool, argon2, &mut shutdown_rx).await {
+        if let Err(e) = handle_client(socket, ctx, &mut shutdown_rx).await {
             eprintln!("connection error from {peer}: {e}");
         }
     });
@@ -224,9 +229,7 @@ async fn await_spawned_tasks(join_set: &mut JoinSet<()>) {
 /// Handles a single client connection, performing handshake and processing transactions.
 async fn handle_client(
     socket: TcpStream,
-    peer: SocketAddr,
-    pool: DbPool,
-    argon2: Arc<Argon2<'static>>,
+    ctx: HandlerContext,
     shutdown: &mut watch::Receiver<bool>,
 ) -> Result<()> {
     let (mut reader, mut writer) = tokio_io::split(socket);
@@ -235,7 +238,6 @@ async fn handle_client(
 
     let mut tx_reader = TransactionReader::new(reader);
     let mut tx_writer = TransactionWriter::new(writer);
-    let ctx = HandlerContext::new(peer, pool.clone(), argon2);
     let mut session = Session::default();
     loop {
         tokio::select! {
@@ -329,11 +331,84 @@ async fn wait_for_ctrl_c() {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use diesel_async::pooled_connection::{AsyncDieselConnectionManager, bb8::Pool};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+        sync::watch,
+        task::JoinSet,
+    };
+
+    use super::*;
+    use crate::{db::DbConnection, protocol};
+
     #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
     #[test]
     fn postgres_url_detection() {
         assert!(super::is_postgres_url("postgres://localhost"));
         assert!(super::is_postgres_url("postgresql://localhost"));
         assert!(!super::is_postgres_url("sqlite://localhost"));
+    }
+
+    fn dummy_pool() -> DbPool {
+        let manager = AsyncDieselConnectionManager::<DbConnection>::new(
+            "postgres://example.invalid/mxd-test",
+        );
+        Pool::builder()
+            .max_size(1)
+            .min_idle(Some(0))
+            .idle_timeout(None::<Duration>)
+            .max_lifetime(None::<Duration>)
+            .test_on_check_out(false)
+            .build_unchecked(manager)
+    }
+
+    fn handshake_frame() -> [u8; protocol::HANDSHAKE_LEN] {
+        let mut buf = [0u8; protocol::HANDSHAKE_LEN];
+        buf[0..4].copy_from_slice(protocol::PROTOCOL_ID);
+        buf[8..10].copy_from_slice(&protocol::VERSION.to_be_bytes());
+        buf
+    }
+
+    #[tokio::test]
+    async fn handle_accept_result_shares_argon2_between_clients() -> Result<()> {
+        let pool = dummy_pool();
+        let argon2 = Arc::new(Argon2::default());
+        let strong_before = Arc::strong_count(&argon2);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let mut join_set = JoinSet::new();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let mut client = TcpStream::connect(addr).await?;
+        let (server_socket, peer) = listener.accept().await?;
+
+        handle_accept_result(
+            Ok((server_socket, peer)),
+            pool,
+            Arc::clone(&argon2),
+            &shutdown_rx,
+            &mut join_set,
+        );
+
+        assert_eq!(Arc::strong_count(&argon2), strong_before + 1);
+
+        client.write_all(&handshake_frame()).await?;
+        let mut reply = [0u8; protocol::REPLY_LEN];
+        client.read_exact(&mut reply).await?;
+        client.shutdown().await?;
+
+        shutdown_tx.send(true).ok();
+
+        while let Some(result) = join_set.join_next().await {
+            result.expect("client handler task");
+        }
+
+        assert_eq!(Arc::strong_count(&argon2), strong_before);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Introduces a shared Argon2 instance wrapped in an Arc and stored in per-connection Context to enable reuse across worker tasks.
- Builds Argon2 once at startup and propagates the Arc to all worker paths, avoiding per-connection duplication.

## Changes
- src/handler.rs
  - Import Arc and Argon2; Context now stores `argon2: Arc<Argon2<'static>>`.
  - `Context::new` signature updated to accept an Argon2 Arc and initialize the context with it.

- src/server/legacy.rs
  - Import Arc from std.
  - Build the Argon2 instance once at startup: `Arc::new(build_argon2(&cfg)?)`.
  - Pass the `argon2` Arc through `accept_connections`, `handle_accept_result`, and `spawn_client_handler`.
  - Thread the Argon2 Arc into client handling and into `handle_client` so each session can use the shared instance.

## Rationale
- Provides a single, validated Argon2 configuration reused across all connections, reducing setup cost and memory footprint per connection.
- Keeps the Argon2 instance lifetime-safe by leveraging `Arc` and a `'static` Argon2.

## Alternatives considered
- Creating a new Argon2 instance per connection would be simpler code-wise but would incur more overhead and risk parameter divergence across tasks. Sharing the instance is preferred for efficiency and consistency.

## Potential impact
- Internal refactor with no public API changes.
- Small interface changes to internal functions to thread the Argon2 Arc through.

## Testing plan
- [x] Build the project successfully: `cargo build`.
- [x] Run the server and verify it starts listening (log output shows the bound address).
- [x] Simulate multiple concurrent clients to ensure Argon2 is shared without contention.
- [x] Confirm startup Argon2 parameters are validated exactly once and reused across all connections.

## Notes
- The Argon2 instance remains immutable after creation, making it safe to share across tasks via `Arc`.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1d0613d2-50ec-4819-9704-c10fb35e2dd8

## Summary by Sourcery

Enhancements:
- Build the Argon2 instance once at startup and pass it via Arc to all worker tasks to avoid per-connection duplication and reduce setup overhead