### PR TITLE
Refactor lint attributes in handshake module

### DIFF
--- a/src/wireframe/handshake.rs
+++ b/src/wireframe/handshake.rs
@@ -6,14 +6,6 @@
 //! The hooks are reusable so tests can inject shorter timeouts without
 //! altering production defaults.
 
-#![cfg_attr(
-    test,
-    allow(
-        unfulfilled_lint_expectations,
-        reason = "rstest unused_braces expectation is not triggered under coverage cfg"
-    )
-)]
-
 use std::{io, time::Duration};
 
 use bincode::error::DecodeError;


### PR DESCRIPTION
## Summary
- Removes crate-level lint allowances in the handshake module
- Improves lint hygiene by eliminating global test-time suppressions

## Changes

### Code
- Deleted the cfg_attr(test, allow(unfulfilled_lint_expectations, reason = "rstest unused_braces expectation is not triggered under coverage cfg"))] block from src/wireframe/handshake.rs

### Rationale
- The previous lint suppression was applied at the crate level for tests and is no longer necessary
- This change encourages more precise lint handling and reduces hidden lint suppression

## Test plan
- [x] Build the workspace succeeds
- [x] Run tests to ensure handshake-related tests pass
- [x] Lint checks run without crate-level allowances

## Notes
- If new lint warnings arise, prefer scoped per-test allowances or code changes to satisfy lints rather than crate-wide suppressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fc81fb28-e185-4585-a417-92c53cdf9175

## Summary by Sourcery

Enhancements:
- Remove a redundant crate-level cfg_attr-based lint suppression from the handshake module to improve lint hygiene.