### PR TITLE
Add AFL circular-dependency ExecPlan and fix fuzz Dockerfile and docs

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1058,7 +1058,7 @@ implementation differences. For instance:
   `BOOLEAN` is fine in Postgres and in SQLite it ends up as 0/1 integer
   (Diesel’s bool mapping covers
   it)([7](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md#L65-L68));
-  `INTEGER` for integer types, etc. Some types don’t line up – e.g. `BYTEA` vs
+   `INTEGER` for integer types, etc. Some types don’t line up – e.g. `BYTEA` vs
   `BLOB` for binary data – but we avoid unsupported types or handle them
   conditionally. The doc notes that JSONB or timezone-aware timestamps aren’t
   portable, so we either avoid them or supply separate SQL. For example, we

--- a/docs/execplans/afl-circular-dependency-issue.md
+++ b/docs/execplans/afl-circular-dependency-issue.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: BLOCKED
 
 ## Purpose / big picture
 
@@ -78,10 +78,15 @@ contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
   `cargo afl build` without `--release`, so the produced harness is under
   `target/debug/fuzz`.
 - [x] (2026-03-11 00:19Z) Drafted this ExecPlan for review.
-- [ ] Implement the Dockerfile repair and any tightly related documentation
-  updates.
-- [ ] Run Markdown gates and Docker validation on a host with a running Docker
-  daemon.
+- [x] (2026-03-14 18:06Z) Implemented the Dockerfile repair by removing the
+  intra-stage self-copy and copying the debug harness from the completed
+  builder stage into the final image.
+- [x] (2026-03-14 18:06Z) Updated `docs/fuzzing.md` so the Docker section
+  matches the repaired image layout and the existing debug-harness contract.
+- [x] (2026-03-14 18:10Z) Ran `make fmt`, `make markdownlint`,
+  `make nixie`, and `make check-fmt`.
+- [ ] Run the remaining repository commit gates, plus Docker validation on a
+  host with a running Docker daemon.
 - [ ] Confirm the nightly workflow can proceed past image build.
 
 ## Surprises & Discoveries
@@ -108,6 +113,15 @@ contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
   Impact: the plan must specify an external validation step instead of claiming
   local proof.
 
+- Observation: the required repository commit gates are presently blocked by
+  environment/tooling issues unrelated to this Dockerfile change. Evidence:
+  `make lint` fails in the `whitaker` step with
+  `error: unknown start of token: \`` while probing a nightly toolchain, and
+  `make test` fails during the postgres nextest path because
+  `/root/.rustup/toolchains/nightly-2025-11-08-x86_64-unknown-linux-gnu/bin/rustc`
+  is missing. Impact: this change cannot be fully validated in the current
+  workspace until those toolchain problems are repaired.
+
 ## Decision Log
 
 - Decision: plan a minimal repair that keeps the current debug-profile fuzz
@@ -125,10 +139,13 @@ contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
 ## Outcomes & Retrospective
 
 The investigation is complete and the implementation plan is ready, but the
-repair has not been applied yet. The main lesson is that the failure message
+repair is now applied in-repo. The main lesson is that the failure message
 accurately points to Dockerfile stage structure, yet static inspection also
-shows a second defect that should be fixed in the same change to avoid a
-predictable follow-on failure.
+showed a second defect that needed to be fixed in the same change to avoid a
+predictable follow-on failure. Docker validation still needs to run on a host
+with a live daemon because this workspace cannot provide that proof. Repository
+commit gates are also blocked by independent nightly-toolchain issues in this
+environment.
 
 ## Context and orientation
 

--- a/docs/execplans/afl-circular-dependency-issue.md
+++ b/docs/execplans/afl-circular-dependency-issue.md
@@ -1,17 +1,17 @@
-# Fix the AFL Docker build stage cycle
+# Fix the American Fuzzy Lop (AFL) Docker build stage cycle
 
 This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
-`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
-`Outcomes & Retrospective` must be kept up to date as work proceeds.
+`Risks`, `Progress`, `Surprises and discoveries`, `Decision log`, and
+`Outcomes and retrospective` must be kept up to date as work proceeds.
 
 Status: BLOCKED
 
 ## Purpose / big picture
 
-Restore the nightly AFL++ container build so
-`docker build -t mxd-fuzz -f fuzz/Dockerfile .` succeeds again and the fuzzing
-workflow can run instead of failing during image creation. Success is visible
-in two places: the Docker image builds without the
+Restore the nightly AFL++ (the extended version of American Fuzzy Lop)
+container build so `docker build -t mxd-fuzz -f fuzz/Dockerfile .` succeeds
+again and the fuzzing workflow can run instead of failing during image
+creation. Success is visible in two places: the Docker image builds without the
 `circular dependency detected on stage: builder` error, and the resulting image
 contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
 
@@ -89,7 +89,7 @@ contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
   host with a running Docker daemon.
 - [ ] Confirm the nightly workflow can proceed past image build.
 
-## Surprises & Discoveries
+## Surprises and discoveries
 
 - Observation: the failing line in `fuzz/Dockerfile` is not the final-stage
   copy. It is a stray
@@ -119,10 +119,10 @@ contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
   `error: unknown start of token: \`` while probing a nightly toolchain, and
   `make test` fails during the postgres nextest path because
   `/root/.rustup/toolchains/nightly-2025-11-08-x86_64-unknown-linux-gnu/bin/rustc`
-  is missing. Impact: this change cannot be fully validated in the current
+   is missing. Impact: this change cannot be fully validated in the current
   workspace until those toolchain problems are repaired.
 
-## Decision Log
+## Decision log
 
 - Decision: plan a minimal repair that keeps the current debug-profile fuzz
   artefact convention. Rationale: the self-cycle bug is the immediate failure,
@@ -131,12 +131,13 @@ contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
   ambiguity. Date/Author: 2026-03-11 / Codex
 
 - Decision: include the release/debug artefact mismatch in the same fix even
-  though the reported CI failure stops earlier. Rationale: once the stage cycle
-  is removed, the build would otherwise fail or produce the wrong image
-  contents in the next step. Shipping only the first half of the repair would
-  be knowingly incomplete. Date/Author: 2026-03-11 / Codex
+  though the reported continuous integration (CI) failure stops earlier.
+  Rationale: once the stage cycle is removed, the build would otherwise fail or
+  produce the wrong image contents in the next step. Shipping only the first
+  half of the repair would be knowingly incomplete. Date/Author: 2026-03-11 /
+  Codex
 
-## Outcomes & Retrospective
+## Outcomes and retrospective
 
 The investigation is complete and the implementation plan is ready, but the
 repair is now applied in-repo. The main lesson is that the failure message
@@ -252,7 +253,7 @@ From the repository root:
 
    ```bash
    docker build -t mxd-fuzz -f fuzz/Dockerfile .
-   docker run --rm mxd-fuzz bash -lc 'test -x /usr/local/bin/fuzz'
+   docker run --rm --entrypoint bash mxd-fuzz -lc 'test -x /usr/local/bin/fuzz'
    ```
 
    Expected result:
@@ -262,9 +263,9 @@ From the repository root:
    docker run exits 0
    ```
 
-6. Optionally prove the GitHub Actions path by triggering the fuzz workflow or
-   pushing the change through pull-request CI, then confirm the "Build fuzzing
-   container" step passes.
+6. Prove the GitHub Actions path by triggering the fuzz workflow or pushing the
+   change through pull-request CI, then confirm the "Build fuzzing container"
+   step passes.
 
 ## Validation and acceptance
 
@@ -272,10 +273,11 @@ Acceptance criteria:
 
 - `fuzz/Dockerfile` no longer contains a self-referential stage copy.
 - The final image copies the same harness profile that the repository already
-  documents and expects, namely `fuzz/target/debug/fuzz`.
+  documents and expects, namely `/mxd/fuzz/target/debug/fuzz`.
 - `docker build -t mxd-fuzz -f fuzz/Dockerfile .` succeeds on a machine with
   Docker.
-- `docker run --rm mxd-fuzz bash -lc 'test -x /usr/local/bin/fuzz'` exits 0.
+- `docker run --rm --entrypoint bash mxd-fuzz -lc 'test -x /usr/local/bin/fuzz'`
+   exits 0.
 - `make fmt`, `make markdownlint`, and `make nixie` pass after any Markdown
   edits.
 - The GitHub Actions fuzz workflow clears the previous image-build failure.
@@ -296,7 +298,7 @@ copy path still points at `target/release/fuzz`; correcting that path is the
 first retry. If a documentation command reformats Markdown, rerun
 `make markdownlint` and `make nixie` after `make fmt`.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Current failing Dockerfile fragment:
 
@@ -338,4 +340,8 @@ final image: runs afl-fuzz with /usr/local/bin/fuzz
 Initial draft created after tracing the reported GitHub Actions failure to a
 self-referential `COPY --from=builder` in `fuzz/Dockerfile` and identifying a
 second debug-versus-release artefact mismatch that should be fixed in the same
-change. Remaining work is implementation and validation only.
+change. Implementation completed 2026-03-14; `fuzz/Dockerfile` and
+`docs/fuzzing.md` have been updated to remove the stage cycle and align the
+artefact path with the debug-profile convention. Full validation remains
+blocked by environment constraints (no Docker daemon available, nightly
+toolchain issues).

--- a/docs/execplans/afl-circular-dependency-issue.md
+++ b/docs/execplans/afl-circular-dependency-issue.md
@@ -1,0 +1,324 @@
+# Fix the AFL Docker build stage cycle
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Restore the nightly AFL++ container build so
+`docker build -t mxd-fuzz -f fuzz/Dockerfile .` succeeds again and the fuzzing
+workflow can run instead of failing during image creation. Success is visible
+in two places: the Docker image builds without the
+`circular dependency detected on stage: builder` error, and the resulting image
+contains an executable `/usr/local/bin/fuzz` binary that AFL++ can run.
+
+## Constraints
+
+- Keep the fix focused on the fuzzing container path. The plan may change
+  `fuzz/Dockerfile`, closely related documentation, and fuzzing workflow
+  references, but must not alter unrelated runtime or protocol code.
+- Preserve the existing fuzz harness entrypoint contract:
+  `afl-fuzz ... -- /usr/local/bin/fuzz @@`.
+- Do not add new third-party dependencies or new container images.
+- Keep the workflow compatible with the existing repository convention that
+  fuzz builds currently use the debug-profile harness unless a deliberate
+  follow-up plan changes that convention everywhere.
+- Validation must include the documented documentation gates for Markdown
+  changes and a real Docker build on a machine with a running Docker daemon.
+
+## Tolerances (exception triggers)
+
+- Scope: stop and escalate if the repair requires changes outside
+  `fuzz/Dockerfile`, `docs/fuzzing.md`, and `.github/workflows/fuzz.yml`.
+- Interface: stop and escalate if the harness path must change from
+  `/usr/local/bin/fuzz`.
+- Dependencies: stop and escalate if the fix would require a different base
+  image, a new toolchain manager, or additional packages.
+- Ambiguity: stop and escalate if the desired artefact profile is not clearly
+  debug. The current repository state points to debug, but a release-profile
+  shift would require coordinated changes beyond a minimal repair.
+- Validation: stop and escalate if
+  `docker build -t mxd-fuzz -f fuzz/Dockerfile .` still fails after one
+  stage-layout fix and one artefact-path fix, because that indicates a second
+  root cause.
+
+## Risks
+
+- Risk: fixing only the self-referential `COPY --from=builder` line could
+  expose a second failure because the final stage currently copies
+  `/mxd/fuzz/target/release/fuzz` even though `cargo afl build` builds the
+  debug harness by default. Severity: high Likelihood: high Mitigation: treat
+  the stage-cycle repair and artefact-path alignment as one atomic change, then
+  validate the produced image contains the expected binary.
+
+- Risk: `docs/fuzzing.md` currently describes sanitizers and automatic
+  nightly installation that do not appear in `fuzz/Dockerfile`. Severity:
+  medium Likelihood: medium Mitigation: update only the statements directly
+  affected by the repair and record any remaining documentation drift as a
+  follow-up if it is outside the minimal fix.
+
+- Risk: this environment cannot run Docker because no daemon socket is
+  available, so local validation here is limited to static inspection.
+  Severity: medium Likelihood: high Mitigation: require a real `docker build`
+  validation step in the plan and note the exact command and expected outcome.
+
+## Progress
+
+- [x] (2026-03-11 00:19Z) Inspected `fuzz/Dockerfile`,
+  `.github/workflows/fuzz.yml`, and `docs/fuzzing.md`.
+- [x] (2026-03-11 00:19Z) Identified the immediate root cause: a
+  `COPY --from=builder` instruction appears before the builder stage ends, so
+  Docker sees a stage copying from itself and aborts with a circular dependency
+  error.
+- [x] (2026-03-11 00:19Z) Identified a follow-on defect in the same file: the
+  final stage copies `target/release/fuzz`, but the build step uses
+  `cargo afl build` without `--release`, so the produced harness is under
+  `target/debug/fuzz`.
+- [x] (2026-03-11 00:19Z) Drafted this ExecPlan for review.
+- [ ] Implement the Dockerfile repair and any tightly related documentation
+  updates.
+- [ ] Run Markdown gates and Docker validation on a host with a running Docker
+  daemon.
+- [ ] Confirm the nightly workflow can proceed past image build.
+
+## Surprises & Discoveries
+
+- Observation: the failing line in `fuzz/Dockerfile` is not the final-stage
+  copy. It is a stray
+  `COPY --from=builder /mxd/fuzz/target/debug/fuzz /usr/local/bin/fuzz` placed
+  before the second `FROM`, which makes the builder stage depend on itself.
+  Evidence: `fuzz/Dockerfile:13` appears after
+  `RUN cargo afl build --manifest-path fuzz/Cargo.toml` and before the next
+  `FROM`. Impact: the fix must first correct Dockerfile stage boundaries, not
+  the AFL command itself.
+
+- Observation: the repository already points to a debug artefact everywhere
+  except the final-stage copy in `fuzz/Dockerfile`. Evidence: `docs/fuzzing.md`
+  runs `cargo afl fuzz ... fuzz/target/debug/fuzz` and
+  `.github/workflows/fuzz.yml` sets `BUILD_PROFILE: debug`. Impact: the minimal
+  consistent repair is to copy the debug harness in the final image, not to
+  switch the whole fuzz path to release.
+
+- Observation: Docker validation cannot be executed in this workspace because
+  `/var/run/docker.sock` is absent. Evidence: `docker build ...` fails here
+  with `failed to connect to the docker API at unix:///var/run/docker.sock`.
+  Impact: the plan must specify an external validation step instead of claiming
+  local proof.
+
+## Decision Log
+
+- Decision: plan a minimal repair that keeps the current debug-profile fuzz
+  artefact convention. Rationale: the self-cycle bug is the immediate failure,
+  and the repository already documents and configures debug artefacts
+  elsewhere. Switching to release would enlarge scope and create avoidable
+  ambiguity. Date/Author: 2026-03-11 / Codex
+
+- Decision: include the release/debug artefact mismatch in the same fix even
+  though the reported CI failure stops earlier. Rationale: once the stage cycle
+  is removed, the build would otherwise fail or produce the wrong image
+  contents in the next step. Shipping only the first half of the repair would
+  be knowingly incomplete. Date/Author: 2026-03-11 / Codex
+
+## Outcomes & Retrospective
+
+The investigation is complete and the implementation plan is ready, but the
+repair has not been applied yet. The main lesson is that the failure message
+accurately points to Dockerfile stage structure, yet static inspection also
+shows a second defect that should be fixed in the same change to avoid a
+predictable follow-on failure.
+
+## Context and orientation
+
+The relevant files are small and tightly coupled:
+
+- `fuzz/Dockerfile` builds the AFL harness and assembles the runtime image.
+- `.github/workflows/fuzz.yml` is the nightly GitHub Actions workflow that
+  runs `docker build -t mxd-fuzz -f fuzz/Dockerfile .`.
+- `docs/fuzzing.md` is the user-facing guide for the same flow.
+
+Docker builds multi-stage images by naming stages with `FROM ... AS <name>` and
+allowing later stages to copy files from earlier stages using
+`COPY --from=<name>`. A stage cannot copy from itself. In the current
+`fuzz/Dockerfile`, the `builder` stage contains a `COPY --from=builder`
+instruction before the next `FROM`, so Docker detects a circular dependency and
+aborts before any AFL-specific logic matters.
+
+The same file also mixes debug and release artefact paths. The builder runs
+`cargo afl build --manifest-path fuzz/Cargo.toml`, which produces
+`/mxd/fuzz/target/debug/fuzz` unless `--release` is passed. The final stage
+instead copies `/mxd/fuzz/target/release/fuzz`, which does not match the rest
+of the repository. The workflow and documentation both point to the debug
+binary, so the minimal safe fix is to make the final image copy the debug
+binary from the completed builder stage.
+
+## Plan of work
+
+Stage A is confirmation and red-state capture. Re-open `fuzz/Dockerfile`,
+`.github/workflows/fuzz.yml`, and `docs/fuzzing.md`, then record the failing
+stage structure and the artefact mismatch as the two issues this change will
+address. Do not edit any files until the reader can explain why Docker reports
+a cycle.
+
+Stage B is the Dockerfile repair. In `fuzz/Dockerfile`, remove the stray
+intra-stage `COPY --from=builder` line and keep exactly two stages: one
+`builder` stage that runs `make corpus` and `cargo afl build`, then one final
+runtime stage that copies the built harness from the completed builder stage
+into `/usr/local/bin/fuzz`. Align that copy path with the actual artefact
+generated by `cargo afl build`, which is the debug binary unless the plan is
+explicitly revised to adopt release everywhere.
+
+Stage C is documentation and workflow alignment. Update `docs/fuzzing.md` only
+where needed so the described container behaviour matches the repaired
+Dockerfile. Re-check `.github/workflows/fuzz.yml`; if it already matches the
+debug artefact convention, no workflow edit is needed. If any wording implies a
+release build or a different harness path, correct it in the same change.
+
+Stage D is validation. Run the Markdown gates required for documentation
+changes. Then, on a machine with a live Docker daemon, build the image and
+inspect the final container for `/usr/local/bin/fuzz`. Finally, rerun the fuzz
+workflow manually or via a pull request so the build step demonstrably clears
+the previous failure point.
+
+Do not proceed from Stage B to Stage C unless the edited Dockerfile has a valid
+two-stage structure. Do not consider Stage D complete unless both the
+documentation gates and a real Docker build succeed.
+
+## Concrete steps
+
+From the repository root:
+
+1. Inspect the current files before editing.
+
+   ```bash
+   sed -n '1,220p' fuzz/Dockerfile
+   sed -n '1,220p' .github/workflows/fuzz.yml
+   sed -n '1,220p' docs/fuzzing.md
+   ```
+
+   Expected observations:
+
+   ```plaintext
+   fuzz/Dockerfile contains COPY --from=builder before the second FROM
+   docs/fuzzing.md references fuzz/target/debug/fuzz
+   .github/workflows/fuzz.yml sets BUILD_PROFILE: debug
+   ```
+
+2. Edit `fuzz/Dockerfile` so it has one builder stage and one final runtime
+   stage, with the final stage copying the debug harness from the completed
+   builder stage.
+
+3. If needed, edit `docs/fuzzing.md` so the container description matches the
+   repaired Dockerfile and the debug harness convention.
+
+4. Run Markdown validation with logged output.
+
+   ```bash
+   set -o pipefail
+   make fmt | tee /tmp/afl-circular-dependency-make-fmt.log
+   set -o pipefail
+   make markdownlint | tee /tmp/afl-circular-dependency-markdownlint.log
+   set -o pipefail
+   make nixie | tee /tmp/afl-circular-dependency-nixie.log
+   ```
+
+   Expected result:
+
+   ```plaintext
+   All three commands exit 0
+   ```
+
+5. On a machine with Docker available, run the container build and a simple
+   runtime check.
+
+   ```bash
+   docker build -t mxd-fuzz -f fuzz/Dockerfile .
+   docker run --rm mxd-fuzz bash -lc 'test -x /usr/local/bin/fuzz'
+   ```
+
+   Expected result:
+
+   ```plaintext
+   docker build completes without "circular dependency detected on stage: builder"
+   docker run exits 0
+   ```
+
+6. Optionally prove the GitHub Actions path by triggering the fuzz workflow or
+   pushing the change through pull-request CI, then confirm the "Build fuzzing
+   container" step passes.
+
+## Validation and acceptance
+
+Acceptance criteria:
+
+- `fuzz/Dockerfile` no longer contains a self-referential stage copy.
+- The final image copies the same harness profile that the repository already
+  documents and expects, namely `fuzz/target/debug/fuzz`.
+- `docker build -t mxd-fuzz -f fuzz/Dockerfile .` succeeds on a machine with
+  Docker.
+- `docker run --rm mxd-fuzz bash -lc 'test -x /usr/local/bin/fuzz'` exits 0.
+- `make fmt`, `make markdownlint`, and `make nixie` pass after any Markdown
+  edits.
+- The GitHub Actions fuzz workflow clears the previous image-build failure.
+
+Quality method:
+
+- Static verification by inspecting the final Dockerfile stage layout.
+- Documentation gates via Makefile targets.
+- Real container build and runtime smoke test on a Docker-enabled host.
+- Workflow confirmation in GitHub Actions.
+
+## Idempotence and recovery
+
+The file edits are idempotent: reapplying the corrected two-stage Dockerfile
+does not change behaviour further. The validation commands are safe to rerun.
+If the Docker build fails after the stage-layout fix, inspect whether the final
+copy path still points at `target/release/fuzz`; correcting that path is the
+first retry. If a documentation command reformats Markdown, rerun
+`make markdownlint` and `make nixie` after `make fmt`.
+
+## Artifacts and notes
+
+Current failing Dockerfile fragment:
+
+```plaintext
+RUN cargo afl build --manifest-path fuzz/Cargo.toml
+
+COPY --from=builder /mxd/fuzz/target/debug/fuzz /usr/local/bin/fuzz
+
+FROM aflplusplus/aflplusplus:latest
+COPY --from=builder /mxd/fuzz/target/release/fuzz /usr/local/bin/fuzz
+```
+
+Current workflow evidence:
+
+```plaintext
+env:
+  FUZZ_HARNESS: /usr/local/bin/fuzz
+  BUILD_PROFILE: debug
+```
+
+## Interfaces and dependencies
+
+No new interfaces or dependencies are required. The repaired image must still
+provide:
+
+```plaintext
+/usr/local/bin/fuzz
+```
+
+The only container stages required at the end of this plan are:
+
+```plaintext
+builder: compiles the AFL harness
+final image: runs afl-fuzz with /usr/local/bin/fuzz
+```
+
+## Revision note
+
+Initial draft created after tracing the reported GitHub Actions failure to a
+self-referential `COPY --from=builder` in `fuzz/Dockerfile` and identifying a
+second debug-versus-release artefact mismatch that should be fixed in the same
+change. Remaining work is implementation and validation only.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -62,7 +62,7 @@ outlined in [roadmap.md](roadmap.md) and the storage notes in
 flowchart TD
     subgraph "Nightly CI Fuzzing Process (described in docs/fuzzing.md)"
         A[GitHub Actions Nightly Trigger] --> B[Build 'mxd-fuzz' Docker Image]
-        B -- "Includes project code, AFL++, and sanitizers" --> B
+        B -- "Builds harness in official AFL++ container, copies debug binary to /usr/local/bin/fuzz" --> B
         B --> C[Execute AFL++ in Docker Container]
         C -- "Targets 'parse_transaction' function" --> D[AFL++ Fuzzing Process]
         D -- "Runs for several hours" --> D

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -33,11 +33,9 @@ The harness panics on parsing errors so crashes will be detected. Refer to
 
 ### Docker
 
-`fuzz/Dockerfile` builds the harness with sanitizers and runs AFL++ inside the
-official container. Building with sanitizers (for example by setting
-`RUSTFLAGS="-Zsanitizer=address"`) requires the nightly Rust toolchain, which
-the Dockerfile installs automatically. Use the container for a
-reproducible environment:
+`fuzz/Dockerfile` builds the harness inside the official AFL++ container and
+copies the resulting debug binary to `/usr/local/bin/fuzz` in the final image.
+Use the container for a reproducible environment:
 
 ```bash
 # build the image

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -35,7 +35,7 @@ The harness panics on parsing errors so crashes will be detected. Refer to
 
 `fuzz/Dockerfile` builds the harness inside the official AFL++ container and
 copies the resulting debug binary to `/usr/local/bin/fuzz` in the final image.
-Use the container for a reproducible environment:
+The container provides a reproducible environment:
 
 ```bash
 # build the image

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -58,6 +58,11 @@ inspect new findings. This process aligns with the overall architecture
 outlined in [roadmap.md](roadmap.md) and the storage notes in
 [file-sharing-design.md](file-sharing-design.md).
 
+The following diagram illustrates the nightly CI fuzzing workflow: GitHub
+Actions triggers a build of the mxd-fuzz Docker image, which then executes
+AFL++ for several hours targeting the parse_transaction function, and finally
+uploads any crash artifacts for review.
+
 ```mermaid
 flowchart TD
     subgraph "Nightly CI Fuzzing Process (described in docs/fuzzing.md)"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -203,8 +203,8 @@ and explicit dependencies. Timeframes are intentionally omitted.
   Acceptance: `AuthStrategy` and `LoginReplyAugmenter` are wired into the
   guardrail routing entrypoint, and default behaviour for Hotline and SynHX
   remains unchanged. See
-  [ADR-003](docs/adr-003-login-authentication-and-reply-augmentation.md). Status:
-  Completed on 20 February 2026 by wiring `AuthStrategy` and
+  [ADR-003](docs/adr-003-login-authentication-and-reply-augmentation.md).
+  Status: Completed on 20 February 2026 by wiring `AuthStrategy` and
   `LoginReplyAugmenter` into `WireframeRouter`/`CompatibilityLayer` while
   preserving default Hotline and SynHX behaviour. Validation includes
   parameterized `rstest` coverage and `rstest-bdd` happy, unhappy, and edge

--- a/fuzz/Dockerfile
+++ b/fuzz/Dockerfile
@@ -10,8 +10,6 @@ ENV CC=afl-clang-fast
 ENV CXX=afl-clang-fast++
 RUN cargo afl build --manifest-path fuzz/Cargo.toml
 
-COPY --from=builder /mxd/fuzz/target/debug/fuzz /usr/local/bin/fuzz
-
 FROM aflplusplus/aflplusplus:latest
-COPY --from=builder /mxd/fuzz/target/release/fuzz /usr/local/bin/fuzz
+COPY --from=builder /mxd/fuzz/target/debug/fuzz /usr/local/bin/fuzz
 ENTRYPOINT ["afl-fuzz", "-M", "main", "-i", "/corpus", "-o", "/out", "--", "/usr/local/bin/fuzz", "@@"]


### PR DESCRIPTION
## Summary
- Implements a two-stage fix in the fuzz/Dockerfile to resolve the circular dependency by removing the intra-stage COPY --from=builder and copying the debug harness from the completed builder stage into the final image.
- Adds docs/execplans/afl-circular-dependency-issue.md containing an ExecPlan to guide investigation, repair, validation, and retroactive checks.
- Updates docs/fuzzing.md to reflect the repaired container layout and the debug-harness contract.
- Aligns GitHub Actions workflow expectations with the corrected artefact path.

## Changes
- Added: docs/execplans/afl-circular-dependency-issue.md
- Updated: fuzz/Dockerfile (two-stage layout; copy path updated)
- Updated: docs/fuzzing.md (Docker section reflects final image layout and path)
- Updated: docs/design.md (minor formatting fix)
- Updated: docs/roadmap.md (typo/line wrap fix)

## Rationale
- Keeps the fuzz container path minimal and consistent with the existing debug artefact path.
- Removes the self-referential stage copy to prevent Docker from erroring on build.
- Documents the problem and repair for future review and escalation.

## Validation plan
- Run Markdown gates: make fmt, make markdownlint, make nixie
- Validate via a real Docker build:
  - docker build -t mxd-fuzz -f fuzz/Dockerfile .
  - docker run --rm mxd-fuzz bash -lc 'test -x /usr/local/bin/fuzz'
- Acceptance: Build completes without the circular dependency error and the fuzz binary exists; GitHub Actions fuzz workflow passes.

## Notes
- The ExecPlan is a living document; updates will be reflected as work proceeds.
- Docker daemon access is required for end-to-end validation; environment limitations may require follow-up PRs to validate in CI.

📎 **Task**: https://www.devboxer.com/task/4fcee205-bcde-4d4f-a023-c6d2eb43702d

📎 **Task**: https://www.devboxer.com/task/f16fde8f-bd2d-4a33-875b-0d4de6f830c6