### PR TITLE
Wireframe v0.3.0: scoped task-local context and fallible app factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5833,9 +5833,9 @@ dependencies = [
 
 [[package]]
 name = "wireframe"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a74f8d429b888f695b9a5e3e0c322dc56abb5b103f59169c4370e35641d05bc"
+checksum = "ae7ba1b82771f0428551e3d19c8578521cc77c73dda66746e1e4ae5986d8a7c6"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 diesel-cte-ext = { workspace = true }
 futures-util = "0.3"
 tracing = "0.1"
-wireframe = "0.2.0"
+wireframe = "0.3.0"
 figment = { version = "0.10", features = ["env", "test"] }
 uncased = "0.9"
 xdg = "3"

--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -1,11 +1,11 @@
 # Documentation contents
 
-This file provides a guide to the mxd documentation, organised by purpose and
+This file provides a guide to the mxd documentation, organized by purpose and
 audience.
 
 ## Getting started
 
-Start here for an introduction to the project.
+Start here for newcomers to the project.
 
 - [`../README.md`](../README.md) — Project overview, quick start, and basic
   usage.
@@ -21,7 +21,7 @@ Documents that explain the system's design and structure.
 - [`design.md`](design.md) — Comprehensive architecture document covering the
   hexagonal (ports-and-adapters) design, runtime selection, and component
   boundaries.
-- [`repository-layout.md`](repository-layout.md) — Organisation of the codebase
+- [`repository-layout.md`](repository-layout.md) — Organization of the codebase
   and the purpose of each directory.
 - [`adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md`](adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md)
   — Notes on adopting hexagonal architecture during the Wireframe migration.
@@ -112,7 +112,7 @@ Quick reference and miscellaneous documentation.
 - [`release-notes-qa-sign-off.md`](release-notes-qa-sign-off.md) — QA sign-off
   checklist for releases.
 - [`complexity-antipatterns-and-refactoring-strategies.md`](complexity-antipatterns-and-refactoring-strategies.md)
-  — Guidance on recognising and addressing code complexity.
+  — Guidance on recognizing and addressing code complexity.
 - [`mermaid-validation.md`](mermaid-validation.md) — Validating Mermaid
   diagrams in documentation.
 - [`codescene-cli.md`](codescene-cli.md) — CodeScene CLI notes.

--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -1,0 +1,130 @@
+# Documentation contents
+
+This file provides a guide to the mxd documentation, organised by purpose and
+audience.
+
+## Getting started
+
+Start here if you are new to the project.
+
+- [`../README.md`](../README.md) — Project overview, quick start, and basic
+  usage.
+- [`users-guide.md`](users-guide.md) — Guide to running the server binaries
+  and using administrative commands.
+- [`developers-guide.md`](developers-guide.md) — Developer workflow, quality
+  gates, and local setup.
+
+## Understanding the architecture
+
+Documents that explain the system's design and structure.
+
+- [`design.md`](design.md) — Comprehensive architecture document covering the
+  hexagonal (ports-and-adapters) design, runtime selection, and component
+  boundaries.
+- [`repository-layout.md`](repository-layout.md) — Organisation of the codebase
+  and the purpose of each directory.
+- [`adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md`](adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md)
+  — Notes on adopting hexagonal architecture during the Wireframe migration.
+
+## Protocol and data models
+
+Reference documentation for the Hotline protocol and data models.
+
+- [`protocol.md`](protocol.md) — Hotline protocol specification, message
+  formats, and transaction types.
+- [`chat-schema.md`](chat-schema.md) — Chat system data model and schema.
+- [`news-schema.md`](news-schema.md) — News system data model and schema.
+- [`file-sharing-design.md`](file-sharing-design.md) — File sharing
+  architecture and design.
+- [`cte-extension-design.md`](cte-extension-design.md) — Common Table
+  Expression extension for Diesel.
+
+## Development guides
+
+Detailed guides for specific development concerns.
+
+### Testing
+
+- [`rstest-bdd-users-guide.md`](rstest-bdd-users-guide.md) — Behaviour-driven
+  development with rstest-bdd.
+- [`rstest-bdd-v0-5-0-migration-guide.md`](rstest-bdd-v0-5-0-migration-guide.md)
+  — Migrating to rstest-bdd v0.5.0.
+- [`rust-testing-with-rstest-fixtures.md`](rust-testing-with-rstest-fixtures.md)
+  — Testing patterns using rstest fixtures.
+- [`rust-doctest-dry-guide.md`](rust-doctest-dry-guide.md) — Patterns for
+  avoiding duplication in Rust doctests.
+- [`reliable-testing-in-rust-via-dependency-injection.md`](reliable-testing-in-rust-via-dependency-injection.md)
+  — Testing strategies using dependency injection.
+- [`verification-strategy.md`](verification-strategy.md) — Overall testing and
+  verification approach.
+- [`fuzzing.md`](fuzzing.md) — Fuzzing harness setup and usage.
+
+### Database
+
+- [`supporting-both-sqlite3-and-postgresql-in-diesel.md`](supporting-both-sqlite3-and-postgresql-in-diesel.md)
+  — Dual-database support implementation.
+- [`pg-embed-setup-unpriv-users-guide.md`](pg-embed-setup-unpriv-users-guide.md)
+  — PostgreSQL test helper guide.
+- [`pg-embed-setup-unpriv-v0-5-0-migration-guide.md`](pg-embed-setup-unpriv-v0-5-0-migration-guide.md)
+  — Migration guide for PostgreSQL helper v0.5.0.
+
+### Configuration and utilities
+
+- [`ortho-config-users-guide.md`](ortho-config-users-guide.md) — Configuration
+  system using ortho-config.
+- [`whitaker-users-guide.md`](whitaker-users-guide.md) — Whitaker component
+  guide.
+- [`wireframe-users-guide.md`](wireframe-users-guide.md) — Wireframe library
+  usage guide.
+- [`wireframe-v0-2-0-to-v0-3-0-migration-guide.md`](wireframe-v0-2-0-to-v0-3-0-migration-guide.md)
+  — Migrating from Wireframe v0.2.0 to v0.3.0.
+
+## Planning and roadmap
+
+Documents for project planning and tracking progress.
+
+- [`roadmap.md`](roadmap.md) — Implementation roadmap with phases, steps, and
+  measurable tasks.
+- [`migration-plan-moving-mxd-protocol-implementation-to-wireframe.md`](migration-plan-moving-mxd-protocol-implementation-to-wireframe.md)
+  — Detailed plan for migrating protocol handling to Wireframe.
+- [`execplans/`](execplans/) — Execution plans for individual roadmap tasks.
+
+## Architectural decisions
+
+Architectural Decision Records (ADRs) capture significant design decisions.
+
+- [`adr-001-login-auth-reply-compatibility-layers.md`](adr-001-login-auth-reply-compatibility-layers.md)
+  — ADR 001: Separate login authentication and reply augmentation
+  (superseded).
+- [`adr-002-compatibility-guardrails-and-augmentation.md`](adr-002-compatibility-guardrails-and-augmentation.md)
+  — ADR 002: Compatibility guardrails and augmentation (superseded).
+- [`adr-003-login-authentication-and-reply-augmentation.md`](adr-003-login-authentication-and-reply-augmentation.md)
+  — ADR 003: Split login authentication and reply augmentation (accepted).
+
+## Reference
+
+Quick reference and miscellaneous documentation.
+
+- [`documentation-style-guide.md`](documentation-style-guide.md) — Conventions
+  for authoring documentation (spelling, formatting, ADR templates).
+- [`internal-compatibility-matrix.md`](internal-compatibility-matrix.md) —
+  Client compatibility matrix for release validation.
+- [`release-notes-qa-sign-off.md`](release-notes-qa-sign-off.md) — QA sign-off
+  checklist for releases.
+- [`complexity-antipatterns-and-refactoring-strategies.md`](complexity-antipatterns-and-refactoring-strategies.md)
+  — Guidance on recognising and addressing code complexity.
+- [`mermaid-validation.md`](mermaid-validation.md) — Validating Mermaid
+  diagrams in documentation.
+- [`codescene-cli.md`](codescene-cli.md) — CodeScene CLI notes.
+
+## Document conventions
+
+This documentation follows the conventions defined in
+[`documentation-style-guide.md`](documentation-style-guide.md):
+
+- British English (en-GB-oxendict) spelling.
+- Sentence case for headings.
+- 80-column wrap for paragraphs.
+- 120-column wrap for code blocks.
+- Oxford comma where it aids comprehension.
+- Footnotes for references using `[^label]` syntax.

--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -5,7 +5,7 @@ audience.
 
 ## Getting started
 
-Start here if you are new to the project.
+Start here for an introduction to the project.
 
 - [`../README.md`](../README.md) — Project overview, quick start, and basic
   usage.

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,11 +24,8 @@ domain operations can be exercised in isolation from their environment.
   loop, the `wireframe` crate acts as the **port** for the Hotline binary
   protocol. It handles socket I/O with Tokio, decodes and encodes the
   Hotline-specific frames, and dispatches incoming messages to the appropriate
-  domain handler via a routing
-  table([2](https://github.com/leynos/wireframe/blob/fa6c62925443e6caed54866a95d3396eb8fa78a2/README.md#L35-L43)
-   )(
-  [1](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/migration-plan-moving-mxd-protocol-implementation-to-wireframe.md#L140-L148)).
-   Each Hotline “transaction” type (a message or request identified by an ID)
+  domain handler via a routing table[^wireframe-routing-table][^mxd-routing-handlers].
+  Each Hotline “transaction” type (a message or request identified by an ID)
   is mapped to a handler function. For example, the Login transaction (Hotline
   ID 0x006B) is routed to a `handle_login` handler in the domain core. The
   Wireframe adapter thus plays the role of the **primary port** on the inbound
@@ -293,8 +290,8 @@ Actix-web-style API but for arbitrary binary
 protocols([2](https://github.com/leynos/wireframe/blob/fa6c62925443e6caed54866a95d3396eb8fa78a2/README.md#L3-L12)
  )(
 [2](https://github.com/leynos/wireframe/blob/fa6c62925443e6caed54866a95d3396eb8fa78a2/README.md#L30-L38)).
- In MXD, we use Wireframe to handle all incoming TCP connections and route
-decoded messages to handler functions based on their **transaction ID**.
+ MXD uses Wireframe to handle all incoming TCP connections and route decoded
+messages to handler functions based on their **transaction ID**.
 
 **Protocol-Level Routing**: In a Hotline server, each client request is
 identified by a numeric transaction type (e.g. 107 for Login, 200 for file
@@ -866,7 +863,7 @@ Key aspects of configuration:
   `#[arg(default_value_t = "0.0.0.0:5500".to_string())]` which sets a default
   if not otherwise
   specified([4](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/src/main.rs#L126-L134)).
-   The user can override these by passing arguments; e.g.
+   These values can be overridden by passing arguments; e.g.
   `mxd --bind 192.168.1.1:1234` to listen on a custom address.
 
 - **Environment Variables**: For each field, an env var is automatically
@@ -1111,13 +1108,12 @@ API([9](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb
 example([4](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/src/main.rs#L114-L122)
  )(
 [4](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/src/main.rs#L116-L124))).
- This ensures that whether you’re using SQLite or PG, the schema will be
-up-to-date. The migration version numbers (the timestamps in filenames) are
-kept identical between the two trees, so that Diesel’s migration tracking
-(which just uses a numeric identifier) stays
-consistent.[^diesel-migration-consistency] – this is important if a user
-switches from SQLite to PG or vice versa with existing data: we want version
-`00000000000003` to represent the same logical migration on both.
+ This ensures that the schema remains current for both SQLite and PG. The
+migration version numbers (the timestamps in filenames) are kept identical
+between the two trees, so that Diesel’s migration tracking (which just uses a
+numeric identifier) stays consistent.[^diesel-migration-consistency] This is
+important when switching existing data between SQLite and PG: version
+`00000000000003` represents the same logical migration on both.
 
 ### Schema Design for Key Domains
 
@@ -3585,4 +3581,10 @@ that adding those features will require minimal changes to existing components
 (thanks to clear module boundaries and use of standard crates for integration).
 
 [^diesel-migration-consistency]:
-  supporting-both-sqlite3-and-postgresql-in-diesel.md#L34-L37
+  [supporting-both-sqlite3-and-postgresql-in-diesel.md#L34-L37](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md#L34-L37)
+
+[^wireframe-routing-table]:
+  [https://github.com/leynos/wireframe/blob/fa6c62925443e6caed54866a95d3396eb8fa78a2/README.md#L35-L43](https://github.com/leynos/wireframe/blob/fa6c62925443e6caed54866a95d3396eb8fa78a2/README.md#L35-L43)
+
+[^mxd-routing-handlers]:
+  [https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/migration-plan-moving-mxd-protocol-implementation-to-wireframe.md#L140-L148](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/migration-plan-moving-mxd-protocol-implementation-to-wireframe.md#L140-L148)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -81,6 +81,46 @@ The behavioural suite uses `rstest-bdd` v0.5.0 in both the root crate and
 - If a scenario needs a fallible return signature, use explicit
   `Result<(), E>` or `StepResult<(), E>` in the scenario function signature.
 
+## Wireframe adapter context handoff
+
+The Wireframe adapter carries Hotline handshake metadata from the asynchronous
+handshake hook into the synchronous app factory through task-local state plus a
+task-ID keyed registry in `src/wireframe/connection.rs`.
+
+- `scope_current_context(...)` seeds the per-task context for a future and
+  mirrors any initial context into the registry so post-handshake app-factory
+  code can retrieve it after the scoped future exits.
+- `store_current_context(...)` updates both the task-local slot and the
+  registry for the current Tokio task.
+- `take_current_context()` consumes the context for the current task. The app
+  factory uses this to fail closed once the per-connection state has been
+  handed off.
+- `has_current_context()` is the public visibility probe for code that needs
+  to ask whether the current Tokio task can see stored context.
+
+The Wireframe server bootstrap converts app-factory failures into the internal
+`AppFactoryError` enum in `src/server/wireframe/mod.rs`. Current variants are:
+
+- `MissingHandshakeContext` when no handshake metadata was stored for the
+  current task.
+- `MissingPeerAddress` when the handshake metadata exists but no peer address
+  was attached.
+- `BuildApplication` when the underlying `WireframeApp` builder returns an
+  error while registering middleware or routes.
+
+Use the fallible app-factory pattern when per-connection setup can fail:
+
+```rust,no_run
+fn app_factory() -> Result<HotlineApp, AppFactoryError> {
+    build_app_for_connection(&pool, &argon2, &outbound_registry)
+}
+```
+
+Returning `Result` allows the adapter to preserve typed failure information and
+propagate setup errors without panicking. Keep these failures explicit in tests
+so missing handshake metadata, missing peer metadata, and builder failures all
+remain covered.
+
 ## Quality gates
 
 Run the full suite from the repository root after making changes:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -103,7 +103,7 @@ The Wireframe server bootstrap converts app-factory failures into the internal
 
 - `MissingHandshakeContext` when no handshake metadata was stored for the
   current task.
-- `MissingPeerAddress` when the handshake metadata exists but no peer address
+- `MissingPeerAddress` when the handshake metadata exists, but no peer address
   was attached.
 - `BuildApplication` when the underlying `WireframeApp` builder returns an
   error while registering middleware or routes.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -121,6 +121,25 @@ propagate setup errors without panicking. Keep these failures explicit in tests
 so missing handshake metadata, missing peer metadata, and builder failures all
 remain covered.
 
+WireframeServer construction now relies on the `AppFactory` trait rather than a
+plain `Fn() -> WireframeApp` assumption. Closures still work through blanket
+implementations, but migration work should make the return type explicit:
+
+```rust,no_run
+let server = WireframeServer::new(|| WireframeApp::default());
+```
+
+becomes:
+
+```rust,no_run
+let server = WireframeServer::new(|| -> Result<HotlineApp, AppFactoryError> {
+    build_app_for_connection(&pool, &argon2, &outbound_registry)
+});
+```
+
+Treat this as the preferred migration pattern whenever the adapter needs
+connection-scoped handshake state or any other fallible setup at factory time.
+
 ## Quality gates
 
 Run the full suite from the repository root after making changes:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -140,6 +140,43 @@ let server = WireframeServer::new(|| -> Result<HotlineApp, AppFactoryError> {
 Treat this as the preferred migration pattern whenever the adapter needs
 connection-scoped handshake state or any other fallible setup at factory time.
 
+Wireframe v0.3.0 also changed the codec and import surface that this adapter
+uses:
+
+- Add `wireframe = "0.3.0"` to `Cargo.toml`, enabling feature flags such as
+  `testkit` explicitly when the main crate APIs are needed during tests or
+  harness setup.
+- `FrameCodec::wrap_payload` now takes `Bytes` rather than `Vec<u8>`. Codecs
+  that still materialize owned frames can convert with `.to_vec()`, while
+  zero-copy codecs should store the `Bytes` directly and optionally override
+  `frame_payload_bytes(...)`.
+- Root-level re-exports are no longer the stable import path for most adapter
+  integrations. Prefer module paths such as `wireframe::app::WireframeApp`,
+  `wireframe::codec::FrameCodec`, `wireframe::server::WireframeServer`,
+  `wireframe::hooks::ConnectionContext`, and `wireframe::testkit::...`.
+- Migration from older imports is mostly mechanical:
+
+```rust,no_run
+use bytes::Bytes;
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    codec::FrameCodec,
+    hooks::ConnectionContext,
+    server::WireframeServer,
+};
+
+impl FrameCodec for HotlineFrameCodec {
+    type Frame = Vec<u8>;
+    // ...
+
+    fn wrap_payload(&self, payload: Bytes) -> Self::Frame { payload.to_vec() }
+}
+```
+
+Keep these import-path changes explicit in migration patches so reviews can
+confirm whether a call site still depends on a compatibility re-export or has
+been moved onto the intended v0.3.0 module path.
+
 ## Quality gates
 
 Run the full suite from the repository root after making changes:

--- a/docs/execplans/wireframe-v0-3-0-migration.md
+++ b/docs/execplans/wireframe-v0-3-0-migration.md
@@ -1,0 +1,450 @@
+# Adopt wireframe v0.3.0 in mxd
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+After this change, `mxd` builds, tests, and runs against `wireframe` v0.3.0
+without relying on APIs removed since v0.2.0. The migration should also take
+advantage of one v0.3.0 capability that clearly fits this codebase: a fallible
+app factory for the wireframe server, so a connection that cannot build a valid
+`WireframeApp` fails closed instead of falling back to a degraded default app.
+
+Observable outcome: `Cargo.toml` and `Cargo.lock` resolve `wireframe` v0.3.0,
+the wireframe-only test suite still passes, and the server preserves current
+Hotline behaviour for handshake handling, transaction routing, XOR
+compatibility, and outbound push delivery. If selected transport tests are
+converted to `wireframe::testkit`, those tests should become simpler without
+changing behaviour.
+
+## Constraints
+
+- Preserve the current Hotline wire contract, including the handshake reply,
+  transaction framing, transaction reassembly, XOR compatibility, and route
+  dispatch behaviour.
+- Keep `src/wireframe/codec/mod.rs`, `src/wireframe/codec/framed.rs`, and
+  `src/wireframe/codec/frame.rs` as the protocol authority for Hotline framing.
+  This migration must not replace Hotline-specific framing with `wireframe`
+  fragmentation or the message assembler in the same change.
+- Do not introduce any new third-party crate unless the user explicitly
+  approves it. Enabling new features on the existing `wireframe` dependency is
+  allowed; adding the separate `wireframe_testing` crate is not.
+- Keep public `mxd` APIs and the behaviour of the `mxd-wireframe-server`
+  binary stable.
+- Follow repository quality gates: `make check-fmt`, `make lint`, and
+  `make test` must pass before the migration is considered complete.
+- Keep Rust files under 400 lines and retain module-level `//!` comments.
+
+## Tolerances (exception triggers)
+
+- Scope: if the migration needs changes in more than 15 files or more than
+  500 net lines, stop and review the plan before continuing.
+- Interfaces: if the migration requires changing public `mxd` interfaces
+  outside the wireframe integration modules, stop and escalate.
+- Dependencies: if `wireframe::testkit` is insufficient and the work appears
+  to require `wireframe_testing`, stop and get approval before adding it.
+- Validation: if `make test-wireframe-only` or the equivalent focused suite
+  still fails after two fix iterations, stop and review the failing surface.
+- Ambiguity: if `wireframe` v0.3.0's fallible factory semantics do not map
+  cleanly to the current handshake/app-context flow, stop and confirm the
+  desired failure mode before proceeding.
+
+## Risks
+
+- Risk: changing the app factory from infallible to fallible may alter how
+  connection setup failures surface. Severity: high. Likelihood: medium.
+  Mitigation: add or update targeted tests around missing handshake context and
+  successful handshake setup before removing the fallback path.
+
+- Risk: root re-export removal may break doc examples, tests, or helper code
+  beyond the three primary source files already identified. Severity: medium.
+  Likelihood: medium. Mitigation: run a focused wireframe-only compile after
+  the dependency bump, then fix import paths before broader refactors.
+
+- Risk: `wireframe::testkit` may not fit tests that depend on the Hotline
+  preamble or custom `HotlineCodec`. Severity: medium. Likelihood: medium.
+  Mitigation: adopt it only in low-level codec/transport tests first, and keep
+  the existing `src/wireframe/test_helpers/` fixtures for protocol-specific
+  data.
+
+- Risk: the migration may accidentally widen scope into unused client features
+  such as pooling, streaming, or tracing. Severity: low. Likelihood: medium.
+  Mitigation: explicitly treat those surfaces as out of scope unless a real
+  `WireframeClient` use appears in the codebase.
+
+## Progress
+
+- [x] (2026-04-06) Review `docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md`
+      and `docs/wireframe-users-guide.md`.
+- [x] (2026-04-06) Inventory current `wireframe` usage in `Cargo.toml`,
+      `src/server/wireframe/mod.rs`, `src/wireframe/protocol.rs`,
+      `src/wireframe/outbound.rs`, `src/wireframe/codec/frame.rs`,
+      `src/wireframe/handshake.rs`, and the wireframe-focused test files.
+- [x] (2026-04-06) Identify the highest-value v0.3.0 adoption points:
+      removed root re-exports, fallible app factories, and selective testkit
+      adoption.
+- [ ] Update the `wireframe` dependency to v0.3.0 and regenerate `Cargo.lock`.
+- [ ] Fix compile-time breakage from removed root re-exports and any changed
+      trait bounds.
+- [ ] Refactor the wireframe server bootstrap to use a fallible app factory
+      and remove the degraded fallback app path.
+- [ ] Evaluate and, if beneficial, adopt `wireframe::testkit` in one or two
+      low-level transport suites.
+- [ ] Run the full repository validation suite and capture the final outcome in
+      this ExecPlan.
+
+## Surprises & discoveries
+
+- Observation: `mxd` already avoids several v0.3.0 breakages.
+  Evidence: current code does not use `WireframeApp::new()`, `AppDataStore`,
+  `WireframeClient`, `PacketParts::payload`, `FragmentParts::payload`, or
+  `BackoffConfig::normalised`. Impact: the migration can stay focused on a
+  narrow set of concrete changes.
+
+- Observation: `src/server/wireframe/mod.rs` currently validates app
+  construction at startup, then logs and falls back to `HotlineApp::default()`
+  when per-connection app setup fails. Evidence: `build_app_with_logging()`
+  catches `try_build_app()` errors and returns `fallback_app()`. Impact:
+  v0.3.0's fallible app factory directly addresses an existing workaround and
+  is the clearest capability win for `mxd`.
+
+- Observation: Hotline transaction fragmentation is already implemented inside
+  `HotlineCodec`, not by wireframe's transport fragmentation layer. Evidence:
+  `src/wireframe/codec/framed.rs` reassembles incoming fragments and fragments
+  large outbound payloads itself. Impact: `memory_budgets`,
+  `enable_fragmentation()`, and `with_message_assembler()` are not direct
+  drop-ins for this migration and should be deferred unless the protocol layer
+  is redesigned.
+
+- Observation: the codebase has no current `WireframeClient` usage.
+  Evidence: the wireframe integration is concentrated in server bootstrap,
+  protocol hooks, codecs, and server-side tests. Impact: client pooling,
+  streaming, tracing, and request hooks are presently informative but not
+  applicable migration targets.
+
+## Decision log
+
+- Decision: scope the migration around the existing server runtime rather than
+  unused client APIs. Rationale: no current `WireframeClient` usage exists, so
+  client pooling, streaming, tracing, and request hooks would add new surface
+  without solving a present problem. Date/Author: 2026-04-06 / Assistant
+
+- Decision: treat the fallible app factory as the primary v0.3.0 capability to
+  adopt in code. Rationale: it removes the current degraded fallback path in
+  `src/server/wireframe/mod.rs` and aligns failure handling with the existing
+  `try_build_app()` split. Date/Author: 2026-04-06 / Assistant
+
+- Decision: keep Hotline framing and reassembly in the in-tree codec modules.
+  Rationale: replacing them with wireframe fragmentation or the message
+  assembler would combine a version bump with a protocol redesign, which is
+  unnecessary risk for this migration. Date/Author: 2026-04-06 / Assistant
+
+- Decision: consider `wireframe::testkit` only for targeted low-level suites,
+  and defer `wireframe_testing` unless approval is given. Rationale:
+  feature-only adoption is lower risk than adding a new crate, and the custom
+  Hotline preamble means not every v0.3.0 test helper will fit. Date/Author:
+  2026-04-06 / Assistant
+
+## Outcomes & retrospective
+
+At draft time, the migration path is intentionally narrow: bump `wireframe` to
+v0.3.0, repair removed import paths, adopt fallible app construction where it
+eliminates a known workaround, and selectively use `wireframe::testkit` only
+where it clearly simplifies low-level tests. The largest uncertainty is not the
+dependency bump itself, but whether any test harnesses gain enough value from
+`testkit` to justify the extra churn.
+
+## Context and orientation
+
+`mxd` is a Rust workspace whose wireframe integration lives under
+`src/server/wireframe/` and `src/wireframe/`. The manifest at `Cargo.toml`
+currently declares `wireframe = "0.2.0"` and builds the `mxd-wireframe-server`
+binary from `src/bin/mxd_wireframe_server.rs`.
+
+The key runtime file is `src/server/wireframe/mod.rs`. It defines `HotlineApp`
+as `WireframeApp<BincodeSerializer, (), Envelope, HotlineFrameCodec>`, prepares
+a `WireframeServer`, installs Hotline preamble hooks from
+`src/wireframe/handshake.rs`, disables wireframe fragmentation with
+`.fragmentation(None)`, and registers the Hotline protocol and transaction
+middleware.
+
+`src/wireframe/protocol.rs` implements wireframe protocol hooks for Hotline. It
+currently imports `ConnectionContext` and `WireframeProtocol` from the crate
+root, which v0.3.0 removes in favour of `wireframe::hooks`.
+
+`src/wireframe/outbound.rs` stores and retrieves per-connection push handles.
+It currently imports `ConnectionId` and `SessionRegistry` from the crate root,
+which v0.3.0 moves under `wireframe::session`.
+
+`src/wireframe/codec/frame.rs` adapts the in-tree `HotlineCodec` to wireframe's
+`FrameCodec` trait. It is the bridge between Hotline transaction bytes and
+wireframe `Envelope` payloads.
+
+`src/wireframe/handshake.rs` attaches preamble success and failure handlers,
+stores handshake context, and contains tests that currently use
+`BincodeSerializer` through a root import in one test module.
+
+The most relevant tests for this migration are:
+
+1. `tests/wireframe_handshake_metadata.rs`
+2. `tests/wireframe_transaction.rs`
+3. `tests/wireframe_xor_compat.rs`
+4. `src/wireframe/codec/tests.rs`
+5. `src/wireframe/codec/framed_tests.rs`
+6. `src/wireframe/handshake.rs` tests
+
+In this plan, a "fallible app factory" means a closure passed to
+`WireframeServer::new` that returns `Result<WireframeApp, E>` instead of always
+returning an app directly. Wireframe v0.3.0 can propagate that error without
+forcing `mxd` to return a default app that accepts traffic without the required
+per-connection routing state.
+
+## Plan of work
+
+### Stage A: bump the dependency and surface actual breakage
+
+Update `Cargo.toml` from `wireframe = "0.2.0"` to `wireframe = "0.3.0"`, then
+refresh `Cargo.lock`. Do not enable new dependency features yet, because the
+first goal is to let the compiler reveal which existing imports and trait
+usages actually break.
+
+After the version bump, run a focused wireframe-only compile first. This keeps
+the feedback loop short and avoids burying API breakage under unrelated
+backend-specific output.
+
+### Stage B: repair v0.3.0 breaking changes already used by mxd
+
+Fix the removed root re-export usages first:
+
+1. In `src/wireframe/protocol.rs`, import
+   `ConnectionContext` and `WireframeProtocol` from `wireframe::hooks`.
+2. In `src/wireframe/outbound.rs`, import `ConnectionId` and
+   `SessionRegistry` from `wireframe::session`.
+3. In `src/wireframe/handshake.rs` test code and any similar sites, import
+   `BincodeSerializer` from `wireframe::serializer`.
+
+While doing this, inspect compile errors for any secondary breakage in tests,
+doc examples, or helper modules. Because the codebase does not appear to use
+other removed or renamed surfaces, this stage should remain small.
+
+### Stage C: adopt the fallible factory path
+
+Refactor `src/server/wireframe/mod.rs` so the closure passed to
+`WireframeServer::new` returns `Result<HotlineApp, anyhow::Error>` (or a
+similarly typed error) rather than always returning `HotlineApp`.
+
+The target shape is:
+
+```rust
+let app_factory = {
+    let pool = pool.clone();
+    let argon2 = Arc::clone(&argon2);
+    let outbound_registry = Arc::clone(&outbound_registry);
+    move || try_build_app(&pool, &argon2, &outbound_registry)
+};
+```
+
+Then remove the fallback path that currently logs and returns
+`HotlineApp::default()`. That default app is safe as a compile-time type, but
+unsafe as a runtime behaviour because it can accept traffic without the
+handshake-derived routing context that `mxd` expects.
+
+Keep `validate_app_factory()` if it still provides value as a startup-time
+sanity check for route registration and middleware wiring. The difference is
+that startup validation remains explicit, while per-connection context failures
+must propagate rather than silently downgrading.
+
+Before considering this stage done, add or update a test that proves the app
+factory fails closed when handshake context is missing or incomplete, and that
+the valid handshake path still sets up the app normally.
+
+### Stage D: selectively adopt v0.3.0 test helpers
+
+Once the runtime compiles and the focused tests are green, review whether one
+or two low-level suites become simpler with `wireframe::testkit`. The best
+starting points are `src/wireframe/codec/tests.rs` and
+`src/wireframe/handshake.rs` tests, because they already exercise transport
+edges such as partial frames, fragmented payloads, or slow reads.
+
+The goal is not to replace `src/wireframe/test_helpers/`. Those helpers encode
+Hotline-specific knowledge that `wireframe::testkit` does not provide. The goal
+is only to replace bespoke transport driving where v0.3.0 now offers a better
+primitive.
+
+If `testkit` clearly improves a test, add the minimal dependency feature
+required for test builds and migrate that suite. If it does not, record the
+discovery in this ExecPlan and keep the existing helpers.
+
+### Stage E: full validation and closeout
+
+After all code changes land, run the full project gates. The migration is only
+done when formatting, linting, and all test suites pass. Capture the final
+results and any deviations in this ExecPlan before marking it complete.
+
+## Concrete steps
+
+All commands run from:
+
+```plaintext
+/data/leynos/Projects/mxd.worktrees/wireframe-v0-3-0-migration
+```
+
+1. Bump the dependency and refresh the lockfile.
+
+   ```plaintext
+   cargo update -p wireframe --precise 0.3.0
+   ```
+
+   Expected transcript excerpt:
+
+   ```plaintext
+   Updating wireframe v0.2.0 -> v0.3.0
+   ```
+
+2. Run a focused wireframe-only compile or test pass to surface API errors
+   quickly.
+
+   ```plaintext
+   make typecheck-wireframe-only
+   make test-wireframe-only
+   ```
+
+   Expected outcome before fixes: compile errors or test failures that mention
+   moved imports such as `ConnectionContext`, `WireframeProtocol`,
+   `ConnectionId`, `SessionRegistry`, or `BincodeSerializer`.
+
+3. After import fixes, re-run the focused wireframe-only suite.
+
+   ```plaintext
+   make typecheck-wireframe-only
+   make test-wireframe-only
+   ```
+
+   Expected outcome after fixes: the wireframe-only build succeeds and the
+   focused tests pass.
+
+4. After the fallible factory refactor and any targeted test updates, run the
+   full repository gates.
+
+   ```plaintext
+   make check-fmt
+   make lint
+   make test
+   ```
+
+   Expected outcome:
+
+   ```plaintext
+   cargo fmt --all -- --check
+   ...
+   Finished `dev` profile ...
+   ...
+   test result: ok
+   ```
+
+5. If implementation edits any Markdown beyond this ExecPlan, also run:
+
+   ```plaintext
+   make fmt
+   make markdownlint
+   ```
+
+## Validation and acceptance
+
+The migration is accepted when all of the following are true:
+
+- `Cargo.toml` and `Cargo.lock` resolve `wireframe` v0.3.0.
+- No code still depends on removed root re-exports for
+  `ConnectionContext`, `WireframeProtocol`, `ConnectionId`, `SessionRegistry`,
+  or `BincodeSerializer`.
+- `mxd-wireframe-server` still handles valid and invalid Hotline handshakes as
+  before, proven by the existing handshake-focused tests.
+- Transaction routing, XOR compatibility, and outbound push behaviour still
+  pass the current wireframe-focused test suites.
+- The server no longer falls back to `HotlineApp::default()` when
+  per-connection app construction fails; instead, that failure is surfaced and
+  the connection fails closed.
+- If `wireframe::testkit` is adopted, at least one migrated suite proves the
+  new helper is a net simplification without changing observable behaviour.
+
+Quality criteria:
+
+- Tests: `make test`
+- Formatting: `make check-fmt`
+- Linting: `make lint`
+- Migration-focused regression check: `make test-wireframe-only`
+
+## Idempotence and recovery
+
+The dependency bump, import fixes, and validation commands are all safe to run
+multiple times. If the v0.3.0 bump exposes unexpected breakage, revert only the
+manifest and lockfile changes first, then re-apply the migration in smaller
+steps.
+
+If `wireframe::testkit` adoption broadens scope without clear payoff, revert
+that sub-step independently and complete the core version bump first. The
+capability adoption is optional; the compatibility migration is not.
+
+## Artifacts and notes
+
+Useful code snippets to preserve during implementation:
+
+```rust
+use wireframe::hooks::{ConnectionContext, WireframeProtocol};
+use wireframe::session::{ConnectionId, SessionRegistry};
+use wireframe::serializer::BincodeSerializer;
+```
+
+Relevant files for review during implementation:
+
+```plaintext
+Cargo.toml
+Cargo.lock
+src/server/wireframe/mod.rs
+src/wireframe/protocol.rs
+src/wireframe/outbound.rs
+src/wireframe/handshake.rs
+src/wireframe/codec/frame.rs
+src/wireframe/codec/tests.rs
+tests/wireframe_handshake_metadata.rs
+tests/wireframe_transaction.rs
+tests/wireframe_xor_compat.rs
+```
+
+## Interfaces and dependencies
+
+The runtime should continue to expose the same `HotlineApp` alias in
+`src/server/wireframe/mod.rs`:
+
+```rust
+type HotlineApp =
+    WireframeApp<BincodeSerializer, (), Envelope, HotlineFrameCodec>;
+```
+
+The `HotlineProtocol` type in `src/wireframe/protocol.rs` should continue to
+implement wireframe protocol hooks, but through the v0.3.0 module path:
+
+```rust
+impl WireframeProtocol for HotlineProtocol {
+    type Frame = Vec<u8>;
+    type ProtocolError = ();
+}
+```
+
+The dependency plan is:
+
+1. Update the main dependency to `wireframe = "0.3.0"`.
+2. Add only the `testkit` feature if a migrated test proves it is useful.
+3. Do not add `wireframe_testing` without explicit approval.
+
+## Revision note
+
+Created this draft after reviewing the current `mxd` wireframe integration and
+the v0.3.0 migration/user guides. The draft narrows the migration to import
+surface repairs, a fallible app factory, and optional `wireframe::testkit`
+adoption, because those are the only changes that currently appear both
+applicable and valuable.

--- a/docs/execplans/wireframe-v0-3-0-migration.md
+++ b/docs/execplans/wireframe-v0-3-0-migration.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -79,23 +79,32 @@ changing behaviour.
 ## Progress
 
 - [x] (2026-04-06) Review `docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md`
-      and `docs/wireframe-users-guide.md`.
+  and `docs/wireframe-users-guide.md`.
 - [x] (2026-04-06) Inventory current `wireframe` usage in `Cargo.toml`,
-      `src/server/wireframe/mod.rs`, `src/wireframe/protocol.rs`,
-      `src/wireframe/outbound.rs`, `src/wireframe/codec/frame.rs`,
-      `src/wireframe/handshake.rs`, and the wireframe-focused test files.
+  `src/server/wireframe/mod.rs`, `src/wireframe/protocol.rs`,
+  `src/wireframe/outbound.rs`, `src/wireframe/codec/frame.rs`,
+  `src/wireframe/handshake.rs`, and the wireframe-focused test files.
 - [x] (2026-04-06) Identify the highest-value v0.3.0 adoption points:
-      removed root re-exports, fallible app factories, and selective testkit
-      adoption.
-- [ ] Update the `wireframe` dependency to v0.3.0 and regenerate `Cargo.lock`.
-- [ ] Fix compile-time breakage from removed root re-exports and any changed
-      trait bounds.
-- [ ] Refactor the wireframe server bootstrap to use a fallible app factory
-      and remove the degraded fallback app path.
-- [ ] Evaluate and, if beneficial, adopt `wireframe::testkit` in one or two
-      low-level transport suites.
-- [ ] Run the full repository validation suite and capture the final outcome in
-      this ExecPlan.
+  removed root re-exports, fallible app factories, and selective testkit
+  adoption.
+- [x] (2026-04-06) Update the `wireframe` dependency to v0.3.0 and regenerate
+  `Cargo.lock`.
+- [x] (2026-04-06) Fix compile-time breakage from removed root re-exports and
+  changed trait bounds by moving imports to `wireframe::hooks`,
+  `wireframe::session`, and `wireframe::serializer`, and by adapting
+  `HotlineFrameCodec` to the v0.3.0 `FrameCodec::wrap_payload(&self, Bytes)`
+  signature.
+- [x] (2026-04-06) Refactor the wireframe server bootstrap to use a fallible
+  app factory and remove the degraded fallback app path. The factory now
+  returns a typed `AppFactoryError`, and unit tests assert that missing
+  handshake context fails closed while valid context still builds an app.
+- [x] (2026-04-06) Evaluate `wireframe::testkit` for targeted transport suites.
+  Conclusion: no adoption in this change because the migration completed with
+  focused compatibility fixes and the existing Hotline-specific helpers remain
+  the better fit for the current preamble and framing tests.
+- [x] (2026-04-06) Run the full repository validation suite and capture the
+  final outcome in this ExecPlan. `make check-fmt`, `make lint`, and
+  `make test` all pass after the migration.
 
 ## Surprises & discoveries
 
@@ -105,12 +114,12 @@ changing behaviour.
   `BackoffConfig::normalised`. Impact: the migration can stay focused on a
   narrow set of concrete changes.
 
-- Observation: `src/server/wireframe/mod.rs` currently validates app
-  construction at startup, then logs and falls back to `HotlineApp::default()`
-  when per-connection app setup fails. Evidence: `build_app_with_logging()`
-  catches `try_build_app()` errors and returns `fallback_app()`. Impact:
-  v0.3.0's fallible app factory directly addresses an existing workaround and
-  is the clearest capability win for `mxd`.
+- Observation: `src/server/wireframe/mod.rs` initially validated app
+  construction at startup, then logged and fell back to
+  `HotlineApp::default()` when per-connection app setup failed. Evidence:
+  `build_app_with_logging()` caught `try_build_app()` errors and returned
+  `fallback_app()`. Impact: v0.3.0's fallible app factory directly addressed
+  an existing workaround and was the clearest capability win for `mxd`.
 
 - Observation: Hotline transaction fragmentation is already implemented inside
   `HotlineCodec`, not by wireframe's transport fragmentation layer. Evidence:
@@ -125,6 +134,22 @@ changing behaviour.
   protocol hooks, codecs, and server-side tests. Impact: client pooling,
   streaming, tracing, and request hooks are presently informative but not
   applicable migration targets.
+
+- Observation: `wireframe` v0.3.0's fallible app factory fits the existing
+  handshake-context dependency cleanly.
+  Evidence: replacing `fallback_app()` with a
+  `Result<HotlineApp, AppFactoryError>` closure required only local changes in
+  `src/server/wireframe/mod.rs` plus targeted tests. Impact: the server now
+  fails closed when per-connection handshake context is missing, without
+  widening the migration into route or middleware redesign.
+
+- Observation: `wireframe::testkit` is not a clear win for the current Hotline
+  transport tests.
+  Evidence: the suites most relevant to the migration already depend on
+  Hotline-specific preamble bytes, frame reassembly, and bespoke helpers, and
+  the dependency bump plus app-factory refactor did not create painful test
+  boilerplate. Impact: the migration can stay smaller and lower risk by
+  keeping the existing test helpers for now.
 
 ## Decision log
 
@@ -149,20 +174,28 @@ changing behaviour.
   Hotline preamble means not every v0.3.0 test helper will fit. Date/Author:
   2026-04-06 / Assistant
 
+- Decision: keep the existing Hotline-specific transport helpers instead of
+  adopting `wireframe::testkit` in this migration. Rationale: after the
+  dependency bump and focused compatibility fixes, `testkit` did not offer a
+  meaningful simplification for the current preamble and codec suites.
+  Date/Author: 2026-04-06 / Assistant
+
 ## Outcomes & retrospective
 
-At draft time, the migration path is intentionally narrow: bump `wireframe` to
-v0.3.0, repair removed import paths, adopt fallible app construction where it
-eliminates a known workaround, and selectively use `wireframe::testkit` only
-where it clearly simplifies low-level tests. The largest uncertainty is not the
-dependency bump itself, but whether any test harnesses gain enough value from
-`testkit` to justify the extra churn.
+The migration landed as a narrow compatibility change: `wireframe` now resolves
+to v0.3.0, import-path and trait-signature breakage is repaired, and
+per-connection app construction now fails closed instead of silently falling
+back to `HotlineApp::default()`. Focused wireframe-only checks passed during
+development, and the full repository gates (`make check-fmt`, `make lint`, and
+`make test`) passed at the end. `wireframe::testkit` was evaluated but not
+adopted because the existing Hotline-specific helpers remain the better fit for
+the current preamble and framing suites.
 
 ## Context and orientation
 
 `mxd` is a Rust workspace whose wireframe integration lives under
 `src/server/wireframe/` and `src/wireframe/`. The manifest at `Cargo.toml`
-currently declares `wireframe = "0.2.0"` and builds the `mxd-wireframe-server`
+now declares `wireframe = "0.3.0"` and builds the `mxd-wireframe-server`
 binary from `src/bin/mxd_wireframe_server.rs`.
 
 The key runtime file is `src/server/wireframe/mod.rs`. It defines `HotlineApp`
@@ -173,29 +206,29 @@ a `WireframeServer`, installs Hotline preamble hooks from
 middleware.
 
 `src/wireframe/protocol.rs` implements wireframe protocol hooks for Hotline. It
-currently imports `ConnectionContext` and `WireframeProtocol` from the crate
-root, which v0.3.0 removes in favour of `wireframe::hooks`.
+now imports `ConnectionContext` and `WireframeProtocol` from
+`wireframe::hooks`.
 
 `src/wireframe/outbound.rs` stores and retrieves per-connection push handles.
-It currently imports `ConnectionId` and `SessionRegistry` from the crate root,
-which v0.3.0 moves under `wireframe::session`.
+It now imports `ConnectionId` and `SessionRegistry` from
+`wireframe::session`.
 
 `src/wireframe/codec/frame.rs` adapts the in-tree `HotlineCodec` to wireframe's
 `FrameCodec` trait. It is the bridge between Hotline transaction bytes and
 wireframe `Envelope` payloads.
 
 `src/wireframe/handshake.rs` attaches preamble success and failure handlers,
-stores handshake context, and contains tests that currently use
-`BincodeSerializer` through a root import in one test module.
+stores handshake context, and contains tests that now import
+`BincodeSerializer` from `wireframe::serializer`.
 
 The most relevant tests for this migration are:
 
 1. `tests/wireframe_handshake_metadata.rs`
-2. `tests/wireframe_transaction.rs`
-3. `tests/wireframe_xor_compat.rs`
-4. `src/wireframe/codec/tests.rs`
-5. `src/wireframe/codec/framed_tests.rs`
-6. `src/wireframe/handshake.rs` tests
+1. `tests/wireframe_transaction.rs`
+1. `tests/wireframe_xor_compat.rs`
+1. `src/wireframe/codec/tests.rs`
+1. `src/wireframe/codec/framed_tests.rs`
+1. `src/wireframe/handshake.rs` tests
 
 In this plan, a "fallible app factory" means a closure passed to
 `WireframeServer::new` that returns `Result<WireframeApp, E>` instead of always
@@ -222,9 +255,9 @@ Fix the removed root re-export usages first:
 
 1. In `src/wireframe/protocol.rs`, import
    `ConnectionContext` and `WireframeProtocol` from `wireframe::hooks`.
-2. In `src/wireframe/outbound.rs`, import `ConnectionId` and
+1. In `src/wireframe/outbound.rs`, import `ConnectionId` and
    `SessionRegistry` from `wireframe::session`.
-3. In `src/wireframe/handshake.rs` test code and any similar sites, import
+1. In `src/wireframe/handshake.rs` test code and any similar sites, import
    `BincodeSerializer` from `wireframe::serializer`.
 
 While doing this, inspect compile errors for any secondary breakage in tests,
@@ -234,8 +267,8 @@ other removed or renamed surfaces, this stage should remain small.
 ### Stage C: adopt the fallible factory path
 
 Refactor `src/server/wireframe/mod.rs` so the closure passed to
-`WireframeServer::new` returns `Result<HotlineApp, anyhow::Error>` (or a
-similarly typed error) rather than always returning `HotlineApp`.
+`WireframeServer::new` returns `Result<HotlineApp, AppFactoryError>` rather
+than always returning `HotlineApp`.
 
 The target shape is:
 
@@ -305,7 +338,7 @@ All commands run from:
    Updating wireframe v0.2.0 -> v0.3.0
    ```
 
-2. Run a focused wireframe-only compile or test pass to surface API errors
+1. Run a focused wireframe-only compile or test pass to surface API errors
    quickly.
 
    ```plaintext
@@ -317,7 +350,7 @@ All commands run from:
    moved imports such as `ConnectionContext`, `WireframeProtocol`,
    `ConnectionId`, `SessionRegistry`, or `BincodeSerializer`.
 
-3. After import fixes, re-run the focused wireframe-only suite.
+1. After import fixes, re-run the focused wireframe-only suite.
 
    ```plaintext
    make typecheck-wireframe-only
@@ -327,7 +360,7 @@ All commands run from:
    Expected outcome after fixes: the wireframe-only build succeeds and the
    focused tests pass.
 
-4. After the fallible factory refactor and any targeted test updates, run the
+1. After the fallible factory refactor and any targeted test updates, run the
    full repository gates.
 
    ```plaintext
@@ -346,7 +379,7 @@ All commands run from:
    test result: ok
    ```
 
-5. If implementation edits any Markdown beyond this ExecPlan, also run:
+1. If implementation edits any Markdown beyond this ExecPlan, also run:
 
    ```plaintext
    make fmt
@@ -438,8 +471,8 @@ impl WireframeProtocol for HotlineProtocol {
 The dependency plan is:
 
 1. Update the main dependency to `wireframe = "0.3.0"`.
-2. Add only the `testkit` feature if a migrated test proves it is useful.
-3. Do not add `wireframe_testing` without explicit approval.
+1. Add only the `testkit` feature if a migrated test proves it is useful.
+1. Do not add `wireframe_testing` without explicit approval.
 
 ## Revision note
 

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -1,0 +1,176 @@
+# Repository layout
+
+This document describes the organisation of the mxd codebase and the purpose
+of each major directory and file.
+
+## Top-level structure
+
+```text
+mxd/
+├── AGENTS.md              # Assistant coding guidelines
+├── Cargo.lock             # Dependency lock file
+├── Cargo.toml             # Workspace and package manifest
+├── LICENSE                # Project licence
+├── Makefile               # Build and development tasks
+├── README.md              # Project overview and quick start
+├── build.rs               # Build script for code generation
+├── clippy.toml            # Clippy configuration
+├── codecov.yml            # Code coverage configuration
+├── diesel.toml            # Diesel ORM configuration
+├── migrations/            # Database schema migrations
+├── rust-toolchain.toml    # Rust toolchain specification
+├── src/                   # Source code
+├── tests/                 # Integration and behavioural tests
+├── docs/                  # Documentation
+├── crates/                # Additional crate workspaces
+├── cli-defs/              # CLI definition utilities
+├── fuzz/                  # Fuzzing harness
+├── test-util/             # Test utilities and fixtures
+└── validator/             # Protocol validation harness
+```
+
+## Source code organisation (`src/`)
+
+The `src/` directory follows a hexagonal architecture pattern, separating
+domain logic from infrastructure adapters.
+
+```text
+src/
+├── lib.rs                 # Library entry point
+├── main.rs                # Legacy server binary entry point
+├── bin/                   # Additional binary entry points
+│   ├── gen_corpus.rs      # Fuzzing corpus generator
+│   └── mxd_wireframe_server.rs  # Wireframe server binary
+├── db/                    # Database adapter (Diesel ORM)
+├── domain/                # Core domain logic
+├── server/                # Server runtime and CLI
+│   ├── admin.rs           # Administrative subcommands
+│   ├── cli.rs             # CLI argument parsing
+│   ├── legacy.rs          # Legacy networking runtime
+│   ├── wireframe.rs       # Wireframe bootstrap
+│   └── mod.rs             # Server module entry
+├── transaction/           # Hotline transaction handling
+├── wireframe/             # Wireframe protocol adapter
+└── wireframe_compat/      # Compatibility layer for Wireframe
+```
+
+## Documentation (`docs/`)
+
+Documentation is organised by purpose and audience.
+
+### Core documentation
+
+- `design.md` — Comprehensive architecture and design decisions.
+- `protocol.md` — Hotline protocol specification and implementation notes.
+- `roadmap.md` — Implementation roadmap with phases and tasks.
+- `users-guide.md` — End-user guide for running the server.
+- `developers-guide.md` — Developer workflow and quality gates.
+
+### Architecture and decisions
+
+- `documentation-style-guide.md` — Conventions for authoring documentation.
+- `adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md` —
+  Hexagonal architecture adoption notes.
+- `adr-*.md` — Architectural Decision Records (ADRs):
+  - `adr-001-login-auth-reply-compatibility-layers.md`
+  - `adr-002-compatibility-guardrails-and-augmentation.md`
+  - `adr-003-login-authentication-and-reply-augmentation.md`
+
+### Feature-specific documentation
+
+- `chat-schema.md` — Chat system data model.
+- `news-schema.md` — News system data model.
+- `file-sharing-design.md` — File sharing architecture.
+- `cte-extension-design.md` — Common Table Expression extension design.
+- `internal-compatibility-matrix.md` — Client compatibility matrix.
+- `verification-strategy.md` — Testing and verification approach.
+- `fuzzing.md` — Fuzzing harness documentation.
+
+### User guides
+
+- `ortho-config-users-guide.md` — Configuration system guide.
+- `pg-embed-setup-unpriv-users-guide.md` — PostgreSQL test helper guide.
+- `pg-embed-setup-unpriv-v0-5-0-migration-guide.md` — Migration guide for
+  PostgreSQL helper v0.5.0.
+- `rstest-bdd-users-guide.md` — Behaviour-driven testing guide.
+- `rstest-bdd-v0-5-0-migration-guide.md` — Migration guide for rstest-bdd
+  v0.5.0.
+- `rust-testing-with-rstest-fixtures.md` — Testing patterns with rstest.
+- `rust-doctest-dry-guide.md` — Doctest patterns guide.
+- `whitaker-users-guide.md` — Whitaker component guide.
+- `wireframe-users-guide.md` — Wireframe library guide.
+- `wireframe-v0-2-0-to-v0-3-0-migration-guide.md` — Wireframe v0.3.0 migration.
+
+### Planning and process
+
+- `migration-plan-moving-mxd-protocol-implementation-to-wireframe.md` —
+  Protocol migration plan.
+- `complexity-antipatterns-and-refactoring-strategies.md` — Refactoring
+  guidance.
+- `reliable-testing-in-rust-via-dependency-injection.md` — Testing strategies.
+- `supporting-both-sqlite3-and-postgresql-in-diesel.md` — Dual-database
+  support notes.
+- `release-notes-qa-sign-off.md` — QA sign-off checklist.
+- `mermaid-validation.md` — Mermaid diagram validation.
+- `codescene-cli.md` — CodeScene CLI notes.
+
+### Execution plans (`docs/execplans/`)
+
+Detailed execution plans for roadmap tasks:
+
+- `wireframe-v0-3-0-migration.md`
+- `1-2-4-model-handshake-readiness.md`
+- `1-3-4-kani-harnesses-for-transaction-framing-invariants.md`
+- `1-4-2-route-transactions-through-wireframe.md`
+- `1-4-3-introduce-a-shared-session-context.md`
+- `1-4-4-outbound-transport-and-messaging-traits.md`
+- `1-4-5-reply-builder.md`
+- `1-4-6-model-routed-transactions-and-session-gating.md`
+- `1-5-1-detect-clients-that-xor-encode-text-fields.md`
+- `1-5-2-gate-protocol-quirks-on-the-handshake-sub-version.md`
+- `1-5-3-internal-compatibility-matrix.md`
+- `1-5-4-verify-xor-and-sub-version-compatibility.md`
+- `1-5-6-split-login-authentication-strategies-from-reply-augmentation.md`
+- `1-6-1-port-unit-and-integration-tests.md`
+- `afl-circular-dependency-issue.md`
+- `adopt-pg-embed-setup-v0-5-0.md`
+- `adopt-rstest-bdd-v0-4-0.md`
+- `adopt-rstest-bdd-v0-5-0.md`
+
+## Tests (`tests/`)
+
+```text
+tests/
+├── features/              # BDD feature files
+│   ├── create_user_command/
+│   ├── runtime_selection.feature
+│   └── session_gating_verification.feature
+├── transaction_streaming.rs
+├── wireframe_handshake_metadata.rs
+├── wireframe_transaction.rs
+└── wireframe_xor_compat.rs
+```
+
+## Crates (`crates/`)
+
+Additional workspace crates:
+
+```text
+crates/
+└── mxd-verification/      # Formal verification and model checking
+```
+
+## Database migrations (`migrations/`)
+
+Diesel database schema migrations for SQLite and PostgreSQL.
+
+## Supporting directories
+
+- `cli-defs/` — Shared CLI definition utilities.
+- `fuzz/` — AFL++ fuzzing harness.
+- `test-util/` — Shared test utilities and fixtures.
+- `validator/` — Protocol validation using `hx` client and `expectrl`.
+- `.cargo/` — Cargo configuration.
+- `.config/` — Tool configurations (nextest, etc.).
+- `.github/` — GitHub Actions workflows.
+- `scripts/` — Development and utility scripts.

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -16,7 +16,7 @@ mxd/
 ├── build.rs               # Build script for code generation
 ├── clippy.toml            # Clippy configuration
 ├── codecov.yml            # Code coverage configuration
-├── diesel.toml            # Diesel ORM configuration
+├── diesel.toml            # Diesel Object–relational mapping (ORM) configuration
 ├── migrations/            # Database schema migrations
 ├── rust-toolchain.toml    # Rust toolchain specification
 ├── src/                   # Source code

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,9 @@
 
 This roadmap sequences the work required to deliver a Hotline-compatible server
 on top of the `wireframe` transport. It consolidates requirements captured in
+
 <!-- markdownlint-disable-next-line MD013 -->
+
 `docs/design.md`,
 `docs/adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md`,
 `docs/protocol.md`, `docs/file-sharing-design.md`,
@@ -231,12 +233,43 @@ and explicit dependencies. Timeframes are intentionally omitted.
   runs Stateright models, selected Kani harnesses, and TLC specs, publishing
   counterexample traces as build artefacts. Dependencies: 1.6.1.
 
-[^1]:
-    [docs/design.md §Transaction routing middleware (December
-    2025)](docs/design.md#transaction-routing-middleware-december-2025)
-[^2]:
-    [docs/design.md §Regression verification via the wireframe binary (February
-    2026)](docs/design.md#regression-verification-via-the-wireframe-binary-february-2026)
+### 1.7. Adopt wireframe v0.3.0 runtime and tooling capabilities
+
+- [ ] 1.7.1. Configure explicit `MemoryBudgets` for the wireframe app using
+  Hotline transaction and streaming limits. Acceptance: `mxd-wireframe-server`
+  sets per-message, per-connection, and in-flight budgets explicitly,
+  oversized or stalled fragmented inputs are disconnected predictably, and
+  integration tests cover soft-pressure and hard-cap behaviour. Dependencies:
+  1.3.2, 1.6.1.
+- [ ] 1.7.2. Add regression coverage for the v0.3.0 budgeting and
+  fragmentation controls using `wireframe::testkit`. Acceptance: low-level
+  transport tests use partial-frame, fragment, and slow-I/O helpers instead of
+  bespoke scaffolding and assert message-assembly outcomes without panicking.
+  Dependencies: 1.7.1.
+- [ ] 1.7.3. Introduce a wireframe client streaming harness built on
+  `call_streaming`, `receive_streaming`, and `send_streaming`. Acceptance: the
+  harness exercises multi-frame request and response flows against
+  `mxd-wireframe-server`, verifies correlation and terminator handling, and is
+  reused by file-transfer and large-payload regression suites. Dependencies:
+  1.3.2, 1.6.1.
+- [ ] 1.7.4. Adopt `wireframe_testing` loopback and observability helpers for
+  selected protocol suites. Acceptance: `WireframePair`,
+  `ObservabilityHandle`, and codec-aware fixtures replace custom loopback
+  scaffolding in at least one routing or handshake suite and expose
+  codec/queue metrics for assertions. Dependencies: 1.7.2, 1.7.3.
+- [ ] 1.7.5. Add client request hooks, structured tracing, and, where
+  justified, pooling to validation tooling. Acceptance: validation and
+  load-oriented harnesses use `before_send`/`after_receive` hooks and
+  `TracingConfig` for frame diagnostics, and any `WireframeClientPool`
+  adoption demonstrates measurable throughput or fixture-simplification gains
+  without changing protocol semantics. Dependencies: 1.6.2, 1.7.3.
+
+\[^1\]:
+[docs/design.md §Transaction routing middleware (December
+2025)](docs/design.md#transaction-routing-middleware-december-2025)
+\[^2\]:
+[docs/design.md §Regression verification via the wireframe binary (February
+2026)](docs/design.md#regression-verification-via-the-wireframe-binary-february-2026)
 
 ## 2. Session and presence parity
 

--- a/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
+++ b/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md
@@ -63,7 +63,7 @@ ______________________________________________________________________
 | Logical type | PostgreSQL              | SQLite notes                                                                      |
 | ------------ | ----------------------- | --------------------------------------------------------------------------------- |
 | strings      | `TEXT` (or `VARCHAR`)   | `TEXT` – SQLite ignores the length specifier anyway                               |
-| booleans     | `BOOLEAN DEFAULT FALSE` | declare as `BOOLEAN`; Diesel serialises to 0 / 1 so this is fine                  |
+| booleans     | `BOOLEAN DEFAULT FALSE` | declare as `BOOLEAN`; Diesel serializes to 0 / 1, so this is fine                 |
 | integers     | `INTEGER` / `BIGINT`    | ditto                                                                             |
 | decimals     | `NUMERIC(…)`            | stored as FLOAT in SQLite; Diesel’s `Numeric` round-trips, but beware precision   |
 | blobs / raw  | `BYTEA`                 | `BLOB`                                                                            |

--- a/docs/wireframe-users-guide.md
+++ b/docs/wireframe-users-guide.md
@@ -217,6 +217,40 @@ the server runtime instead of aborting via `panic!`. Use this pattern when app
 construction depends on connection metadata, negotiated protocol state, or
 other per-connection prerequisites that can legitimately fail.
 
+#### Accessing handshake context inside a factory
+
+Adapters that negotiate connection metadata before app construction can fetch
+that state from the current task inside a fallible factory. In mxd, the
+Hotline handshake stores a `ConnectionContext` that the app factory retrieves
+with `take_current_context()`, failing closed when the handshake did not
+provide the expected metadata.
+
+```rust,no_run
+use wireframe::app::{Envelope, WireframeApp};
+
+use mxd::wireframe::connection::take_current_context;
+
+#[derive(Debug, thiserror::Error)]
+enum AppFactoryError {
+    #[error("missing handshake context")]
+    MissingHandshakeContext,
+    #[error("missing peer address")]
+    MissingPeerAddress,
+}
+
+fn app_factory() -> Result<WireframeApp<(), (), Envelope>, AppFactoryError> {
+    let context = take_current_context().ok_or(AppFactoryError::MissingHandshakeContext)?;
+    let (_handshake, peer) = context.into_parts();
+    let _peer = peer.ok_or(AppFactoryError::MissingPeerAddress)?;
+
+    Ok(WireframeApp::default())
+}
+```
+
+This pattern keeps connection-specific validation at the factory boundary and
+lets setup errors propagate through the server runtime as typed failures rather
+than panics.
+
 ### Custom frame codecs
 
 Custom protocols supply a `FrameCodec` implementation to describe their framing

--- a/docs/wireframe-users-guide.md
+++ b/docs/wireframe-users-guide.md
@@ -5,6 +5,41 @@ with pluggable routing, middleware, and connection utilities.[^1] The guide
 below walks through the components that exist today and explains how they work
 together when assembling an application.
 
+## API discovery and imports
+
+Wireframe uses progressive discovery for public APIs:
+
+- `wireframe::` root is intentionally small and stable, exposing canonical
+  `Result` and `WireframeError`.
+- `wireframe::<module>::...` is the default path for specialized APIs.
+- `wireframe::prelude::*` is an optional convenience import for common
+  workflows.
+
+## Conceptual model and vocabulary
+
+Wireframe uses layer-specific terms. Keep these boundaries explicit so
+transport concerns do not leak into routing or domain logic.
+
+| Layer                 | Canonical term | Meaning                                                                                                                   |
+| --------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Transport             | Frame          | The wire unit produced and consumed by `FrameCodec`.                                                                      |
+| Routing envelope      | Envelope       | The routable wrapper that carries `id`, optional `correlation_id`, and payload bytes (`Packet` is the trait abstraction). |
+| Domain payload        | Message        | The typed value encoded into and decoded from payload bytes.                                                              |
+| Transport subdivision | Fragment       | A bounded slice of large payload bytes plus fragmentation metadata.                                                       |
+
+Vocabulary rules:
+
+- Use `frame` for wire-format codec units only.
+- Use `envelope` for routable wrappers and instances; use `packet` when
+  discussing the `Packet` trait abstraction or `PacketParts`.
+- Use `message` for typed application payloads implementing
+  `wireframe::message::EncodeWith`/`wireframe::message::DecodeWith` (or
+  `wireframe::message::Message` for bincode-compatible types).
+- Use `fragment` only for transport-level split/reassembly units.
+
+For invariants and naming rules used across internal modules, see the
+[developers' guide](developers-guide.md).
+
 ## Quick start: building an application
 
 A `WireframeApp` collects route handlers and middleware. Each handler is stored
@@ -63,7 +98,7 @@ async fn ping(env: &Envelope) {
     log::info!("received correlation id: {:?}", env.clone().into_parts().correlation_id());
 }
 
-fn build_app() -> wireframe::app::Result<WireframeApp> {
+fn build_app() -> wireframe::Result<WireframeApp> {
     let handler: Handler<Envelope> = Arc::new(|env: &Envelope| Box::pin(ping(env)));
 
     WireframeApp::new()?
@@ -99,14 +134,21 @@ async fn main() -> Result<(), ServerError> {
 ```
 
 Route identifiers must be unique; the builder returns
-`WireframeError::DuplicateRoute` when a handler is registered twice, keeping
-the dispatch table unambiguous.[^2][^5] New applications default to the bundled
-bincode serializer, a length-delimited codec capped at 1024 bytes per frame,
-and a 100 ms read timeout. Clamp the length-delimited limit with
-`buffer_capacity` (length-delimited only), swap codecs with `with_codec`, and
-override the serializer with `with_serializer` when a different encoding
-strategy is required.[^3][^4] Custom protocols implement `FrameCodec` to
-describe their framing rules.
+`wireframe::WireframeError::DuplicateRoute` when a handler is registered twice,
+keeping the dispatch table unambiguous.[^2][^5] The crate-level
+`wireframe::Result<T>` alias always resolves to this canonical
+`wireframe::WireframeError` surface, so setup-time and streaming failures share
+one error contract.[^5] New applications default to the bundled bincode
+serializer, a length-delimited codec capped at 1024 bytes per frame, and a 100
+ms read timeout. Clamp the length-delimited limit with `buffer_capacity`
+(length-delimited only), swap codecs with `with_codec`, and override the
+serializer with `with_serializer` when a different encoding strategy is
+required.[^3][^4] Use `memory_budgets(...)` to set explicit per-connection
+buffering caps for inbound assembly paths. Custom protocols implement
+`FrameCodec` to describe their framing rules. Changing frame budgets with
+`buffer_capacity` or swapping codecs with `with_codec` clears fragmentation
+settings, so call `enable_fragmentation()` (or `fragmentation(Some(cfg))`)
+again when transport fragmentation is required.
 
 Once a stream is accepted—either from a manual accept loop or via
 `WireframeServer`—`handle_connection(stream)` builds (or reuses) the middleware
@@ -129,18 +171,22 @@ A codec implementation must:
   `std::io::Error` on failure.
 - Return only the logical payload bytes from `frame_payload` so metadata parsing
   and deserialization run against the right buffer.
-- Wrap outbound payloads with `wrap_payload`, adding any protocol headers or
-  metadata required by the wire format.
+- Wrap outbound payloads with `wrap_payload(&self, Bytes)`, adding any protocol
+  headers or metadata required by the wire format.
 - Provide `correlation_id` when the protocol stores it outside the payload;
   Wireframe only uses this hook when the deserialized envelope is missing a
   correlation identifier.
-- Report `max_frame_length`, which clamps inbound frames and seeds default
-  fragmentation limits.
+- Report `max_frame_length`, which clamps inbound frames and determines the
+  budget used by `enable_fragmentation`.
 
-Install a custom codec with `with_codec`. The builder resets fragmentation to
-the codec-derived defaults, so override fragmentation afterwards if the
-protocol uses a different budget. When a framed stream is already available,
-use `send_response_framed_with_codec`, so responses pass through
+Install a custom codec with `with_codec`. The builder disables fragmentation
+when codecs or the length-delimited frame budget change, so explicitly call
+`enable_fragmentation()` (or `fragmentation(Some(cfg))`) afterwards when
+transport fragmentation is required. Wireframe clones the codec per connection,
+so stateful codecs should ensure `Clone` produces an independent state (for
+example, reset sequence counters) when per-connection isolation is required.
+When a framed stream is already available, use
+`send_response_framed_with_codec`, so responses pass through
 `FrameCodec::wrap_payload`.
 
 Assume `MyCodec` implements `FrameCodec`:
@@ -162,6 +208,542 @@ let app = WireframeApp::new()?
 See `examples/hotline_codec.rs` and `examples/mysql_codec.rs` for complete
 implementations.
 
+#### Codec accessor
+
+Retrieve the configured codec from a `WireframeApp` instance:
+
+```rust,no_run
+use wireframe::app::WireframeApp;
+use wireframe::codec::examples::HotlineFrameCodec;
+
+let codec = HotlineFrameCodec::new(4096);
+let app = WireframeApp::new()?.with_codec(codec);
+let codec_ref = app.codec(); // &HotlineFrameCodec
+```
+
+#### Testing custom codecs with `wireframe_testing`
+
+The `wireframe_testing` crate provides codec-aware driver functions that handle
+frame encoding and decoding transparently:
+
+```rust,no_run
+use wireframe::app::WireframeApp;
+use wireframe::codec::examples::HotlineFrameCodec;
+use wireframe_testing::{drive_with_codec_payloads, drive_with_codec_frames};
+
+let codec = HotlineFrameCodec::new(4096);
+let payload: Vec<u8> = vec![0x01, 0x02, 0x03];
+
+// Payload-level: returns decoded response payloads as byte vectors.
+let app = WireframeApp::new()?.with_codec(codec.clone());
+let payloads =
+    drive_with_codec_payloads(app, &codec, vec![payload.clone()]).await?;
+
+// Frame-level: returns decoded codec frames for metadata inspection.
+let app = WireframeApp::new()?.with_codec(codec.clone());
+let frames =
+    drive_with_codec_frames(app, &codec, vec![payload]).await?;
+```
+
+Available codec-aware driver functions:
+
+- `drive_with_codec_payloads` / `drive_with_codec_payloads_with_capacity` —
+  owned app, returns payload bytes.
+- `drive_with_codec_payloads_mut` /
+  `drive_with_codec_payloads_with_capacity_mut` — mutable app reference,
+  returns payload bytes.
+- `drive_with_codec_frames` / `drive_with_codec_frames_with_capacity` — owned
+  app, returns decoded `F::Frame` values.
+
+Supporting helpers for composing custom test patterns:
+
+- `encode_payloads_with_codec` — encode payloads to wire bytes.
+- `decode_frames_with_codec` — decode wire bytes to frames.
+- `extract_payloads` — extract payload bytes from decoded frames.
+
+#### Codec test fixtures
+
+The `wireframe_testing` crate provides fixture functions for generating
+Hotline-framed wire bytes covering common test scenarios — valid frames,
+invalid frames, incomplete (truncated) frames, and frames with correlation
+metadata. These fixtures construct raw bytes directly, so they can represent
+malformed data that the encoder would reject:
+
+```rust,no_run
+use wireframe::codec::examples::HotlineFrameCodec;
+use wireframe_testing::{
+    valid_hotline_wire, oversized_hotline_wire,
+    truncated_hotline_header, correlated_hotline_wire,
+    decode_frames_with_codec,
+};
+
+let codec = HotlineFrameCodec::new(4096);
+
+// Valid frame — decodes cleanly.
+let wire = valid_hotline_wire(b"hello", 7);
+let frames = decode_frames_with_codec(&codec, wire).unwrap();
+
+// Oversized frame — rejected with "payload too large".
+let wire = oversized_hotline_wire(4096);
+assert!(decode_frames_with_codec(&codec, wire).is_err());
+
+// Truncated header — rejected with "bytes remaining on stream".
+let wire = truncated_hotline_header();
+assert!(decode_frames_with_codec(&codec, wire).is_err());
+
+// Correlated frames — all share the same transaction ID.
+let wire = correlated_hotline_wire(42, &[b"a", b"b"]);
+let frames = decode_frames_with_codec(&codec, wire).unwrap();
+```
+
+Available fixture functions:
+
+- `valid_hotline_wire` / `valid_hotline_frame` — well-formed frames.
+- `oversized_hotline_wire` — payload exceeds `max_frame_length`.
+- `mismatched_total_size_wire` — header with incorrect `total_size`.
+- `truncated_hotline_header` / `truncated_hotline_payload` — incomplete data.
+- `correlated_hotline_wire` — frames sharing a transaction ID.
+- `sequential_hotline_wire` — frames with incrementing transaction IDs.
+
+#### Feeding partial frames and fragments
+
+Real networks rarely deliver a complete codec frame in a single TCP read. The
+main crate now exposes these drivers through `wireframe::testkit` behind the
+opt-in `testkit` feature, while `wireframe_testing` keeps source-compatible
+re-exports for existing callers.
+
+**Chunked-write drivers** encode payloads via a codec, concatenate the wire
+bytes, and write them in configurable chunk sizes (including one byte at a
+time):
+
+```rust,no_run
+use std::num::NonZeroUsize;
+use wireframe::app::WireframeApp;
+use wireframe::codec::examples::HotlineFrameCodec;
+use wireframe::testkit::drive_with_partial_frames;
+
+let codec = HotlineFrameCodec::new(4096);
+let app = WireframeApp::new()?.with_codec(codec.clone());
+let chunk = NonZeroUsize::new(1).expect("non-zero");
+let payloads =
+    drive_with_partial_frames(app, &codec, vec![vec![1, 2, 3]], chunk)
+        .await?;
+```
+
+Available chunked-write driver functions:
+
+- `drive_with_partial_frames` / `drive_with_partial_frames_with_capacity` —
+  owned app, returns payload bytes.
+- `drive_with_partial_frames_mut` — mutable app reference, returns payload
+  bytes.
+- `drive_with_partial_codec_frames` — owned app, returns decoded `F::Frame`
+  values.
+
+**Fragment-feeding drivers** accept a raw payload, fragment it with a
+`Fragmenter`, encode each fragment into a codec frame, and feed the frames
+through the app:
+
+```rust,no_run
+use std::num::NonZeroUsize;
+use wireframe::app::WireframeApp;
+use wireframe::codec::examples::HotlineFrameCodec;
+use wireframe::fragment::Fragmenter;
+use wireframe::testkit::drive_with_fragments;
+
+let codec = HotlineFrameCodec::new(4096);
+let app = WireframeApp::new()?.with_codec(codec.clone());
+let fragmenter = Fragmenter::new(NonZeroUsize::new(20).unwrap());
+let payloads =
+    drive_with_fragments(app, &codec, &fragmenter, vec![0; 100]).await?;
+```
+
+Available fragment-feeding driver functions:
+
+- `drive_with_fragments` / `drive_with_fragments_with_capacity` — owned
+  app, returns payload bytes.
+- `drive_with_fragments_mut` — mutable app reference, returns payload
+  bytes.
+- `drive_with_fragment_frames` — owned app, returns decoded `F::Frame`
+  values.
+- `drive_with_partial_fragments` — fragment AND feed in chunks,
+  exercising both fragmentation and partial-frame buffering simultaneously.
+
+#### Asserting reassembly outcomes
+
+The `wireframe::testkit::reassembly` module provides non-panicking assertion
+helpers for both transport fragment reassembly and protocol message assembly.
+The API is built around lightweight snapshot structs, so the same helper can be
+used from `rstest` tests and `rstest-bdd` step definitions. Existing
+`wireframe_testing::reassembly` imports remain valid as compatibility
+re-exports.
+
+```rust,no_run
+use wireframe::message_assembler::MessageKey;
+use wireframe::testkit::{
+    MessageAssemblySnapshot,
+    TestResult,
+    assert_message_assembly_completed_for_key,
+};
+
+# fn check(snapshot: MessageAssemblySnapshot<'_>) -> TestResult {
+assert_message_assembly_completed_for_key(snapshot, MessageKey(7), b"done")?;
+# Ok(())
+# }
+```
+
+Available message-assembly assertion helpers:
+
+- `assert_message_assembly_incomplete` — verify the latest assembly is still
+  awaiting more frames.
+- `assert_message_assembly_completed` — verify the latest assembly completed
+  with a specific body.
+- `assert_message_assembly_completed_for_key` — verify the most recent
+  completed message for a specific `MessageKey`.
+- `assert_message_assembly_error` — verify structured failures such as
+  sequence mismatch, duplicate first frame, and budget errors.
+- `assert_message_assembly_buffered_count` /
+  `assert_message_assembly_total_buffered_bytes` — verify cleanup and memory
+  accounting side effects.
+- `assert_message_assembly_evicted` — verify timeout-based eviction.
+
+Available fragment-reassembly assertion helpers:
+
+- `assert_fragment_reassembly_absent` — verify no full message has been
+  reconstructed yet.
+- `assert_fragment_reassembly_completed_len` — verify reconstructed payload
+  length.
+- `assert_fragment_reassembly_error` — verify reassembly errors including
+  `MessageTooLarge` (with or without specific message ID), `IndexMismatch`
+  (out-of-order fragments), `MessageMismatch` (fragments from wrong logical
+  message), `SeriesComplete` (duplicate or late fragments after completion),
+  and `IndexOverflow` (fragment index exceeding limits).
+- `assert_fragment_reassembly_buffered_messages` — verify buffered partial
+  message count.
+- `assert_fragment_reassembly_evicted` — verify timeout-based eviction.
+
+#### Test observability
+
+The `wireframe_testing` crate provides an `ObservabilityHandle` that combines
+log capture with metrics recording in a single fixture. This is useful for
+asserting that codec errors, recovery policies, and other instrumentation
+behave correctly under test.
+
+```rust,no_run
+use wireframe_testing::ObservabilityHandle;
+
+let mut obs = ObservabilityHandle::new();
+obs.clear();
+
+// Record metrics via a thread-local recorder.
+metrics::with_local_recorder(obs.recorder(), || {
+    wireframe::metrics::inc_codec_error("framing", "drop");
+});
+
+// Take a snapshot and query the captured counter.
+obs.snapshot();
+assert_eq!(
+    obs.counter(
+        wireframe::metrics::CODEC_ERRORS,
+        &[("error_type", "framing"), ("recovery_policy", "drop")],
+    ),
+    1
+);
+```
+
+The handle serializes access to the global logger via a mutex, so tests using
+it should run serially (`--test-threads=1` for the affected binary). Metrics
+are captured per-thread via `metrics::with_local_recorder`, so metric-emitting
+code must run on the same thread as the handle. For async tests, use
+`#[tokio::test(flavor = "current_thread")]` or
+`tokio::runtime::Runtime::new()?.block_on(...)`.
+
+Available assertion helpers:
+
+- `counter(name, labels)` / `counter_without_labels(name)` — query counter
+  values from the most recent snapshot.
+- `codec_error_counter(error_type, recovery_policy)` — convenience for the
+  `wireframe_codec_errors_total` metric.
+- `assert_counter(name, labels, expected)` — assert a counter matches.
+- `assert_no_metric(name)` — assert no metric with the given name exists.
+- `assert_codec_error_counter(error_type, recovery_policy, expected)` — assert
+  a codec error counter matches.
+- `assert_log_contains(substring)` — assert any captured log contains a
+  substring.
+- `assert_log_at_level(level, substring)` — assert a log at a specific level
+  contains a substring.
+
+#### Simulating slow readers and writers
+
+Back-pressure tests often need more than partial-frame delivery. The
+`wireframe_testing` crate also provides slow-I/O helpers that pace the client
+write side, the client read side, or both directions at once.
+
+Use `SlowIoPacing` to define a chunk size and inter-chunk delay, then apply it
+through `SlowIoConfig`:
+
+Enable the feature in `Cargo.toml` when importing from the main crate:
+
+```toml
+wireframe = { version = "0.3.0", features = ["testkit"] }
+```
+
+```rust,no_run
+use std::{num::NonZeroUsize, time::Duration};
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    codec::examples::HotlineFrameCodec,
+    serializer::{BincodeSerializer, Serializer},
+};
+use wireframe::testkit::{
+    SlowIoConfig, SlowIoPacing, drive_with_slow_codec_payloads,
+};
+
+let codec = HotlineFrameCodec::new(4096);
+let app = WireframeApp::new()?.with_codec(codec.clone());
+let config = SlowIoConfig::new()
+    .with_writer_pacing(SlowIoPacing::new(
+        NonZeroUsize::new(8).expect("non-zero"),
+        Duration::from_millis(5),
+    ))
+    .with_reader_pacing(SlowIoPacing::new(
+        NonZeroUsize::new(32).expect("non-zero"),
+        Duration::from_millis(5),
+    ))
+    .with_capacity(64);
+
+let request = BincodeSerializer.serialize(&Envelope::new(
+    1,
+    Some(7),
+    vec![1, 2, 3],
+))?;
+let payloads = drive_with_slow_codec_payloads(app, &codec, vec![request], config)
+    .await?;
+
+```
+
+Available slow-I/O helper functions:
+
+- `drive_with_slow_frames` — pre-framed bytes, returns raw output bytes.
+- `drive_with_slow_payloads` — default length-delimited payloads, returns raw
+  output bytes.
+- `drive_with_slow_codec_payloads` — codec-aware payloads, returns decoded
+  payload byte vectors.
+- `drive_with_slow_codec_frames` — codec-aware frames, returns decoded
+  `F::Frame` values.
+
+These helpers are designed for deterministic tests under paused Tokio time.
+Small duplex capacities should be used together with reader pacing when the
+app's outbound writes must hit back-pressure quickly.
+
+#### In-process server/client pair harness
+
+The `wireframe_testing::client_pair` module provides a harness for starting a
+real `WireframeServer` and a connected `WireframeClient` inside one test
+process. Unlike the `drive_with_*` helpers, which exercise server-side
+behaviour over in-memory `tokio::io::duplex` streams, the pair harness
+communicates over a real loopback TCP socket so compatibility assertions
+exercise the full client/server network path.
+
+Use the pair harness when a downstream crate needs to verify that its protocol
+implementation works end-to-end through a real Wireframe server. A shared
+`echo_app_factory` provides a ready-made app factory with invocation counting:
+
+```rust,no_run
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use wireframe_testing::{
+    TestResult,
+    echo_app_factory,
+    spawn_wireframe_pair,
+};
+
+async fn example() -> TestResult<()> {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut pair = spawn_wireframe_pair(
+        echo_app_factory(&counter),
+        |builder| builder.max_frame_length(2048),
+    )
+    .await?;
+
+    // pair.client_mut()? returns &mut WireframeClient for
+    // request/response operations. Streaming responses borrow the
+    // client exclusively, keeping that constraint visible.
+    let addr = pair.local_addr();
+
+    pair.shutdown().await?;
+    Ok(())
+}
+```
+
+`spawn_wireframe_pair_default` is a convenience wrapper that connects with
+default client settings when no builder customization is needed. If the client
+connection fails, the server task is torn down automatically so no orphaned
+tasks leak into subsequent tests.
+
+The harness depends on the `wireframe_testing` dev-dependency crate. It does
+not require the main-crate `testkit` feature unless the test also uses
+`wireframe::testkit` helpers directly.
+
+#### Zero-copy payload extraction
+
+For performance-critical codecs, use `Bytes` instead of `Vec<u8>` for payload
+storage and override `frame_payload_bytes` to avoid allocation:
+
+```rust
+use bytes::Bytes;
+use wireframe::codec::FrameCodec;
+
+pub struct MyFrame {
+    pub metadata: u32,
+    pub payload: Bytes,  // Use Bytes, not Vec<u8>
+}
+
+impl FrameCodec for MyCodec {
+    type Frame = MyFrame;
+    // ... other associated types ...
+
+    fn frame_payload(frame: &Self::Frame) -> &[u8] {
+        &frame.payload
+    }
+
+    fn frame_payload_bytes(frame: &Self::Frame) -> Bytes {
+        frame.payload.clone()  // Cheap: atomic reference count increment
+    }
+
+    fn wrap_payload(&self, payload: Bytes) -> Self::Frame {
+        MyFrame {
+            metadata: 0,
+            payload,  // Store directly, no copy
+        }
+    }
+
+    // ... other methods ...
+}
+```
+
+In the decoder, use `BytesMut::freeze()` instead of `.to_vec()`:
+
+```rust
+use bytes::BytesMut;
+use tokio_util::codec::Decoder;
+
+fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+    // ... parse header ...
+    let payload = src.split_to(payload_len).freeze();  // Zero-copy
+    Ok(Some(MyFrame { metadata, payload }))
+}
+```
+
+The default `frame_payload_bytes` implementation copies from the
+`frame_payload()` slice, ensuring backward compatibility for codecs that use
+`Vec<u8>` payloads.
+
+### Codec error handling
+
+The codec layer provides a structured error taxonomy via `CodecError` that
+enables recovery policies, structured logging, and proper EOF handling.
+
+**Error categories:**
+
+- `FramingError` - Wire-level frame boundary issues (oversized frames, invalid
+  length encoding, incomplete headers, checksum mismatches, empty frames).
+- `ProtocolError` - Semantic violations after frame extraction (unknown message
+  types, invalid versions).
+- `io::Error` - Transport layer failures (connection resets, timeouts).
+- `EofError` - End-of-stream conditions with clean/mid-frame/mid-header
+  variants.
+
+**Recovery policies:**
+
+Each error type has a default recovery policy:
+
+| Error Type                     | Default Policy |
+| ------------------------------ | -------------- |
+| `FramingError::OversizedFrame` | Drop           |
+| `FramingError::EmptyFrame`     | Drop           |
+| Other `FramingError`           | Disconnect     |
+| All `ProtocolError`            | Drop           |
+| All `io::Error`                | Disconnect     |
+| `EofError::CleanClose`         | Disconnect     |
+| Other `EofError`               | Disconnect     |
+
+Override recovery policies with a custom `RecoveryPolicyHook`:
+
+```rust
+use wireframe::codec::{
+    CodecError, CodecErrorContext, RecoveryPolicy, RecoveryPolicyHook,
+};
+
+struct StrictRecovery;
+
+impl RecoveryPolicyHook for StrictRecovery {
+    fn recovery_policy(&self, _error: &CodecError, _ctx: &CodecErrorContext) -> RecoveryPolicy {
+        // Disconnect on any codec error
+        RecoveryPolicy::Disconnect
+    }
+}
+```
+
+`CodecErrorContext` provides connection metadata for policy decisions:
+
+```rust
+use wireframe::codec::CodecErrorContext;
+
+let ctx = CodecErrorContext::new()
+    .with_connection_id(42)
+    .with_correlation_id(123)
+    .with_codec_state("seq=5");
+```
+
+**Protocol hooks for EOF:**
+
+The `WireframeProtocol` trait includes an `on_eof` hook for handling EOF
+conditions during frame decoding:
+
+```rust,ignore
+use wireframe::{
+    codec::EofError,
+    hooks::{ConnectionContext, WireframeProtocol},
+};
+
+impl WireframeProtocol for MyProtocol {
+    type Frame = Vec<u8>;
+    type ProtocolError = String;
+
+    fn on_eof(&self, error: &EofError, partial_data: &[u8], _ctx: &mut ConnectionContext) {
+        match error {
+            EofError::CleanClose => tracing::info!("connection closed cleanly"),
+            EofError::MidFrame { bytes_received, expected } => {
+                tracing::warn!(
+                    received = bytes_received,
+                    expected = expected,
+                    partial_len = partial_data.len(),
+                    "connection closed mid-frame"
+                );
+            }
+            EofError::MidHeader { bytes_received, header_size } => {
+                tracing::warn!(
+                    received = bytes_received,
+                    header_size = header_size,
+                    "connection closed mid-header"
+                );
+            }
+        }
+    }
+}
+```
+
+**Metrics:**
+
+When the `metrics` feature is enabled, codec errors increment the
+`wireframe_codec_errors_total` counter with `error_type` and `recovery_policy`
+labels:
+
+```text
+wireframe_codec_errors_total{error_type="framing",recovery_policy="drop"} 5
+wireframe_codec_errors_total{error_type="eof",recovery_policy="disconnect"} 2
+```
+
 ## Packets, payloads, and serialization
 
 Packets drive routing. Implement the `Packet` trait (or use the bundled
@@ -174,9 +756,41 @@ that meets the trait bounds.[^4]
 
 When `FrameMetadata::parse` succeeds, the framework extracts identifiers from
 metadata without deserializing the payload. If parsing fails, it falls back to
-full deserialization.[^9][^6] Application messages implement the `Message`
-trait, gaining `to_bytes` and `from_bytes` helpers that use bincode with the
-standard configuration.[^10]
+full deserialization.[^9][^6] Serializer integration now uses adapter traits:
+`EncodeWith<S>` for encoding and `DecodeWith<S>` for decoding. Existing bincode
+message types remain compatible through `Message`, which still provides
+`to_bytes` and `from_bytes` helpers.[^10]
+
+### Migration from `Message`-only bounds
+
+If existing code previously relied on `M: Message` for client/server API calls,
+no change is required for bincode-compatible types.
+
+- Existing `#[derive(bincode::Encode, bincode::BorrowDecode)]` payloads still
+  work in `send`, `receive`, `call`, and `send_response`.
+- Serializer implementations should update method signatures to use
+  `EncodeWith<Self>` and `DecodeWith<Self>` bounds.
+- Custom serializers that rely on legacy `Message`-derived payload encoding
+  should also implement `wireframe::serializer::MessageCompatibilitySerializer`.
+- Metadata-aware serializers can implement
+  `Serializer::deserialize_with_context` to inspect `DeserializeContext`.
+- `Serializer` is not object-safe (`Self: Sized` on serializer entry points), so
+  using `dyn Serializer` directly is unsupported unless concrete wrappers are
+  provided. For migration, keep concrete serializer types in `EncodeWith` /
+  `DecodeWith` bounds, retain
+  `wireframe::serializer::MessageCompatibilitySerializer` for legacy
+  `Message`-based payloads, and use `SerdeMessage` with `SerdeSerializerBridge`
+  for Serde-only payloads. When runtime-polymorphic serializer behaviour is
+  required, wrap concrete serializer implementations in adapter wrappers that
+  expose object-safe APIs and delegate to
+  `Serializer::deserialize_with_context` as needed.
+
+Optional Serde bridge support is available behind the feature
+`serializer-serde`. Wrap values with `SerdeMessage<T>` (or
+`into_serde_message()`) and implement `SerdeSerializerBridge` on the serializer
+to reduce per-type adapter boilerplate. This explicit wrapper is required
+because blanket Serde adapters would overlap with the default `T: Message`
+adapter implementations.
 
 ### Fragmentation metadata
 
@@ -200,7 +814,7 @@ The standalone `Fragmenter` helper now slices oversized payloads into capped
 fragments while stamping the shared `MessageId` and sequential `FragmentIndex`.
 Each call returns a `FragmentBatch` that reports whether the message required
 fragmentation and yields individual `FragmentFrame` values for serialization or
-logging. This keeps transport experiments lightweight while the full adaptor
+logging. This keeps transport experiments lightweight while the full adapter
 layer evolves. The helper is fallible—`FragmentationError` surfaces encoding
 failures or index overflows—so production code should bubble the error up or
 log it rather than unwrapping.
@@ -257,10 +871,9 @@ let complete = reassembler
 `wireframe::request` exposes `RequestParts` to separate routing metadata from
 streaming request payloads.[^45]
 
-- Use `RequestParts::id()` to read the message identifier for routing.
-- The `correlation_id()` accessor returns the optional correlation
-  identifier.
-- Protocol-defined header bytes are exposed via `RequestParts::metadata()`.
+- `RequestParts::id()` returns the message identifier for routing.
+- `RequestParts::correlation_id()` returns the optional correlation identifier.
+- `RequestParts::metadata()` returns protocol-defined header bytes.
 
 This type pairs with `RequestBodyStream` for incremental consumption of large
 request payloads. Handlers can choose between buffered (existing) and streaming
@@ -278,7 +891,305 @@ assert_eq!(parts.metadata(), &[0x01, 0x02]);
 Unlike `PacketParts` (which carries the raw payload for envelope
 reconstruction), `RequestParts` carries only protocol-defined metadata required
 to interpret the streaming body. The body itself is consumed through a separate
-stream, enabling back-pressure and incremental processing.[^46]
+stream, enabling back-pressure and incremental processing.[^46] When
+`MessageAssembler` is configured, this split happens after any transport
+fragment reassembly, so handlers and protocol extractors see protocol-level
+metadata rather than lower-level fragment state.
+
+### Message assembler hook
+
+Wireframe exposes a protocol-facing `MessageAssembler` hook that parses
+per-frame headers into `FrameHeader::First` and `FrameHeader::Continuation`
+values. It returns a `ParsedFrameHeader` that includes the header length so the
+remaining bytes can be treated as the body chunk.
+
+Register an assembler with `WireframeApp::with_message_assembler`:
+
+```rust,no_run
+use wireframe::{
+    app::WireframeApp,
+    message_assembler::{
+        FrameHeader,
+        FirstFrameHeader,
+        MessageAssembler,
+        MessageKey,
+        ParsedFrameHeader,
+    },
+};
+
+struct DemoAssembler;
+
+impl MessageAssembler for DemoAssembler {
+    fn parse_frame_header(
+        &self,
+        _payload: &[u8],
+    ) -> Result<ParsedFrameHeader, std::io::Error> {
+        Ok(ParsedFrameHeader::new(
+            FrameHeader::First(FirstFrameHeader {
+                message_key: MessageKey(1),
+                metadata_len: 0,
+                body_len: 0,
+                total_body_len: None,
+                is_last: true,
+            }),
+            0,
+        ))
+    }
+}
+
+let _app = WireframeApp::new()
+    .expect("builder")
+    .with_message_assembler(DemoAssembler);
+```
+
+When configured, this hook now runs on the inbound connection path after
+transport fragmentation reassembly and before handler dispatch. Incomplete
+assemblies remain buffered per message key until completion or timeout eviction.
+
+The assembler's output drives the handler-facing request shape:
+
+- fully assembled messages continue through the buffered request path; and
+- streaming-capable messages surface as `RequestParts` plus
+  `RequestBodyStream` / `StreamingBody`.
+
+Message-assembly parsing and continuity failures are treated as inbound
+deserialization failures and follow the existing failure threshold policy.
+
+`WireframeApp::message_assembler` returns the configured hook as an
+`Option<&Arc<dyn MessageAssembler>>` if direct access is required.
+
+### Per-connection memory budgets
+
+`MemoryBudgets` configures explicit per-connection byte caps for inbound
+buffering and assembly:
+
+- bytes buffered per message;
+- bytes buffered per connection; and
+- bytes buffered across in-flight assemblies.
+
+Configure budgets through the app builder:
+
+```rust,no_run
+use std::num::NonZeroUsize;
+use wireframe::app::{BudgetBytes, MemoryBudgets, WireframeApp};
+
+let budgets = MemoryBudgets::new(
+    BudgetBytes::new(NonZeroUsize::new(16 * 1024).expect("non-zero")),
+    BudgetBytes::new(NonZeroUsize::new(64 * 1024).expect("non-zero")),
+    BudgetBytes::new(NonZeroUsize::new(48 * 1024).expect("non-zero")),
+);
+
+let _app = WireframeApp::new()
+    .expect("builder creation should not fail")
+    .memory_budgets(budgets)
+    .read_timeout_ms(250);
+```
+
+When budgets are configured, the message assembly subsystem enforces them at
+frame acceptance time. Frames that would cause the total buffered bytes to
+exceed the per-connection or in-flight budget are rejected, the offending
+partial assembly is freed, and the failure is surfaced through the existing
+deserialization-failure policy (`InvalidData`). The effective per-message limit
+is the minimum of the fragmentation `max_message_size` and the configured
+`bytes_per_message`. Single-frame messages that complete immediately are never
+counted against aggregate budgets, since they do not buffer.
+
+If `memory_budgets(...)` is not configured explicitly, Wireframe derives the
+same three fields from `buffer_capacity`, so the protection model remains
+active even on the default path.
+
+Wireframe provides a three-tier protection model for inbound memory budgets:
+
+1. **Per-frame enforcement** — frames that would cause total buffered bytes to
+   exceed the per-connection or in-flight budget are rejected, the offending
+   partial assembly is freed, and the failure is surfaced through the existing
+   deserialization-failure policy (`InvalidData`).
+2. **Soft-limit read pacing** — when buffered assembly bytes reach the
+   soft-pressure threshold (80% of the smaller aggregate cap from
+   `bytes_per_connection` and `bytes_in_flight`), the inbound connection loop
+   briefly pauses socket reads before polling the next frame. This propagates
+   back-pressure to senders while allowing progress on in-flight assemblies.
+3. **Hard-cap connection abort** — if total buffered bytes strictly exceed the
+   aggregate cap (100% of the smaller of `bytes_per_connection` and
+   `bytes_in_flight`), the connection is terminated immediately with
+   `InvalidData`. This is a defence-in-depth safety net; under normal
+   operation, per-frame enforcement prevents this state from being reached.
+
+#### Derived budget defaults
+
+When `memory_budgets(...)` is not called on the builder, Wireframe derives
+sensible defaults automatically from `buffer_capacity` (the codec's
+`max_frame_length()`). The derived values use the same multiplier pattern as
+fragmentation defaults:
+
+| Budget field           | Multiplier           | Default (1024-byte frame) |
+| ---------------------- | -------------------- | ------------------------- |
+| `bytes_per_message`    | `frame_budget × 16`  | 16 KiB                    |
+| `bytes_per_connection` | `frame_budget × 64`  | 64 KiB                    |
+| `bytes_in_flight`      | `frame_budget × 64`  | 64 KiB                    |
+
+All three protection tiers (per-frame enforcement, soft-limit read pacing, and
+hard-cap connection abort) are active with derived defaults. Changing
+`buffer_capacity` adjusts derived budgets proportionally. Calling
+`.memory_budgets(...)` overrides the derived defaults entirely.
+
+#### Message key multiplexing (8.2.3)
+
+The `MessageAssemblyState` type manages multiple concurrent message assemblies
+keyed by `MessageKey`. This enables interleaved frame streams where frames from
+different logical messages arrive on the same connection:
+
+```rust
+use std::{num::NonZeroUsize, time::Duration};
+use wireframe::message_assembler::{
+    ContinuationFrameHeader,
+    EnvelopeId,
+    EnvelopeRouting,
+    FirstFrameHeader,
+    FirstFrameInput,
+    FrameSequence,
+    MessageAssemblyState,
+    MessageKey,
+};
+
+let mut state = MessageAssemblyState::new(
+    NonZeroUsize::new(1_048_576).expect("non-zero size"), // 1 mebibyte (MiB) max message
+    Duration::from_secs(30),                               // 30s timeout for partial assemblies
+);
+
+// First frame for message key=1
+let first1 = FirstFrameHeader {
+    message_key: MessageKey(1),
+    metadata_len: 0,
+    body_len: 5,
+    total_body_len: Some(15),
+    is_last: false,
+};
+let routing1 = EnvelopeRouting { envelope_id: EnvelopeId(1), correlation_id: None };
+let input1 = FirstFrameInput::new(&first1, routing1, vec![], b"hello")
+    .expect("header lengths match");
+state.accept_first_frame(input1)?;
+
+// First frame for message key=2 (interleaved)
+let first2 = FirstFrameHeader {
+    message_key: MessageKey(2),
+    metadata_len: 0,
+    body_len: 5,
+    total_body_len: None,
+    is_last: false,
+};
+let routing2 = EnvelopeRouting { envelope_id: EnvelopeId(2), correlation_id: None };
+let input2 = FirstFrameInput::new(&first2, routing2, vec![], b"world")
+    .expect("header lengths match");
+state.accept_first_frame(input2)?;
+
+// Continuation for key=1 completes its message
+let cont1 = ContinuationFrameHeader {
+    message_key: MessageKey(1),
+    sequence: Some(FrameSequence(1)),
+    body_len: 10,
+    is_last: true,
+};
+let msg1 = state.accept_continuation_frame(&cont1, b" completed")?
+    .expect("message 1 should complete");
+assert_eq!(msg1.body(), b"hello completed");
+```
+
+#### Continuity validation (8.2.4)
+
+The `MessageSeries` type validates frame ordering when protocols supply
+sequence numbers via `ContinuationFrameHeader::sequence`. It detects:
+
+- **Out-of-order frames**: sequence gaps produce
+  `MessageSeriesError::SequenceMismatch`
+- **Duplicate frames**: already-processed sequences produce
+  `MessageSeriesError::DuplicateFrame`
+- **Frames after completion**: produce `MessageSeriesError::SeriesComplete`
+
+For protocols that do not supply sequence numbers, the series accepts frames in
+any order (ordering validation is skipped).
+
+```rust
+use wireframe::message_assembler::{
+    ContinuationFrameHeader,
+    FirstFrameHeader,
+    FrameSequence,
+    MessageKey,
+    MessageSeries,
+    MessageSeriesError,
+    MessageSeriesStatus,
+};
+
+let first = FirstFrameHeader {
+    message_key: MessageKey(1),
+    metadata_len: 0,
+    body_len: 10,
+    total_body_len: None,
+    is_last: false,
+};
+let mut series = MessageSeries::from_first_frame(&first);
+
+// Accept continuation with sequence 1
+let cont1 = ContinuationFrameHeader {
+    message_key: MessageKey(1),
+    sequence: Some(FrameSequence(1)),
+    body_len: 5,
+    is_last: false,
+};
+assert_eq!(series.accept_continuation(&cont1), Ok(MessageSeriesStatus::Incomplete));
+
+// Attempting sequence 3 (gap) fails
+let cont3 = ContinuationFrameHeader {
+    message_key: MessageKey(1),
+    sequence: Some(FrameSequence(3)), // Expected 2
+    body_len: 5,
+    is_last: false,
+};
+assert!(matches!(
+    series.accept_continuation(&cont3),
+    Err(MessageSeriesError::SequenceMismatch { .. })
+));
+
+// Accept sequence 2, then try sequence 1 again (duplicate)
+let cont2 = ContinuationFrameHeader {
+    message_key: MessageKey(1),
+    sequence: Some(FrameSequence(2)),
+    body_len: 5,
+    is_last: false,
+};
+assert_eq!(series.accept_continuation(&cont2), Ok(MessageSeriesStatus::Incomplete));
+
+let dup = ContinuationFrameHeader {
+    message_key: MessageKey(1),
+    sequence: Some(FrameSequence(1)), // Already seen
+    body_len: 5,
+    is_last: false,
+};
+assert!(matches!(
+    series.accept_continuation(&dup),
+    Err(MessageSeriesError::DuplicateFrame { .. })
+));
+
+// Complete the series, then try to add more (SeriesComplete)
+let final_cont = ContinuationFrameHeader {
+    message_key: MessageKey(1),
+    sequence: Some(FrameSequence(3)),
+    body_len: 5,
+    is_last: true,
+};
+assert_eq!(series.accept_continuation(&final_cont), Ok(MessageSeriesStatus::Complete));
+
+let extra = ContinuationFrameHeader {
+    message_key: MessageKey(1),
+    sequence: Some(FrameSequence(4)),
+    body_len: 5,
+    is_last: false,
+};
+assert!(matches!(
+    series.accept_continuation(&extra),
+    Err(MessageSeriesError::SeriesComplete)
+));
+```
 
 ### Streaming request body consumption
 
@@ -286,7 +1197,8 @@ Handlers can opt into streaming request bodies using the `StreamingBody`
 extractor or by accepting a `RequestBodyStream` directly. The framework creates
 a bounded channel and forwards body chunks as they arrive; back-pressure
 propagates automatically when the handler consumes slower than the network
-delivers.
+delivers. Routing and correlation metadata stay available immediately through
+`RequestParts`, so handlers can begin work before the full body is assembled.
 
 ```rust,no_run
 use tokio::io::AsyncReadExt;
@@ -305,7 +1217,7 @@ async fn handle_upload(parts: RequestParts, body: RequestBodyStream) {
 }
 ```
 
-The `RequestBodyReader` adaptor implements `AsyncRead`, allowing protocol
+The `RequestBodyReader` adapter implements `AsyncRead`, allowing protocol
 crates to reuse existing parsers. For raw stream access, use the
 `RequestBodyStream` directly with `StreamExt` methods:
 
@@ -343,8 +1255,10 @@ async fn with_extractor(parts: RequestParts, body: StreamingBody) {
 
 Back-pressure is enforced via bounded channels: when the internal buffer fills,
 the framework pauses reading from the socket until the handler drains pending
-chunks. This prevents memory exhaustion under slow consumer conditions. The
-`body_channel` helper creates channels with configurable capacity:
+chunks. This prevents memory exhaustion under slow consumer conditions. When
+the request arrived through `MessageAssembler`, the same per-connection memory
+budgets continue to govern partial buffered state before chunks reach the
+handler. The `body_channel` helper creates channels with configurable capacity:
 
 ```rust
 use wireframe::request::body_channel;
@@ -365,14 +1279,14 @@ identifiers, or wrap the remainder of the pipeline using `Transform`. The
 `Next` continuation calls the inner service, returning a `ServiceResponse`
 containing the frame that will be serialized back to the client.[^11]
 
-The `middleware::from_fn` helper acts as an adaptor for async functions,
-turning them into middleware components that enable payload decoding,
-invocation of the inner service, and response editing before the response is
-serialized. `HandlerService` rebuilds a packet from the request bytes, invokes
-the registered handler, and by default returns the original payload; replies
-are crafted in middleware (or custom packet types with interior mutability).
-Decode typed payloads via the `Message` helpers, then write the encoded
-response into `ServiceResponse::frame_mut()`.[^10][^12]
+The `middleware::from_fn` helper adapts async functions into middleware
+components, enabling payload decoding, invocation of the inner service, and
+response editing before the response is serialized. `HandlerService` rebuilds a
+packet from the request bytes, invokes the registered handler, and by default
+returns the original payload; replies are crafted in middleware (or custom
+packet types with interior mutability). Decode typed payloads via the `Message`
+helpers, then write the encoded response into
+`ServiceResponse::frame_mut()`.[^10][^12]
 
 ```rust
 use std::convert::Infallible;
@@ -461,13 +1375,17 @@ async fn main() -> Result<(), SendError> {
 
 ## Message fragmentation
 
-`WireframeApp` now fragments oversized payloads automatically. The builder
-derives a `FragmentationConfig` from the active frame codec's maximum frame
-length (the default length-delimited codec uses `buffer_capacity`): any payload
-that will not fit into a single frame is split into fragments carrying a
+`WireframeApp` keeps transport fragmentation disabled by default. Enable it
+explicitly with `enable_fragmentation()` or provide a bespoke
+`FragmentationConfig` using `fragmentation(Some(cfg))`. When enabled, payloads
+that exceed the frame budget are split into fragments carrying a
 `FragmentHeader` (`message_id`, `fragment_index`, `is_last_fragment`) wrapped
 with the `FRAG` marker. The connection reassembles fragments before invoking
 handlers, so handlers continue to work with complete `Envelope` values.[^6]
+
+Layering order is fixed. Outbound processing runs serializer → fragmentation →
+codec wrapping. Inbound processing runs codec decode → fragment reassembly →
+deserialization.
 
 Fragmented messages enforce two guards: `max_message_size` caps the total
 reassembled payload, and `reassembly_timeout` evicts stale partial messages.
@@ -492,11 +1410,17 @@ let app = WireframeApp::new()?
     .route(42, handler)?;
 ```
 
-Set `fragmentation(None)` when the transport already supports large frames, or
-when fragmentation should be deferred to an upstream gateway. The
-`ConnectionActor` mirrors the same behaviour for push traffic and streaming
-responses through `enable_fragmentation`, ensuring client-visible frames follow
-the same format.
+Call `fragmentation(None)` to keep fragmentation disabled after explicit
+configuration (for example, when the transport already supports large frames or
+fragmentation is delegated to an upstream gateway). The `ConnectionActor`
+mirrors the same behaviour for push traffic and streaming responses through
+`enable_fragmentation`, ensuring client-visible frames follow the same format.
+
+On the server side, a unified `FramePipeline` applies the same fragmentation
+logic to all outbound `Envelope` values — handler responses, streaming frames,
+and multi-packet channels — before serialization and codec wrapping. This
+guarantees that a single connection-scoped `FragmentationState` manages both
+outbound fragmentation and inbound reassembly.
 
 ## Protocol hooks
 
@@ -530,7 +1454,7 @@ the failure callback path.[^20]
 `spawn_connection_task` wraps each accepted stream in `read_preamble` and
 `RewindStream`, records connection panics, and logs failures without crashing
 worker tasks.[^20][^37][^38] `ServerError` surfaces bind and accept failures as
-typed errors, so callers can react appropriately.[^21]
+typed errors so callers can react appropriately.[^21]
 
 ## Client runtime
 
@@ -541,11 +1465,34 @@ serializer, codec settings, and socket options before connecting.[^44] Use
 `buffer_capacity`, and apply `SocketOptions` when TCP tuning is required, such
 as `TCP_NODELAY` or buffer size adjustments.
 
+### Client configuration reference
+
+| Surface              | API                                          | Default                                                 | Use when                                                            |
+| -------------------- | -------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------- |
+| Serializer           | `WireframeClient::builder().serializer(...)` | `BincodeSerializer`                                     | Server and client need a non-default serialization contract.        |
+| Frame codec settings | `codec_config(ClientCodecConfig)`            | 4-byte big-endian prefix and 1024-byte max frame length | Server `buffer_capacity` or protocol limits differ from defaults.   |
+| Socket tuning        | `socket_options(SocketOptions)`              | OS defaults                                             | Low-latency tuning (`TCP_NODELAY`) or keepalive policy is required. |
+| Preamble payload     | `with_preamble(T)`                           | Disabled                                                | Protocol negotiation must happen before framed payload traffic.     |
+| Preamble timeout     | `preamble_timeout(Duration)`                 | Disabled unless configured                              | Connection setup should fail fast on stalled preamble exchange.     |
+| Setup hook           | `on_connection_setup(...)`                   | Disabled                                                | Per-connection state is needed for metrics or lifecycle coupling.   |
+| Teardown hook        | `on_connection_teardown(...)`                | Disabled                                                | Close should flush counters or release stateful resources.          |
+| Error hook           | `on_error(...)`                              | Disabled                                                | Transport and decode failures must be routed to observability.      |
+| Before-send hook     | `before_send(...)`                           | Disabled                                                | Inspect or mutate serialized bytes before every outgoing frame.     |
+| After-receive hook   | `after_receive(...)`                         | Disabled                                                | Inspect or mutate raw bytes after every incoming frame is read.     |
+| Tracing config       | `tracing_config(TracingConfig)`              | INFO connect/close, DEBUG data ops, timing off          | Customize tracing span levels and per-command timing.               |
+| Pool connect         | `connect_pool(addr, ClientPoolConfig)`       | Disabled                                                | Warm socket reuse or bounded socket fan-out is required.            |
+| Pool size            | `ClientPoolConfig::pool_size(n)`             | `4`                                                     | More than one warm physical socket should be maintained.            |
+| Per-socket admission | `max_in_flight_per_socket(n)`                | `1`                                                     | More than one caller may queue work against the same warm socket.   |
+| Idle recycle         | `idle_timeout(Duration)`                     | `600s`                                                  | Idle sockets should be replaced before they become stale.           |
+
 ```rust
 use std::{net::SocketAddr, time::Duration};
 
 use wireframe::{
+    app::Envelope,
     client::{ClientCodecConfig, SocketOptions},
+    correlation::CorrelatableFrame,
+    message::Message,
     WireframeClient,
 };
 
@@ -556,7 +1503,7 @@ struct Login {
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug, PartialEq)]
 struct LoginAck {
-    ok: bool,
+    username: String,
 }
 
 let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid socket address");
@@ -574,15 +1521,151 @@ let mut client = WireframeClient::builder()
 let login = Login {
     username: "guest".to_string(),
 };
-let ack: LoginAck = client.call(&login).await?;
-assert!(ack.ok);
+let request = Envelope::new(1, None, login.to_bytes()?);
+let response: Envelope = client.call_correlated(request).await?;
+let (ack, _) = LoginAck::from_bytes(response.payload_bytes())?;
+assert_eq!(ack.username, "guest");
+assert!(response.correlation_id().is_some());
 ```
+
+For screen readers: the following sequence diagram shows the client lifecycle
+for connect, optional preamble exchange, message I/O, error handling, and
+teardown.
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Builder as WireframeClientBuilder
+    participant Stream as TcpStream
+    participant Hooks as Client hooks
+    App->>Builder: connect(addr)
+    Builder->>Stream: apply socket options + connect
+    alt preamble configured
+        Builder->>Stream: write/read preamble
+        Builder->>Builder: preamble success/failure callbacks
+    end
+    Builder->>Hooks: on_connection_setup
+    App->>Stream: send / receive / call / call_correlated
+    App->>Hooks: on_error (if operation fails)
+    App->>Builder: close()
+    Builder->>Hooks: on_connection_teardown
+```
+
+Run the client example against the echo server:
+
+```plaintext
+# terminal 1
+cargo run --example echo --features examples
+
+# terminal 2
+cargo run --example client_echo_login --features examples
+```
+
+### Client pools
+
+Use `connect_pool` when one warm socket is too little, but opening a new TCP
+connection for every request is too expensive. `WireframeClientPool` keeps a
+bounded set of warm sockets, preserves preamble state on reuse, recycles idle
+sockets after the configured timeout, and can schedule blocked logical sessions
+fairly through `PoolHandle`.
+
+```rust,no_run
+use std::{net::SocketAddr, time::Duration};
+
+use wireframe::client::{ClientPoolConfig, PoolFairnessPolicy, WireframeClient};
+
+#[derive(bincode::Encode, bincode::Decode)]
+struct Ping(u8);
+
+#[derive(bincode::Encode, bincode::Decode, Debug, PartialEq)]
+struct Pong(u8);
+
+# #[tokio::main]
+# async fn main() -> Result<(), wireframe::client::ClientError> {
+let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid socket address");
+let pool = WireframeClient::builder()
+    .connect_pool(
+        addr,
+        ClientPoolConfig::default()
+            .pool_size(2)
+            .max_in_flight_per_socket(2)
+            .idle_timeout(Duration::from_secs(30))
+            .fairness_policy(PoolFairnessPolicy::RoundRobin),
+    )
+    .await?;
+
+let lease = pool.acquire().await?;
+let pong: Pong = lease.call(&Ping(1)).await?;
+assert_eq!(pong, Pong(1));
+
+pool.close().await;
+# Ok(())
+# }
+```
+
+Pooled leases forward the common request methods instead of exposing a mutable
+reference to a long-lived `WireframeClient`. That keeps actual socket I/O
+serialized per physical connection while still allowing multiple callers to be
+admitted against the same warm slot. Treat `max_in_flight_per_socket` as an
+admission budget, not as a guarantee of parallel writes on one TCP stream.
+
+Create a `PoolHandle` when one logical session needs repeated pooled access and
+that session should participate in the configured fairness policy over time:
+
+```rust,no_run
+# use std::net::SocketAddr;
+use wireframe::client::{ClientPoolConfig, PoolFairnessPolicy, PoolHandle, WireframeClient};
+
+#[derive(bincode::Encode, bincode::Decode)]
+struct Ping(u8);
+
+#[derive(bincode::Encode, bincode::Decode, Debug, PartialEq)]
+struct Pong(u8);
+
+# #[tokio::main]
+# async fn main() -> Result<(), wireframe::client::ClientError> {
+let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid socket address");
+let pool = WireframeClient::builder()
+    .connect_pool(
+        addr,
+        ClientPoolConfig::default()
+            .pool_size(1)
+            .fairness_policy(PoolFairnessPolicy::RoundRobin),
+    )
+    .await?;
+
+let mut session_a: PoolHandle<_, _, _> = pool.handle();
+let mut session_b = pool.handle();
+
+let pong_a: Pong = session_a.call(&Ping(1)).await?;
+let pong_b: Pong = session_b.call(&Ping(2)).await?;
+
+assert_eq!(pong_a, Pong(1));
+assert_eq!(pong_b, Pong(2));
+# Ok(())
+# }
+```
+
+Use `pool.handle()` instead of repeated `pool.acquire()` when a long-lived
+workflow should receive fair turns relative to other workflows. Fairness
+policies order blocked handles; they do not create a second queue outside the
+pool or bypass its back-pressure. If all permits are busy, the waiting handle
+still blocks until capacity returns.
+
+Continue using `PooledClientLease` for explicit split-phase work such as
+`send()` followed later by `receive()`. `PoolHandle` does not pin a logical
+session to one socket and does not demultiplex arbitrary responses across
+shared handles.
+
+Preamble callbacks and setup hooks run per physical socket creation. Warm reuse
+keeps the existing preamble state; idle recycle closes the old socket and
+creates a fresh one, which reruns preamble and setup.
 
 ### Client preamble exchange
 
 The client builder supports an optional preamble exchange before framing
 begins. Use `with_preamble` to send a preamble immediately after TCP connect,
-and register callbacks for success or failure scenarios.[^45]
+and register callbacks for success or failure scenarios.[^47]
 
 ```rust
 use std::{net::SocketAddr, time::Duration};
@@ -640,7 +1723,321 @@ TCP stream, enabling bidirectional preamble negotiation. Any bytes read beyond
 the server's response must be returned as "leftover" bytes so they can be
 replayed before the framing layer begins. The failure callback runs when the
 preamble exchange fails (timeout, I/O error, or encode error) and can log
-diagnostics or send an error response before the connection closes.
+diagnostics or send an error response before the connection closes. In the
+current implementation, callback read failures surface as
+`ClientError::PreambleRead`, timeout expiry surfaces as
+`ClientError::PreambleTimeout`, and write-side failures from
+`write_preamble(...)` are wrapped by `ClientError::PreambleEncode` because the
+helper returns `bincode::EncodeError`.
+
+### Client lifecycle hooks
+
+The client builder supports lifecycle hooks that mirror the server's hook
+system, enabling consistent instrumentation across both client and server.[^48]
+
+- **Setup hook** (`on_connection_setup`): Invoked once after the TCP connection
+  is established and preamble exchange (if configured) succeeds. Returns
+  connection-specific state stored for the connection's lifetime.
+- **Teardown hook** (`on_connection_teardown`): Invoked when `close()` is
+  called. Receives the state produced by the setup hook for cleanup.
+- **Error hook** (`on_error`): Invoked when errors occur during send, receive,
+  or call operations. Receives a reference to the error for logging or metrics.
+
+```rust
+use std::{net::SocketAddr, sync::Arc};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use wireframe::client::WireframeClient;
+
+struct SessionState {
+    request_count: AtomicUsize,
+}
+
+let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid socket address");
+
+let client = WireframeClient::builder()
+    .on_connection_setup(|| async {
+        SessionState {
+            request_count: AtomicUsize::new(0),
+        }
+    })
+    .on_connection_teardown(|state: SessionState| async move {
+        println!(
+            "Session ended after {} requests",
+            state.request_count.load(Ordering::SeqCst)
+        );
+    })
+    .on_error(|err| async move {
+        eprintln!("Client error: {err}");
+    })
+    .connect(addr)
+    .await?;
+
+// Use the client...
+
+client.close().await; // Teardown hook invoked here
+```
+
+The setup hook runs after connection establishment (and preamble exchange if
+configured). The teardown hook only runs if a setup hook was configured and
+successfully produced state. The error hook is independent and can be
+configured without a setup hook.
+
+### Client request hooks
+
+The client builder supports **request hooks** that fire on every outgoing and
+incoming frame, enabling symmetric instrumentation with the server middleware
+stack.[^52]
+
+- **Before-send hook** (`before_send`): Invoked after serialization, before
+  each frame is written to the transport. Receives a `&mut Vec<u8>` of the
+  serialized bytes, allowing inspection or mutation (e.g., prepending an
+  authentication token, incrementing a metrics counter).
+- **After-receive hook** (`after_receive`): Invoked after each frame is read
+  from the transport, before deserialization. Receives a `&mut BytesMut` of the
+  raw frame bytes, allowing inspection or mutation before the deserializer
+  processes them.
+
+Multiple hooks of the same kind may be registered; they execute in registration
+order. Hooks are synchronous `Fn` closures—users who need mutable state should
+capture an `Arc<AtomicUsize>` or `Arc<Mutex<_>>` in the closure.
+
+```rust
+use std::{net::SocketAddr, sync::Arc};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use wireframe::client::WireframeClient;
+
+let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid socket address");
+
+let send_counter = Arc::new(AtomicUsize::new(0));
+let recv_counter = Arc::new(AtomicUsize::new(0));
+let sc = send_counter.clone();
+let rc = recv_counter.clone();
+
+let mut client = WireframeClient::builder()
+    .before_send(move |_bytes: &mut Vec<u8>| {
+        sc.fetch_add(1, Ordering::SeqCst);
+    })
+    .after_receive(move |_bytes: &mut bytes::BytesMut| {
+        rc.fetch_add(1, Ordering::SeqCst);
+    })
+    .connect(addr)
+    .await?;
+```
+
+Request hooks fire on all message paths: `send`, `send_envelope`,
+`receive_envelope`, `call_correlated`, `call_streaming`, and `ResponseStream`
+polling. Clients configured without request hooks behave identically to clients
+that have none registered.
+
+### Outbound streaming sends
+
+The client supports sending large request bodies as multiple frames using
+`send_streaming`. The caller provides a protocol-defined frame header and an
+`AsyncRead` body source; the helper reads chunks, prepends the header to each
+chunk, and emits framed packets over the transport.
+
+```rust,no_run
+use std::net::SocketAddr;
+use wireframe::client::{SendStreamingConfig, WireframeClient};
+
+# #[tokio::main]
+# async fn main() -> Result<(), wireframe::client::ClientError> {
+let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid address");
+let mut client = WireframeClient::builder().connect(addr).await?;
+
+let header = [0xCA, 0xFE, 0xBA, 0xBE];
+let body = vec![0u8; 4096];
+let config = SendStreamingConfig::default()
+    .with_chunk_size(512)
+    .with_timeout(std::time::Duration::from_secs(5));
+
+let outcome = client.send_streaming(&header, &body[..], config).await?;
+println!("sent {} frames", outcome.frames_sent());
+# Ok(())
+# }
+```
+
+`SendStreamingConfig` controls chunking and timeout behaviour:
+
+- `with_chunk_size(usize)` — maximum body bytes per frame. When not set, the
+  chunk size is derived as `max_frame_length - header.len()`.
+- `with_timeout(Duration)` — timeout for the entire operation. If the timeout
+  elapses, `std::io::ErrorKind::TimedOut` is returned and no further frames are
+  emitted. Any frames already sent remain sent; callers must assume the
+  operation may have been partially successful.
+
+`SendStreamingOutcome` reports the number of frames emitted via
+`frames_sent()`. The error hook is invoked on all failure paths, consistent
+with other client send methods.[^53]
+
+### Client tracing
+
+The client emits `tracing` spans around every operation. Span levels and
+per-command timing are configurable via `TracingConfig`, which is passed to the
+builder with `tracing_config()`. When no `tracing` subscriber is installed, all
+instrumentation is zero-cost.
+
+Default span levels: `INFO` for lifecycle operations (`connect`, `close`) and
+`DEBUG` for data operations (`send`, `receive`, `call`, `call_streaming`).
+Per-command timing is disabled by default.
+
+```rust
+use std::net::SocketAddr;
+
+use tracing::Level;
+use wireframe::client::{TracingConfig, WireframeClient};
+
+let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid socket address");
+
+// Enable timing for connect and call, set all spans to TRACE level.
+let config = TracingConfig::default()
+    .with_all_levels(Level::TRACE)
+    .with_connect_timing(true)
+    .with_call_timing(true);
+
+let mut client = WireframeClient::builder()
+    .tracing_config(config)
+    .connect(addr)
+    .await?;
+```
+
+When timing is enabled for an operation, a `DEBUG`-level event recording
+`elapsed_us` is emitted when the operation completes (on both success and error
+paths). Streaming responses emit per-frame `DEBUG` events with
+`stream.frames_received` and a termination event with `stream.frames_total`.
+
+Clients configured without `tracing_config()` use the default configuration and
+behave identically to the pre-tracing API.
+
+### Client message API with correlation identifiers
+
+The client provides envelope-aware messaging APIs that work with the `Packet`
+trait, supporting automatic correlation ID generation and validation. These
+methods complement the basic `send`, `receive`, and `call` methods that operate
+on raw `Message` types.
+
+**Correlation ID generation**: Each client maintains an atomic counter for
+generating unique correlation IDs. The `next_correlation_id` method returns the
+next ID, which is useful when managing correlation manually.
+
+**Envelope-aware methods**:
+
+- `send_envelope<P: Packet>(envelope: P)` — Sends an envelope, auto-generating
+  a correlation ID if not present. Returns the correlation ID used.
+- `receive_envelope<P: Packet>()` — Receives and deserializes the next frame as
+  the specified packet type.
+- `call_correlated<P: Packet>(request: P)` — Sends a request with auto-
+  generated correlation ID, receives the response, and validates that the
+  response's correlation ID matches the request. Returns
+  `ClientError::CorrelationMismatch` if the IDs differ.
+
+```rust,no_run
+use std::net::SocketAddr;
+
+use wireframe::{
+    app::{Envelope, Packet},
+    client::{ClientError, WireframeClient},
+};
+
+# async fn example() -> Result<(), ClientError> {
+let addr: SocketAddr = "127.0.0.1:7878".parse().expect("valid socket address");
+let mut client = WireframeClient::builder()
+    .connect(addr)
+    .await?;
+
+// Create an envelope without a correlation ID.
+let request = Envelope::new(1, None, vec![1, 2, 3]);
+
+// call_correlated auto-generates a correlation ID, sends the request,
+// receives the response, and validates the correlation ID matches.
+let response: Envelope = client.call_correlated(request).await?;
+
+// The response's correlation ID matches the auto-generated request ID.
+assert!(response.correlation_id().is_some());
+# Ok(())
+# }
+```
+
+For more control over correlation, use `send_envelope` and `receive_envelope`
+separately:
+
+```rust,no_run
+use wireframe::app::{Envelope, Packet};
+# use wireframe::client::{ClientError, WireframeClient};
+# async fn example(client: &mut WireframeClient) -> Result<(), ClientError> {
+
+// Auto-generate correlation ID when sending.
+let envelope = Envelope::new(1, None, b"payload".to_vec());
+let correlation_id = client.send_envelope(envelope).await?;
+
+// Receive the response.
+let response: Envelope = client.receive_envelope().await?;
+
+// Manually verify correlation if needed.
+assert_eq!(response.correlation_id(), Some(correlation_id));
+# Ok(())
+# }
+```
+
+The `CorrelationMismatch` error provides diagnostic information when validation
+fails:
+
+```rust,ignore
+use wireframe::client::ClientError;
+
+match client.call_correlated(request).await {
+    Ok(response) => {
+        // Handle successful response.
+    }
+    Err(ClientError::CorrelationMismatch { expected, received }) => {
+        eprintln!(
+            "Correlation mismatch: expected {:?}, received {:?}",
+            expected, received
+        );
+    }
+    Err(e) => {
+        // Handle other errors.
+    }
+}
+```
+
+### Client request/response error mapping
+
+Client request/response operations (`receive`, `call`, `receive_envelope`, and
+`call_correlated`) map transport and decode failures to `WireframeError`
+variants exposed through `ClientError::Wireframe`:
+
+- Transport failures map to `WireframeError::Io`.
+- Decode failures map to `WireframeError::Protocol` with
+  `ClientProtocolError::Deserialize`.
+
+```rust,ignore
+use wireframe::{
+    ClientError,
+    ClientProtocolError,
+    WireframeError,
+};
+
+match client.call(&request).await {
+    Ok(response) => {
+        // Handle successful response.
+    }
+    Err(ClientError::Wireframe(WireframeError::Io(err))) => {
+        eprintln!("transport failure: {err}");
+    }
+    Err(ClientError::Wireframe(WireframeError::Protocol(
+        ClientProtocolError::Deserialize(err),
+    ))) => {
+        eprintln!("decode failure: {err}");
+    }
+    Err(other) => {
+        // Handle serialize/preamble/correlation failures.
+        eprintln!("other client error: {other}");
+    }
+}
+```
 
 ## Push queues and connection actors
 
@@ -668,7 +2065,10 @@ invokes protocol hooks, records metrics for outbound frames, and returns a
 `WireframeError` when the response stream hits an I/O problem.[^30][^33] Active
 connection counts are tracked with a guard that increments on creation and
 decrements on drop; the `active_connection_count()` helper exposes the current
-gauge.[^31]
+gauge.[^31] Interleaved high- and low-priority push behaviour is validated by
+the test suite: the shared rate limiter enforces symmetrical throughput caps
+across both queues, and `FairnessConfig` prevents low-priority starvation
+during sustained high-priority bursts.
 
 ## Session management
 
@@ -684,7 +2084,7 @@ to enumerate active sessions.[^40]
 The `Response` enum models several reply styles: a single frame, a vector of
 frames, a streamed response, a channel-backed multi-packet response, or an
 empty reply. `into_stream` converts any variant into a boxed `FrameStream`,
-ready to install on a connection actor with `set_response`, so streaming output
+ready to install on a connection actor with `set_response` so streaming output
 can be interleaved with push traffic. `WireframeError` distinguishes transport
 failures from protocol-level errors emitted by streaming
 responses.[^34][^35][^31]
@@ -751,11 +2151,286 @@ Multi-packet responders rely on the protocol hook `stream_end_frame` to emit a
 terminator when the producer side of the channel closes naturally. The
 connection actor records why the channel ended (`drained`, `disconnected`, or
 `shutdown`), stamps the stored `correlation_id` on the terminator frame, and
-routes it through the standard `before_send` instrumentation, so telemetry and
+routes it through the standard `before_send` instrumentation so telemetry and
 higher-level lifecycle hooks observe a consistent end-of-stream signal.
 Dropping all senders closes the channel; the actor logs the termination reason
 and forwards the terminator through the same hooks used for regular frames so
 existing observability continues to work.
+
+## Consuming streaming responses on the client
+
+The client library supports consuming `Response::Stream` and
+`Response::MultiPacket` server responses through the `call_streaming` and
+`receive_streaming` methods on `WireframeClient`. These methods return a
+`ResponseStream` that yields typed data frames until the protocol's
+end-of-stream terminator arrives. `ResponseStream` holds an exclusive mutable
+borrow of `WireframeClient` while it exists, so the client cannot perform other
+I/O operations until the stream is dropped or fully consumed (`None` is
+observed).
+
+For protocols where every frame is meaningful, a manual `StreamExt::next` loop
+remains the clearest option. For multiplexed protocols that interleave data
+frames with notices, progress updates, or other control frames, prefer
+`StreamingResponseExt::typed_with`. It maps each frame into
+`Result<Option<Item>, ClientError>`, yielding `Some(item)` values in order
+while silently skipping `None`.
+
+### Terminator detection with `is_stream_terminator`
+
+Protocol implementations must override `Packet::is_stream_terminator` to teach
+the client how to recognize the server's end-of-stream marker. The default
+implementation returns `false`; protocols override it to match their terminator
+format:
+
+```rust
+use wireframe::app::{Packet, PacketParts};
+use wireframe::correlation::CorrelatableFrame;
+
+#[derive(bincode::BorrowDecode, bincode::Encode)]
+struct MyEnvelope {
+    id: u32,
+    correlation_id: Option<u64>,
+    payload: Vec<u8>,
+}
+
+impl CorrelatableFrame for MyEnvelope {
+    fn correlation_id(&self) -> Option<u64> { self.correlation_id }
+    fn set_correlation_id(&mut self, cid: Option<u64>) {
+        self.correlation_id = cid;
+    }
+}
+
+// Message is auto-implemented via the blanket impl for Encode + BorrowDecode types.
+
+impl Packet for MyEnvelope {
+    fn id(&self) -> u32 { self.id }
+    fn into_parts(self) -> PacketParts {
+        PacketParts::new(self.id, self.correlation_id, self.payload)
+    }
+    fn from_parts(parts: PacketParts) -> Self {
+        Self {
+            id: parts.id(),
+            correlation_id: parts.correlation_id(),
+            payload: parts.into_payload(),
+        }
+    }
+    // An envelope with id == 0 signals end-of-stream.
+    fn is_stream_terminator(&self) -> bool { self.id == 0 }
+}
+```
+
+This mirrors the server's `stream_end_frame` hook symmetrically: the server
+*produces* terminators; the client *detects* them.[^49]
+
+### High-level API: `call_streaming`
+
+`call_streaming` sends a request, auto-generates a correlation identifier if
+needed, and returns a `ResponseStream`. The stream yields data frames as
+`Result<P, ClientError>` and terminates with `None` when the terminator
+arrives: because the stream borrows the `WireframeClient` mutably, this call
+also prevents other client I/O until the stream is dropped or drained.
+
+```rust,no_run
+use futures::StreamExt;
+use std::net::SocketAddr;
+use wireframe::{app::Envelope, client::{ClientError, WireframeClient}};
+
+# #[tokio::main]
+# async fn main() -> Result<(), ClientError> {
+let addr: SocketAddr = "127.0.0.1:9000".parse().expect("valid address");
+let mut client = WireframeClient::builder().connect(addr).await?;
+
+let request = Envelope::new(1, None, vec![]);
+let mut stream = client.call_streaming::<Envelope>(request).await?;
+
+while let Some(result) = stream.next().await {
+    let frame = result?;
+    println!("received: {:?}", frame);
+}
+// Stream terminated — all data frames consumed.
+# Ok(())
+# }
+```
+
+### Helper-based typed consumption with `typed_with`
+
+`StreamingResponseExt::typed_with` adapts a `ResponseStream` into a stream of
+domain items. This is useful when only some protocol frames should be exposed
+to the caller:
+
+```rust,no_run
+use futures::TryStreamExt;
+use std::net::SocketAddr;
+use wireframe::{
+    app::{Packet, PacketParts},
+    client::{ClientError, StreamingResponseExt, WireframeClient},
+    correlation::CorrelatableFrame,
+};
+
+#[derive(bincode::BorrowDecode, bincode::Encode)]
+struct MyEnvelope {
+    id: u32,
+    correlation_id: Option<u64>,
+    payload: Vec<u8>,
+}
+
+impl CorrelatableFrame for MyEnvelope {
+    fn correlation_id(&self) -> Option<u64> { self.correlation_id }
+    fn set_correlation_id(&mut self, cid: Option<u64>) {
+        self.correlation_id = cid;
+    }
+}
+
+impl Packet for MyEnvelope {
+    fn id(&self) -> u32 { self.id }
+    fn into_parts(self) -> PacketParts {
+        PacketParts::new(self.id, self.correlation_id, self.payload)
+    }
+    fn from_parts(parts: PacketParts) -> Self {
+        Self {
+            id: parts.id(),
+            correlation_id: parts.correlation_id(),
+            payload: parts.into_payload(),
+        }
+    }
+    fn is_stream_terminator(&self) -> bool { self.id == 0 }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Row(Vec<u8>);
+
+# #[tokio::main]
+# async fn main() -> Result<(), ClientError> {
+let addr: SocketAddr = "127.0.0.1:9000".parse().expect("valid address");
+let mut client = WireframeClient::builder().connect(addr).await?;
+
+let request = MyEnvelope {
+    id: 1,
+    correlation_id: None,
+    payload: vec![],
+};
+
+let rows: Vec<Row> = client
+    .call_streaming::<MyEnvelope>(request)
+    .await?
+    .typed_with(|frame| match frame.id {
+        1 => Ok(Some(Row(frame.payload))),
+        2 => Ok(None),
+        other => Err(ClientError::from(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("unexpected frame id {other}"),
+        ))),
+    })
+    .try_collect()
+    .await?;
+
+println!("received {} rows", rows.len());
+# Ok(())
+# }
+```
+
+Because the helper wraps `ResponseStream` rather than replacing it, transport
+failures and correlation mismatches still surface as `ClientError` values from
+the underlying stream. The helper also does not change the exclusive
+`&mut WireframeClient` borrow: while the typed stream is alive, other client
+I/O remains blocked.
+
+### Low-level API: `receive_streaming`
+
+When the caller has already sent a request via `send_envelope`, the
+`receive_streaming` method accepts the known correlation identifier and returns
+a `ResponseStream` without re-sending. As with `call_streaming`, that stream
+holds an exclusive mutable borrow of `WireframeClient` until dropped or fully
+consumed:
+
+```rust,no_run
+use futures::StreamExt;
+use std::net::SocketAddr;
+use wireframe::{app::Envelope, client::{ClientError, WireframeClient}};
+
+# #[tokio::main]
+# async fn main() -> Result<(), ClientError> {
+let addr: SocketAddr = "127.0.0.1:9000".parse().expect("valid address");
+let mut client = WireframeClient::builder().connect(addr).await?;
+
+let request = Envelope::new(1, None, vec![]);
+let cid = client.send_envelope(request).await?;
+let mut stream = client.receive_streaming::<Envelope>(cid);
+
+while let Some(result) = stream.next().await {
+    let frame = result?;
+    println!("received: {:?}", frame);
+}
+# Ok(())
+# }
+```
+
+### Back-pressure
+
+Back-pressure propagates naturally through Transmission Control Protocol (TCP)
+flow control. If the client reads slowly, the client's TCP receive buffer
+fills. As that receive window shrinks, the server's TCP send buffer fills
+because bytes cannot be flushed quickly enough. Once the send buffer is full,
+write operations suspend, and the server stops polling its response stream or
+channel until the client drains data. No explicit flow-control messages are
+required.[^50]
+
+Interleaved high- and low-priority push behaviour is validated against this
+streaming path as part of roadmap item `11.3.2`. The parity suite confirms
+fairness-driven low-priority progress and shared cross-priority rate limiting
+without changing the public `WireframeClient` interface.
+
+### Error handling
+
+`ResponseStream` validates the correlation identifier on every frame. If a
+frame carries a different identifier, the stream yields
+`ClientError::StreamCorrelationMismatch` and terminates. Transport errors and
+decode failures are surfaced through `ClientError::Wireframe`.[^51]
+
+### Client troubleshooting
+
+- Codec length mismatch:
+  if small requests succeed but larger ones fail once payload size crosses a
+  threshold, suspect a frame-budget mismatch between client and server. The
+  client usually reports `ClientError::Wireframe(WireframeError::Io(_))`
+  because the peer closes the connection after rejecting the oversized frame.
+  Check the client `ClientCodecConfig::max_frame_length`, the server
+  `buffer_capacity`, and any server-side frame-limit logs together. The fix is
+  to align both ends to the same maximum frame length.
+- Preamble timeout:
+  `ClientError::PreambleTimeout` means the handshake stalled before framed
+  traffic began. Reduce ambiguity by setting an explicit
+  `preamble_timeout(Duration)` and verify that the server actually reads or
+  replies during the preamble phase.
+- Preamble read or decode failure:
+  `ClientError::PreambleRead(_)` means the success callback could not read or
+  decode the server's acknowledgement bytes. This usually indicates the wrong
+  preamble type, malformed server bytes, or callback logic that reads the
+  response incorrectly. Confirm both sides use the same preamble schema and
+  that `on_preamble_success` returns any leftover bytes it consumed.
+- Preamble encode or write failure:
+  `ClientError::PreambleEncode(_)` means the client failed before handshake
+  completion while serializing or writing the preamble. In the current client
+  flow, `write_preamble(...)` wraps write-side I/O in `bincode::EncodeError`,
+  so there is no separate user-visible `PreambleWrite` branch to match against.
+- TLS or wrong-protocol port mismatch:
+  pointing a plain `WireframeClient` at a port that expects Transport Layer
+  Security (TLS), Hypertext Transfer Protocol (HTTP), or another protocol
+  usually surfaces as `ClientError::Wireframe(WireframeError::Io(_))` after the
+  first request because the bytes returned are not valid Wireframe frames.
+  Verify the host and port, confirm whether a TLS terminator is required, and
+  remember that built-in client TLS configuration is still future work.
+- Correlation mismatch errors:
+  `ClientError::CorrelationMismatch` and
+  `ClientError::StreamCorrelationMismatch` mean the response did not preserve
+  the request correlation identifier. Verify that the server echoes or stamps
+  the expected `correlation_id` for `call_correlated` and streaming responses.
+- Streaming API contention:
+  `ResponseStream` holds `&mut WireframeClient`; do not issue additional client
+  I/O until the stream is drained or dropped.
+- Transport disconnects:
+  treat `ClientError::Wireframe(WireframeError::Io(_))` as a network-level or
+  peer-closure failure and apply a reconnect or retry policy at the call site.
 
 ## Versioning and graceful deprecation
 
@@ -763,10 +2438,10 @@ Phase out older message versions without breaking clients:
 
 - Accept versions N and N-1 on ingress; rewrite legacy payloads in middleware so
   downstream handlers see the current schema.[^10][^12]
-- Emit version N on egress, so clients observe a single schema.
+- Emit version N on egress so clients observe a single schema.
 - Publish metrics and logs describing legacy usage to support operator
   dashboards.[^33][^8]
-- Remove adaptors once the sunset window ends.
+- Remove adapters once the sunset window ends.
 
 ```rust
 use std::sync::Arc;
@@ -831,7 +2506,7 @@ fn build_app() -> Result<WireframeApp> {
 When the optional `metrics` feature is enabled, Wireframe updates the
 `wireframe_connections_active` gauge, frame counters tagged by direction, error
 counters tagged by kind, and a counter for panicking connection tasks. All
-helpers become no-ops when the feature is disabled, so instrumentation can stay
+helpers become no-ops when the feature is disabled so instrumentation can stay
 in place.[^33] `handle_connection`, the connection actor, and the panic wrapper
 call these helpers to maintain consistent telemetry.[^6][^7][^31][^20]
 
@@ -849,9 +2524,9 @@ call these helpers to maintain consistent telemetry.[^6][^7][^31][^20]
 [^2]: Implemented in `src/app/builder.rs` (lines 66-209).
 [^3]: Implemented in `src/app/builder.rs` (lines 100-121, 347-360).
 [^4]: Implemented in `src/app/builder.rs` (lines 326-344).
-[^5]: Implemented in `src/app/error.rs` (lines 7-26).
-[^6]: Implemented in `src/app/connection.rs` (lines 41-205).
-[^7]: Implemented in `src/app/connection.rs` (lines 207-289).
+[^5]: Implemented in `src/error.rs` (lines 1-68).
+[^6]: Implemented in `src/app/inbound_handler.rs` (lines 41-205).
+[^7]: Implemented in `src/app/inbound_handler.rs` (lines 207-289).
 [^8]: Implemented in `src/app/envelope.rs` (lines 11-172).
 [^9]: Implemented in `src/frame/metadata.rs` (lines 1-40).
 [^10]: Implemented in `src/message.rs` (lines 4-41).
@@ -865,7 +2540,7 @@ call these helpers to maintain consistent telemetry.[^6][^7][^31][^20]
 [^18]: Implemented in `src/server/runtime.rs` (lines 90-233).
 [^19]: Implemented in `src/server/runtime.rs` (lines 240-333).
 [^20]: Implemented in `src/server/config/preamble.rs` (lines 14-135) and
-    `src/server/connection.rs` (lines 1-222).
+    `src/server/connection_spawner.rs` (lines 1-222).
 [^21]: Implemented in `src/server/error.rs` (lines 7-18).
 [^23]: Implemented in `src/push/queues/mod.rs` (lines 41-190).
 [^24]: Implemented in `src/push/queues/errors.rs` (lines 7-28).
@@ -892,5 +2567,32 @@ call these helpers to maintain consistent telemetry.[^6][^7][^31][^20]
 [^45]: Implemented in `src/request.rs`.
 [^46]: See ADR 0002 for design rationale:
     `docs/adr/0002-streaming-requests-and-shared-message-assembly.md`.
+[^47]: Client preamble support implemented in `src/client/builder.rs`
+    (lines 288-566) and `src/client/mod.rs` (callback types).
+[^48]: Client lifecycle hooks implemented in `src/client/hooks.rs`,
+    `src/client/builder.rs` (lifecycle methods), and `src/client/runtime.rs`
+    (hook invocation). Behaviour-driven development (BDD) tests in
+    `tests/features/client_lifecycle.feature`.
+
+[^49]: Implemented in `src/app/envelope.rs` (`Packet::is_stream_terminator`)
+    and `src/client/response_stream.rs` (terminator detection in
+    `ResponseStream::poll_next`).
+[^50]: See Section 3.1 of the
+    [streaming design](multi-packet-and-streaming-responses-design.md) for
+    back-pressure architecture.
+[^51]: Implemented in `src/client/response_stream.rs` (correlation
+    validation) and `src/client/error.rs`
+    (`ClientError::StreamCorrelationMismatch`). Once terminated, the stream
+    returns `None` per the fused-stream convention.
+
+[^52]: Client request hooks implemented in `src/client/hooks.rs`
+    (`BeforeSendHook`, `AfterReceiveHook`, `RequestHooks`),
+    `src/client/builder/request_hooks.rs` (builder methods), and
+    `src/client/messaging.rs` (hook invocation). BDD tests in
+    `tests/features/client_request_hooks.feature`.
+
+[^53]: Implemented in `src/client/send_streaming.rs`. See
+    [ADR 0002](adr-002-streaming-requests-and-shared-message-assembly.md),
+    Section 4, for design rationale.
 
 [adr-0002-ref]: adr/0002-streaming-requests-and-shared-message-assembly.md

--- a/docs/wireframe-users-guide.md
+++ b/docs/wireframe-users-guide.md
@@ -159,6 +159,64 @@ helpers `send_response` and `send_response_framed` (or
 variants when encoding or I/O fails, and the connection closes after ten
 consecutive deserialization errors.[^6][^7]
 
+### App factories
+
+`WireframeServer::new` accepts an app factory rather than a pre-built
+`WireframeApp`. The server calls that factory for each accepted connection so
+handlers, middleware state, and connection-scoped resources can be assembled
+at connection start.
+
+Wireframe models this through two traits:
+
+- `AppFactory<Ser, Ctx, E, Codec>` describes the callable factory.
+- `FactoryResult<App>` marks valid return types from the factory.
+
+An infallible factory returns a `WireframeApp` directly:
+
+```rust,no_run
+use wireframe::app::{Envelope, WireframeApp};
+use wireframe::server::WireframeServer;
+
+fn app_factory() -> WireframeApp<(), (), Envelope> {
+    WireframeApp::default()
+}
+
+let server = WireframeServer::new(app_factory);
+```
+
+A fallible factory returns `Result<WireframeApp, E>`, allowing setup failures
+to propagate without panicking:
+
+```rust,no_run
+use std::sync::Arc;
+
+use argon2::Argon2;
+use wireframe::app::{Envelope, WireframeApp};
+use wireframe::server::WireframeServer;
+
+#[derive(Debug, thiserror::Error)]
+enum AppFactoryError {
+    #[error("missing connection metadata")]
+    MissingMetadata,
+}
+
+fn app_factory(
+    argon2: Arc<Argon2<'static>>,
+) -> impl Fn() -> Result<WireframeApp<(), (), Envelope>, AppFactoryError> {
+    move || {
+        let _shared_hasher = Arc::clone(&argon2);
+        Ok(WireframeApp::default())
+    }
+}
+
+let server = WireframeServer::new(app_factory(Arc::new(Argon2::default())));
+```
+
+When a fallible factory returns `Err`, Wireframe surfaces that error through
+the server runtime instead of aborting via `panic!`. Use this pattern when app
+construction depends on connection metadata, negotiated protocol state, or
+other per-connection prerequisites that can legitimately fail.
+
 ### Custom frame codecs
 
 Custom protocols supply a `FrameCodec` implementation to describe their framing

--- a/docs/wireframe-users-guide.md
+++ b/docs/wireframe-users-guide.md
@@ -2684,7 +2684,7 @@ call these helpers to maintain consistent telemetry.[^6][^7][^31][^20]
     `tests/features/client_request_hooks.feature`.
 
 [^53]: Implemented in `src/client/send_streaming.rs`. See
-    [ADR 0002](adr-002-streaming-requests-and-shared-message-assembly.md),
+    [ADR 0002][adr-0002-ref],
     Section 4, for design rationale.
 
-[adr-0002-ref]: adr/0002-streaming-requests-and-shared-message-assembly.md
+[adr-0002-ref]: docs/adr/0002-streaming-requests-and-shared-message-assembly.md

--- a/docs/wireframe-users-guide.md
+++ b/docs/wireframe-users-guide.md
@@ -797,7 +797,7 @@ When the `metrics` feature is enabled, codec errors increment the
 `wireframe_codec_errors_total` counter with `error_type` and `recovery_policy`
 labels:
 
-```text
+```plaintext
 wireframe_codec_errors_total{error_type="framing",recovery_policy="drop"} 5
 wireframe_codec_errors_total{error_type="eof",recovery_policy="disconnect"} 2
 ```

--- a/docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md
@@ -398,7 +398,7 @@ Two new types are exported from `wireframe::app`:
 Two new builder methods on `WireframeApp`:
 
 - `memory_budgets(MemoryBudgets)` – set explicit limits. When set, the runtime
-  enforces a soft read-pacing threshold at 75% of the limit and aborts the
+  enforces a soft read-pacing threshold at 80% of the limit and aborts the
   connection on breach.
 - `enable_fragmentation()` – enable fragmentation with codec-derived defaults,
   replacing the previous manual `fragmentation(Some(config))` call for common
@@ -1042,7 +1042,7 @@ classDiagram
     }
 
     class PooledClientLease {
-        <<Deref_to_WireframeClient>>
+        <<forwards_to_WireframeClient>>
         -client: WireframeClient
         +call(request: Envelope) Result~Response~
         +send(frame: Frame) Result~()~
@@ -1136,8 +1136,10 @@ in-flight limit. The lease delegates the call through to the underlying
 `WireframeClient`, which exchanges frames with the server. Dropping the lease
 returns the socket to the pool for reuse.*
 
-`PoolHandle` is cheaply cloneable. `PooledClientLease` implements `Deref` to
-`WireframeClient` for one-off calls via `call`, `send`, and `receive`.
+`PoolHandle` is cheaply cloneable. `PooledClientLease` forwards common request
+methods (`call`, `send`, `receive`) to the underlying `WireframeClient` for
+one-off calls. The lease is cheaply cloneable and does not expose a direct
+`WireframeClient` reference.
 
 ### Request hooks
 

--- a/docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md
@@ -1,0 +1,1193 @@
+# v0.2.0 to v0.3.0 migration guide
+
+This guide summarizes the breaking changes and new capabilities that must be
+addressed when migrating from wireframe v0.2.0 to v0.3.0.
+
+## Contents
+
+### Breaking changes
+
+- [Cargo feature changes](#cargo-feature-changes)
+- [Unified error surface](#unified-error-surface)
+- [Root re-exports removed](#root-re-exports-removed)
+- [Payload accessor renames](#payload-accessor-renames)
+- [BackoffConfig spelling update](#backoffconfig-spelling-update)
+- [Serializer trait bounds](#serializer-trait-bounds)
+- [WireframeApp construction](#wireframeapp-construction)
+- [Server factory trait](#server-factory-trait)
+- [AppDataStore module](#new-appdatastore-module)
+- [Message assembler type additions](#message-assembler-type-additions)
+
+### New capabilities
+
+- [Memory budget configuration](#memory-budget-configuration)
+- [Codec improvements](#codec-improvements)
+- [Testkit module](#testkit-module)
+- [wireframe\_testing additions](#wireframe_testing-additions)
+- [Client: streaming, pooling, hooks, tracing](#client-new-capabilities)
+
+Server and protocol type overview for v0.3.0: unified error surface,
+WireframeApp configuration, server factory traits, message assembler types, and
+serializer trait bounds.
+
+```mermaid
+classDiagram
+    class WireframeError~E~ {
+        +DuplicateRoute code: u32
+        +Io error: std_io_Error
+        +Protocol error: E
+        +Codec error: CodecError
+    }
+
+    class Result~T~ {
+        <<type alias>>
+    }
+
+    class CodecError {
+    }
+
+    class WireframeApp {
+        +memory_budgets: MemoryBudgets
+        +new() Result~WireframeApp~
+        +memory_budgets(budgets: MemoryBudgets) WireframeApp
+        +enable_fragmentation() WireframeApp
+    }
+
+    class MemoryBudgets {
+        +per_message: BudgetBytes
+        +per_connection: BudgetBytes
+        +in_flight: BudgetBytes
+        +new(per_message: BudgetBytes, per_connection: BudgetBytes, in_flight: BudgetBytes) MemoryBudgets
+    }
+
+    class BudgetBytes {
+        +value: NonZeroUsize
+        +new(value: NonZeroUsize) BudgetBytes
+    }
+
+    class AppFactory~Ser, Ctx, E, Codec~ {
+        <<trait>>
+        +call() R
+    }
+
+    class FactoryResult~App~ {
+        <<trait>>
+    }
+
+    class WireframeServer {
+        +new(factory: AppFactory) WireframeServer
+        +bind(addr: SocketAddr) Result~BoundServer~
+        +run_with_shutdown(signal: ShutdownSignal) Result~()~
+    }
+
+    class AppDataStore {
+    }
+
+    class EnvelopeId {
+        +value: u32
+    }
+
+    class CorrelationId {
+        +value: u64
+    }
+
+    class AssembledMessage {
+        +routing: EnvelopeRouting
+    }
+
+    class EnvelopeRouting {
+        +envelope_id: EnvelopeId
+        +correlation_id: CorrelationId
+    }
+
+    class BackoffConfig {
+        +normalized() BackoffConfig
+    }
+
+    class PacketParts {
+        +into_payload() Bytes
+    }
+
+    class FragmentParts {
+        +into_payload() Bytes
+    }
+
+    class Serializer~S~ {
+        <<trait>>
+        +serialize(message: EncodeWith~S~) Result~Vec_u8~~
+        +deserialize(bytes: &[u8]) Result~DecodeWith~S~~
+    }
+
+    class EncodeWith~S~ {
+        <<trait>>
+        +encode_with(serializer: S) Result~Vec_u8~~
+    }
+
+    class DecodeWith~S~ {
+        <<trait>>
+        +decode_with(serializer: S, bytes: &[u8]) Result~Self~
+    }
+
+    class SerdeSerializerBridge {
+        <<trait>>
+    }
+
+    class SerdeMessage~T~ {
+    }
+
+    WireframeError --> CodecError
+    Result --> WireframeError
+
+    WireframeApp --> MemoryBudgets
+    MemoryBudgets --> BudgetBytes
+
+    AppFactory ..|> Fn
+    AppFactory ..> FactoryResult
+    WireframeServer --> AppFactory
+    FactoryResult <|.. WireframeApp
+    FactoryResult <|.. Result
+
+    AssembledMessage --> EnvelopeRouting
+    EnvelopeRouting --> EnvelopeId
+    EnvelopeRouting --> CorrelationId
+
+    AppDataStore ..> WireframeApp
+
+    Serializer --> EncodeWith
+    Serializer --> DecodeWith
+    SerdeMessage ..> SerdeSerializerBridge
+```
+
+*Class diagram: overview of server and protocol types changed in v0.3.0.
+`WireframeError<E>` unifies the error surface with four variants; `Result<T>`
+aliases it. `WireframeApp` gains `memory_budgets` and `enable_fragmentation`
+builder methods, with `MemoryBudgets` grouping three `BudgetBytes` dimensions.
+`WireframeServer` binds an `AppFactory` (blanket-implemented for closures
+satisfying `FactoryResult`) and runs with a shutdown signal. `AssembledMessage`
+carries `EnvelopeRouting` with typed `EnvelopeId` and `CorrelationId` wrappers.
+`Serializer<S>` now requires `EncodeWith<S>` and `DecodeWith<S>` bounds;
+`SerdeMessage<T>` bridges Serde types via `SerdeSerializerBridge`.*
+
+## Cargo feature changes
+
+Three features are new. One is removed.
+
+- New feature: `pool` – connection pooling via `bb8`. Required for
+  `WireframeClientPool` and its supporting types.
+- New feature: `testkit` – downstream testing utilities. Replaces ad-hoc
+  test scaffolding. See [Testkit module](#testkit-module).
+- New feature: `serializer-serde` – Serde bridge for `SerdeMessage` and
+  `IntoSerdeMessage`.
+- Removed feature: `test-helpers`. Use `test-support` instead (announced in
+  the [v0.1.0 → v0.2.0 migration guide](v0-1-0-to-v0-2-0-migration-guide.md);
+  the deprecated alias is now gone).
+
+```toml
+# Before
+[dependencies]
+wireframe = { version = "0.2.0", features = ["test-helpers"] }
+
+# After
+[dependencies]
+wireframe = { version = "0.3.0", features = ["test-support"] }
+
+# For pooling
+wireframe = { version = "0.3.0", features = ["pool"] }
+
+# For testing utilities
+wireframe = { version = "0.3.0", features = ["testkit"] }
+```
+
+## Unified error surface
+
+`wireframe` now exposes one canonical error type: `wireframe::WireframeError<E>`,
+defined in `wireframe::error`. The two previous error types are gone.
+
+- `wireframe::app::error::WireframeError` is removed.
+- `wireframe::response::WireframeError` is removed.
+- `wireframe::Result<T>` now resolves to `wireframe::error::Result<T>` and is
+  re-exported at the crate root.
+
+```rust
+// Before
+use wireframe::app::error::WireframeError as AppError;
+use wireframe::response::WireframeError as StreamError;
+
+// After
+use wireframe::WireframeError;
+use wireframe::Result;
+```
+
+The unified `WireframeError<E>` carries four variants:
+
+- `DuplicateRoute(u32)` – setup-time route conflict.
+- `Io(std::io::Error)` – transport failure.
+- `Protocol(E)` – protocol-defined logical error.
+- `Codec(CodecError)` – codec-layer error with structured context.
+
+## Root re-exports removed
+
+The crate root now exposes only `wireframe::Result<T>` and
+`wireframe::WireframeError<E>`. Every other type is still available through its
+owning public module – those modules are all `pub mod` at the crate root and
+their contents have not been removed from the public API. What changed is that
+the convenience re-exports at the crate root are gone. Update import paths to
+reference the module directly rather than the root shorthand.
+
+The most common moves:
+
+| Removed root path | New path |
+| --- | --- |
+| `wireframe::BincodeSerializer`, `wireframe::Serializer` | `wireframe::serializer::{BincodeSerializer, Serializer}` |
+| `wireframe::ConnectionActor` | `wireframe::connection::ConnectionActor` |
+| `wireframe::CorrelatableFrame` | `wireframe::correlation::CorrelatableFrame` |
+| `wireframe::ConnectionContext`, `wireframe::ProtocolHooks`, `wireframe::WireframeProtocol` | `wireframe::hooks::{ConnectionContext, ProtocolHooks, WireframeProtocol}` |
+| `wireframe::ClientCodecConfig`, `wireframe::ClientError`, `wireframe::WireframeClient` | `wireframe::client::{...}` |
+| `wireframe::CodecError`, `wireframe::DefaultRecoveryPolicy`, `wireframe::RecoveryConfig` | `wireframe::codec::{...}` |
+| `wireframe::FrameStream`, `wireframe::Response` | `wireframe::response::{FrameStream, Response}` |
+| `wireframe::ConnectionId`, `wireframe::SessionRegistry` | `wireframe::session::{ConnectionId, SessionRegistry}` |
+| `wireframe::RequestParts`, `wireframe::RequestBodyStream` | `wireframe::request::{RequestParts, RequestBodyStream}` |
+
+The full list of moved types is in the
+[v0.1.0 → v0.2.0 migration guide](v0-1-0-to-v0-2-0-migration-guide.md).
+That list now takes effect.
+
+`wireframe::prelude::*` provides an optional convenience import for
+high-frequency types. It is intentionally small; prefer direct module imports
+for specialized APIs.
+
+```rust
+// Convenience import
+use wireframe::prelude::*;
+
+// Explicit equivalent
+use wireframe::{
+    app::{Envelope, Handler, Middleware, WireframeApp},
+    error::{Result, WireframeError},
+    message::{DecodeWith, EncodeWith, Message},
+    response::Response,
+    serializer::{BincodeSerializer, Serializer},
+};
+```
+
+## Payload accessor renames
+
+The consuming payload methods were renamed to follow Rust idioms. The old names
+are gone.
+
+- `PacketParts::payload(self)` → `PacketParts::into_payload(self)`
+- `FragmentParts::payload(self)` → `FragmentParts::into_payload(self)`
+
+```rust
+// Before
+let packet_payload = packet_parts.payload();
+let fragment_payload = fragment_parts.payload();
+
+// After
+let packet_payload = packet_parts.into_payload();
+let fragment_payload = fragment_parts.into_payload();
+```
+
+## BackoffConfig spelling update
+
+The configuration builder method was updated to the en-GB-oxendict `-ize`
+suffix. The old spelling is gone.
+
+- Old name: `BackoffConfig::normalised`
+- New name: `BackoffConfig::normalized`
+
+```rust
+use std::time::Duration;
+
+use wireframe::server::BackoffConfig;
+
+let config = BackoffConfig {
+    initial_delay: Duration::from_millis(50),
+    max_delay: Duration::from_secs(5),
+}
+.normalized();
+```
+
+## Serializer trait bounds
+
+`Serializer::serialize` and `Serializer::deserialize` now require message types
+to implement `EncodeWith<S>` and `DecodeWith<S>` respectively.
+
+Any type implementing `wireframe::message::Message` (i.e. deriving
+`bincode::Encode` and `bincode::BorrowDecode`) receives these impls via blanket
+implementations and requires no change.
+
+Custom serializer implementations must implement `EncodeWith<S>` and
+`DecodeWith<S>` for their message types rather than relying on
+`bincode::Encode` bounds directly.
+
+```rust
+// Before – custom serializer impl relied on bincode bounds directly
+impl<M: bincode::Encode> EncodeHelper<M> for MySerializer { ... }
+
+// After – implement EncodeWith<S> for message types
+impl EncodeWith<MySerializer> for MyMessage {
+    fn encode_with(
+        &self,
+        serializer: &MySerializer,
+    ) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+        serializer.serialize(self)
+    }
+}
+```
+
+A `SerdeSerializerBridge` trait (behind the `serializer-serde` feature) and
+the `SerdeMessage<T>` wrapper provide a path for Serde-derived types without
+implementing `bincode::Encode`.
+
+## WireframeApp construction
+
+`WireframeApp::new()` now returns `Result<Self>` for forward compatibility.
+The call currently always succeeds, but the return type must be handled.
+
+```rust
+// Before
+let app = WireframeApp::new();
+
+// After
+let app = WireframeApp::new()?;
+// or
+let app = WireframeApp::new().expect("app construction failed");
+```
+
+## Server factory trait
+
+The server previously required factories to be bare `Fn() -> WireframeApp`
+closures. The requirement is now expressed through two public traits:
+
+- `AppFactory<Ser, Ctx, E, Codec>` – the factory trait. Blanket-implemented
+  for any `Fn() -> R where R: FactoryResult`.
+- `FactoryResult<App>` – marks valid return types. Implemented for both
+  `WireframeApp` and `Result<WireframeApp, _>`.
+
+Factories returning `WireframeApp` directly continue to work without change.
+The new `Result<WireframeApp, _>` return path enables factories to surface
+initialization errors without panicking.
+
+```rust
+use wireframe::server::WireframeServer;
+
+// Infallible factory – closure returning WireframeApp; unchanged from v0.2.0
+WireframeServer::new(|| build_app())
+    .bind(addr)?
+    .run_with_shutdown(shutdown_signal)
+    .await?;
+
+// Fallible factory (new capability) – closure may return Result; init errors
+// propagate without panicking inside the factory
+WireframeServer::new(|| build_app_or_fail())
+    .bind(addr)?
+    .run_with_shutdown(shutdown_signal)
+    .await?;
+```
+
+## Memory budget configuration
+
+Per-connection inbound buffering limits are now configurable on `WireframeApp`.
+Two new types are exported from `wireframe::app`:
+
+- `MemoryBudgets` – groups three byte-cap dimensions: per-message, per-
+  connection, and aggregate in-flight.
+- `BudgetBytes` – non-zero byte-count wrapper used by `MemoryBudgets`.
+
+Two new builder methods on `WireframeApp`:
+
+- `memory_budgets(MemoryBudgets)` – set explicit limits. When set, the runtime
+  enforces a soft read-pacing threshold at 75% of the limit and aborts the
+  connection on breach.
+- `enable_fragmentation()` – enable fragmentation with codec-derived defaults,
+  replacing the previous manual `fragmentation(Some(config))` call for common
+  cases.
+
+```rust
+use std::num::NonZeroUsize;
+
+use wireframe::app::{BudgetBytes, MemoryBudgets, WireframeApp};
+
+let per_msg  = BudgetBytes::new(NonZeroUsize::new(64 * 1024).unwrap());
+let per_conn = BudgetBytes::new(NonZeroUsize::new(512 * 1024).unwrap());
+let in_flight = BudgetBytes::new(NonZeroUsize::new(256 * 1024).unwrap());
+
+let app = WireframeApp::new()?
+    .memory_budgets(MemoryBudgets::new(per_msg, per_conn, in_flight))
+    .enable_fragmentation();
+```
+
+When `memory_budgets` is not set, the runtime applies derived defaults scaled
+from the frame codec's `max_frame_length`. Soft-pressure read pacing and hard-
+cap enforcement are both active by default.
+
+## New: AppDataStore module
+
+`wireframe::app_data_store::AppDataStore` is now a standalone module rather
+than an embedded type. Import paths must be updated.
+
+```rust
+// Before – AppDataStore was embedded in the app module
+use wireframe::app::AppDataStore;
+
+// After
+use wireframe::app_data_store::AppDataStore;
+```
+
+## Message assembler type additions
+
+Two newtypes are now exported from `wireframe::message_assembler`:
+
+- `EnvelopeId(u32)` – typed wrapper for envelope identifiers.
+- `CorrelationId(u64)` – typed wrapper for correlation identifiers.
+
+`AssembledMessage` now carries routing metadata via an `EnvelopeRouting` field.
+Code constructing `AssembledMessage` directly must be updated to supply this
+field.
+
+## Codec improvements
+
+`FrameCodec` gains one new method with a default implementation:
+
+```rust
+fn frame_payload_bytes(frame: &Self::Frame) -> Bytes {
+    Bytes::copy_from_slice(Self::frame_payload(frame))
+}
+```
+
+The default copies the slice returned by `frame_payload` into a new `Bytes`
+buffer. Codecs whose frame type stores the payload as `Bytes` internally can
+override the method to avoid that allocation.
+
+`LengthDelimitedFrameCodec` overrides `frame_payload_bytes` to return
+`frame.clone()` – a reference-count increment rather than a copy.
+
+No existing codec implementation is required to change. The method is purely
+additive.
+
+```rust
+// Override in a custom codec when Frame wraps Bytes directly.
+impl FrameCodec for MyCodec {
+    type Frame = Bytes;
+
+    fn frame_payload(frame: &Bytes) -> &[u8] { frame }
+
+    fn frame_payload_bytes(frame: &Bytes) -> Bytes { frame.clone() }
+
+    fn wrap_payload(&self, payload: Bytes) -> Bytes { payload }
+
+    fn max_frame_length(&self) -> usize { self.limit }
+}
+```
+
+## Testkit module
+
+Testing infrastructure overview: the wireframe::testkit module (drive helpers,
+slow-IO simulation, assembly assertions) and the wireframe_testing companion
+crate (WireframePair, ObservabilityHandle, HotlineFixtures).
+
+```mermaid
+classDiagram
+    class TestkitModule {
+        <<module wireframe::testkit>>
+    }
+
+    class WireframeApp {
+    }
+
+    class TestSerializer {
+    }
+
+    class TestResult~T~ {
+        <<type alias>>
+    }
+
+    class TestError {
+    }
+
+    class SlowIoConfig {
+        +payload_chunk_size: usize
+        +frame_delay: Duration
+    }
+
+    class SlowIoPacing {
+        +interval: Duration
+    }
+
+    class MessageAssemblySnapshot {
+    }
+
+    class FragmentReassemblySnapshot {
+    }
+
+    class TestkitHelpers {
+        +drive_with_partial_frames(app: WireframeApp, frames: Vec~Bytes~)
+        +drive_with_fragments(app: WireframeApp, fragments: Vec~Bytes~)
+        +drive_with_fragment_frames(app: WireframeApp, frames: Vec~Bytes~)
+        +drive_with_slow_frames(app: WireframeApp, config: SlowIoConfig)
+        +drive_with_slow_payloads(app: WireframeApp, config: SlowIoConfig)
+        +assert_message_assembly_completed(snapshot: MessageAssemblySnapshot)
+        +assert_fragment_reassembly_error(snapshot: FragmentReassemblySnapshot)
+    }
+
+    class WireframePair {
+        +client_mut() WireframeClient_ref_mut
+        +local_addr() SocketAddr
+        +shutdown() TestResult~()~
+    }
+
+    class WireframeClient {
+    }
+
+    class ObservabilityHandle {
+        +new() ObservabilityHandle
+        +clear() void
+        +recorder() MetricsRecorder
+        +snapshot() void
+        +codec_error_counter(kind: &str, action: &str) u64
+    }
+
+    class Labels {
+        +with_label(key: &str, value: &str) Labels
+    }
+
+    class MetricsRecorder {
+    }
+
+    class HotlineFrameCodec {
+    }
+
+    class HotlineFixtures {
+        +valid_hotline_wire(payload: Bytes, transaction_id: u32) Bytes
+        +valid_hotline_frame(payload: Bytes, transaction_id: u32) HotlineFrame
+        +oversized_hotline_wire(max_frame_length: usize) Bytes
+        +mismatched_total_size_wire(payload: Bytes) Bytes
+        +truncated_hotline_header() Bytes
+        +truncated_hotline_payload(payload_len: usize) Bytes
+        +correlated_hotline_wire(transaction_id: u32, payloads: Vec~Bytes~) Bytes
+        +sequential_hotline_wire(base_transaction_id: u32, payloads: Vec~Bytes~) Bytes
+        +new_test_codec() HotlineFrameCodec
+    }
+
+    class HotlineFrame {
+    }
+
+    class Bytes {
+    }
+
+    class WireframeTestingCrate {
+        <<crate wireframe_testing>>
+    }
+
+    TestkitModule --> WireframeApp
+    TestkitModule --> TestSerializer
+    TestkitModule --> TestResult
+    TestkitModule --> TestError
+    TestkitModule --> SlowIoConfig
+    TestkitModule --> SlowIoPacing
+    TestkitModule --> MessageAssemblySnapshot
+    TestkitModule --> FragmentReassemblySnapshot
+    TestkitModule --> TestkitHelpers
+
+    WireframeTestingCrate --> WireframePair
+    WireframeTestingCrate --> ObservabilityHandle
+    WireframeTestingCrate --> Labels
+    WireframeTestingCrate --> HotlineFixtures
+
+    WireframePair --> WireframeClient
+
+    ObservabilityHandle --> MetricsRecorder
+    ObservabilityHandle --> Labels
+
+    HotlineFixtures --> HotlineFrame
+    HotlineFixtures --> HotlineFrameCodec
+    HotlineFixtures --> Bytes
+```
+
+*Class diagram: two complementary testing layers. The `wireframe::testkit`
+module (behind the `testkit` feature) provides in-process drive helpers for
+partial frames, fragments, and slow I/O, plus `TestSerializer`, `TestResult`,
+`TestError`, and assembly snapshot assertion helpers. The `wireframe_testing`
+companion crate provides `WireframePair` (real loopback server–client pair),
+`ObservabilityHandle` (log + metrics capture with atomic snapshot semantics),
+`Labels`, and `HotlineFixtures` (codec regression fixtures and `new_test_codec`).*
+
+`wireframe::testkit` (behind the `testkit` Cargo feature) provides optional
+test utilities for downstream protocol crates. The module is not available in
+normal builds.
+
+Capabilities include:
+
+- Frame and fragment drive helpers (`drive_with_partial_frames`,
+  `drive_with_fragments`, `drive_with_fragment_frames`, and variants) for
+  feeding partial or fragmented data into an in-process app.
+- Slow I/O simulation (`drive_with_slow_frames`, `drive_with_slow_payloads`,
+  `SlowIoConfig`, `SlowIoPacing`) for back-pressure testing without needing
+  real network delay.
+- Assembly assertion helpers (`assert_message_assembly_completed`,
+  `assert_fragment_reassembly_error`, and the full `MessageAssemblySnapshot` /
+  `FragmentReassemblySnapshot` families) for verifying assembly and
+  reassembly outcomes without panicking.
+- `TestSerializer` – a minimal serializer for use in tests.
+- `TestResult` and `TestError` – ergonomic result types for test functions.
+
+```toml
+[dev-dependencies]
+wireframe = { version = "0.3.0", features = ["testkit"] }
+```
+
+## wireframe_testing additions
+
+The `wireframe_testing` companion crate gained three new areas of test
+infrastructure. These are relevant to protocol crates that already depend on
+`wireframe_testing` in `dev-dependencies`.
+
+### In-process server–client pair harness
+
+`wireframe_testing::client_pair` provides `WireframePair`, a test harness that
+starts a real `WireframeServer` bound to a loopback TCP listener and connects a
+`WireframeClient` inside the same test process. Both sides communicate over a
+real loopback socket, keeping compatibility assertions honest while remaining
+fast and deterministic.
+
+```rust
+use wireframe::app::WireframeApp;
+use wireframe_testing::{TestResult, client_pair::spawn_wireframe_pair};
+
+async fn example() -> TestResult<()> {
+    let mut pair = spawn_wireframe_pair(
+        || WireframeApp::default(),
+        |builder| builder.max_frame_length(2048),
+    )
+    .await?;
+
+    let addr = pair.local_addr();
+    assert!(addr.port() > 0);
+
+    pair.shutdown().await?;
+    Ok(())
+}
+```
+
+`WireframePair::client_mut()` exposes the connected `WireframeClient` for
+request/response assertions. The pair's `Drop` implementation sends a shutdown
+signal and waits up to 100 milliseconds for the server task before aborting it.
+
+`spawn_wireframe_pair_default` is a convenience variant that uses
+`WireframeClientBuilder::new()` without any builder customization.
+
+### Observability harness
+
+`wireframe_testing::observability` provides `ObservabilityHandle`, a unified
+guard that combines log capture with metrics recording.
+
+```rust
+use wireframe_testing::ObservabilityHandle;
+
+let mut obs = ObservabilityHandle::new();
+obs.clear();
+
+metrics::with_local_recorder(obs.recorder(), || {
+    wireframe::metrics::inc_codec_error("framing", "drop");
+});
+
+obs.snapshot();
+assert_eq!(
+    obs.codec_error_counter("framing", "drop"),
+    1
+);
+```
+
+`obs_handle()` is an `rstest` fixture that constructs a handle directly.
+`Labels` provides a builder for label pairs used with `ObservabilityHandle::
+counter`.
+
+The handle's `snapshot()` method drains counters atomically. Query after
+`snapshot()`; earlier values are not retained.
+
+Metric-emitting code must run on the same thread as the handle. Async tests
+should use `#[tokio::test(flavor = "current_thread")]`.
+
+### Codec-aware test helpers
+
+A family of codec-aware helpers handles the encode → transport → decode
+pipeline so test authors pass raw payloads and receive decoded frames without
+manual framing.
+
+- `drive_with_codec_frames(app, codec, payloads)` – encode payloads with
+  `codec`, drive the server, and return decoded response frames.
+- `drive_with_codec_payloads(app, codec, payloads)` – as above but returns
+  decoded payload byte vectors.
+- `decode_frames_with_codec(codec, bytes)` – decode a raw byte sequence
+  into typed frames using the codec's decoder.
+- `encode_payloads_with_codec(codec, payloads)` – encode payload vectors
+  into wire bytes.
+- `extract_payloads(codec, frames)` – extract payload bytes from a slice
+  of decoded frames.
+
+Hotline protocol fixtures are available for codec regression tests:
+
+- `valid_hotline_wire(payload, transaction_id)` – well-formed wire bytes.
+- `valid_hotline_frame(payload, transaction_id)` – a typed `HotlineFrame`
+  without the wire-encode/decode cycle.
+- `oversized_hotline_wire(max_frame_length)` – triggers the
+  `"payload too large"` decoder error.
+- `mismatched_total_size_wire(payload)` – triggers `"invalid total size"`.
+- `truncated_hotline_header()` – fewer than 20 bytes; produces a
+  `"bytes remaining"` error at EOF.
+- `truncated_hotline_payload(payload_len)` – header claims more payload
+  than present; produces a `"bytes remaining"` error at EOF.
+- `correlated_hotline_wire(transaction_id, payloads)` – multiple frames
+  sharing one transaction identifier.
+- `sequential_hotline_wire(base_transaction_id, payloads)` – frames with
+  incrementing transaction identifiers.
+
+`new_test_codec()` returns a `HotlineFrameCodec` at the standard
+`TEST_MAX_FRAME` limit for use in parametrized tests.
+
+## Client: new capabilities
+
+The wireframe client now covers three domains that had no prior API surface:
+streaming, connection pooling, and structured observability.
+
+Client API type overview: WireframeClientBuilder construction paths,
+WireframeClient streaming methods, ResponseStream and TypedResponseStream
+iteration, outbound streaming types, and TracingConfig with hook closures.
+
+```mermaid
+classDiagram
+    class WireframeClient {
+        +call(request: Envelope) Result~Response~
+        +call_streaming(request: Envelope) Result~ResponseStream~
+        +receive_streaming(correlation_id: CorrelationId) Result~ResponseStream~
+        +send_streaming(header: FrameHeader, reader: AsyncRead, config: SendStreamingConfig) Result~SendStreamingOutcome~
+    }
+
+    class ResponseStream {
+        <<futures::Stream>>
+        -client: &mut WireframeClient
+        +try_next() Result~Option~Frame~~
+    }
+
+    class StreamingResponseExt {
+        <<trait>>
+        +typed_with(mapper: Mapper) TypedResponseStream
+    }
+
+    class TypedResponseStream~S, Mapper, P, Item~ {
+        <<futures::Stream>>
+        -inner: S
+        -mapper: Mapper
+        +try_next() Result~Option~Item~~
+    }
+
+    class SendStreamingConfig {
+        +chunk_size: Option~usize~
+        +timeout: Option~Duration~
+        +with_chunk_size(size: usize) SendStreamingConfig
+        +with_timeout(timeout: Duration) SendStreamingConfig
+    }
+
+    class SendStreamingOutcome {
+        +frames_sent() usize
+        +bytes_sent() usize
+    }
+
+    class WireframeClientBuilder {
+        +before_send(f: FnMutableVecU8) WireframeClientBuilder
+        +after_receive(f: FnMutableBytesMut) WireframeClientBuilder
+        +tracing_config(config: TracingConfig) WireframeClientBuilder
+        +connect(addr: SocketAddr) Result~WireframeClient~
+        +connect_pool(addr: SocketAddr, config: ClientPoolConfig) Result~WireframeClientPool~
+    }
+
+    class TracingConfig {
+        +with_all_levels(level: Level) TracingConfig
+        +with_all_timing(enabled: bool) TracingConfig
+        +with_call_level(level: Level) TracingConfig
+        +with_send_timing(enabled: bool) TracingConfig
+        +with_streaming_level(level: Level) TracingConfig
+    }
+
+    class FnMutableVecU8 {
+        <<closure>>
+        +call(bytes: Vec_u8_ref_mut)
+    }
+
+    class FnMutableBytesMut {
+        <<closure>>
+        +call(bytes: BytesMut_ref_mut)
+    }
+
+    class Envelope {
+    }
+
+    class FrameHeader {
+    }
+
+    class Frame {
+    }
+
+    class AsyncRead {
+        <<trait>>
+    }
+
+    class Response {
+    }
+
+    class ClientPoolConfig {
+    }
+
+    class WireframeClientPool {
+    }
+
+    WireframeClient --> ResponseStream
+    WireframeClient --> SendStreamingConfig
+    WireframeClient --> SendStreamingOutcome
+
+    ResponseStream --> WireframeClient
+
+    StreamingResponseExt <|.. ResponseStream
+    StreamingResponseExt --> TypedResponseStream
+    TypedResponseStream --> ResponseStream
+
+    WireframeClientBuilder --> WireframeClient
+    WireframeClientBuilder --> WireframeClientPool
+    WireframeClientBuilder --> ClientPoolConfig
+    WireframeClientBuilder --> TracingConfig
+    WireframeClientBuilder --> FnMutableVecU8
+    WireframeClientBuilder --> FnMutableBytesMut
+
+    SendStreamingConfig --> SendStreamingOutcome
+```
+
+*Class diagram: `WireframeClientBuilder` is the entry point for all client
+construction – it connects to a `WireframeClient` or a `WireframeClientPool`,
+and accepts `TracingConfig`, `before_send`, and `after_receive` hooks. A
+`WireframeClient` produces a `ResponseStream` for inbound streaming (which
+implements `StreamingResponseExt`, enabling conversion to a
+`TypedResponseStream`) and drives `send_streaming` via `SendStreamingConfig`,
+yielding a `SendStreamingOutcome`.*
+
+### Streaming responses
+
+> **Scope note.** This section covers the **client-side consumption** API:
+> how a `WireframeClient` receives and iterates over multi-frame server
+> responses. Server-side multi-packet response production – where handlers
+> return a `(mpsc::Sender, Response)` tuple and use helpers such as
+> `Response::with_channel` – is a distinct concern governed by
+> [ADR 0001](adr-001-multi-packet-streaming-response-api.md).
+
+`WireframeClient` gains two new call methods for multi-frame responses:
+
+- `call_streaming(envelope)` – assigns a correlation identifier, sends the
+  request, and returns a `ResponseStream` that yields typed frames until the
+  server sends a stream terminator.
+- `receive_streaming(correlation_id)` – the lower-level variant for callers
+  that have already sent the request via `send` or `send_envelope` and hold
+  the correlation identifier. Returns a `ResponseStream` that validates every
+  inbound frame against that identifier.
+
+`ResponseStream` implements `futures::Stream` with `Item = Result<P,
+ClientError>`. It holds an exclusive borrow of the client for the duration of
+the stream, preventing concurrent sends. The terminator frame is consumed
+internally and the stream returns `None` once it arrives.
+
+```rust
+use std::net::SocketAddr;
+
+use futures::StreamExt;
+use wireframe::{
+    app::Envelope,
+    client::{ClientError, WireframeClient},
+};
+
+let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+let mut client = WireframeClient::builder().connect(addr).await?;
+
+let request = Envelope::new(1, None, vec![]);
+let mut stream = client.call_streaming::<Envelope>(request).await?;
+
+while let Some(result) = stream.next().await {
+    let frame = result?;
+    process_frame(frame);
+}
+```
+
+Sequence diagram showing the call_streaming lifecycle: sending the request,
+iterating frames via try_next until the server sends a terminator, then
+releasing the exclusive client borrow when the stream is dropped.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Client as WireframeClient
+    participant Server as WireframeServer
+    participant Stream as ResponseStream
+
+    User->>Client: call_streaming(envelope)
+    Client->>Server: send request frame(s)
+    Server-->>Client: stream response frames
+    Client-->>User: ResponseStream
+
+    loop consume stream
+        User->>Stream: try_next()
+        Stream->>Client: poll_next_frame()
+        Client->>Server: receive next frame
+        Server-->>Client: next frame or terminator
+        Client-->>Stream: frame or None
+        Stream-->>User: frame or None
+    end
+
+    User->>Stream: drop ResponseStream
+    Stream->>Client: release exclusive borrow
+```
+
+*Sequence diagram: `call_streaming` sends the request and returns a
+`ResponseStream` that holds an exclusive borrow of the client. Each `try_next()`
+call polls the client for the next server frame; the loop continues until the
+server sends a terminator, at which point the stream returns `None`. Dropping
+the `ResponseStream` releases the borrow, making the client available for
+further calls.*
+
+`StreamingResponseExt` is a trait on any `Stream` of response frames. It
+provides `typed_with(mapper)`, which produces a `TypedResponseStream<S, Mapper,
+P, Item>` that translates raw frames into domain values and skips control
+frames where the mapper returns `Ok(None)`.
+
+```rust
+use wireframe::client::StreamingResponseExt;
+
+let typed_stream = raw_stream.typed_with(|frame| {
+    if is_data_frame(&frame) {
+        Ok(Some(decode_payload(frame)?))
+    } else {
+        Ok(None) // skip control frames
+    }
+});
+```
+
+### Outbound streaming sends
+
+`WireframeClient::send_streaming` sends a large body as a sequence of
+protocol-framed chunks, reading from any `AsyncRead` source.
+
+`SendStreamingConfig` controls chunk sizing and timeout. When chunk size is
+not set, it is derived from `max_frame_length - frame_header.len()`.
+
+```rust
+use std::time::Duration;
+
+use wireframe::client::SendStreamingConfig;
+
+let config = SendStreamingConfig::default()
+    .with_chunk_size(4096)
+    .with_timeout(Duration::from_secs(30));
+
+let outcome = client
+    .send_streaming(&frame_header, body_reader, config)
+    .await?;
+
+println!("sent {} frames", outcome.frames_sent());
+```
+
+### Connection pooling
+
+`WireframeClientPool` (behind the `pool` feature) provides warm, reusable
+sockets with per-socket in-flight admission control.
+
+Build a pool from `WireframeClientBuilder::connect_pool`. The pool manages
+socket lifecycle, idle eviction, and fair waiter scheduling.
+
+```rust
+use wireframe::client::{
+    ClientPoolConfig, PoolFairnessPolicy, WireframeClientBuilder,
+};
+
+let pool = WireframeClientBuilder::new()
+    .with_preamble(preamble)
+    .connect_pool(
+        addr,
+        ClientPoolConfig::default()
+            .pool_size(4)
+            .max_in_flight_per_socket(8)
+            .idle_timeout(Duration::from_secs(30))
+            .fairness_policy(PoolFairnessPolicy::RoundRobin),
+    )
+    .await?;
+
+// Acquire a lease and make a request.
+let handle = pool.handle();
+let lease = handle.acquire().await?;
+let response: MyResponse = lease.call(request_envelope).await?;
+```
+
+Connection pool type hierarchy: WireframeClientBuilder creates a
+WireframeClientPool via ClientPoolConfig, vending PoolHandle instances that
+yield PooledClientLease objects delegating to WireframeClient.
+
+```mermaid
+classDiagram
+    class WireframeClientBuilder {
+        +connect_pool(addr: SocketAddr, config: ClientPoolConfig) Result~WireframeClientPool~
+    }
+
+    class WireframeClientPool {
+        +handle() PoolHandle
+    }
+
+    class PoolHandle {
+        +acquire() Result~PooledClientLease~
+    }
+
+    class PooledClientLease {
+        <<Deref_to_WireframeClient>>
+        -client: WireframeClient
+        +call(request: Envelope) Result~Response~
+        +send(frame: Frame) Result~()~
+        +receive() Result~Frame~
+    }
+
+    class ClientPoolConfig {
+        +pool_size(value: usize) ClientPoolConfig
+        +max_in_flight_per_socket(value: usize) ClientPoolConfig
+        +idle_timeout(timeout: Duration) ClientPoolConfig
+        +fairness_policy(policy: PoolFairnessPolicy) ClientPoolConfig
+    }
+
+    class PoolFairnessPolicy {
+        <<enum>>
+        +RoundRobin
+        +Lifo
+    }
+
+    class WireframeClient {
+        +call(request: Envelope) Result~Response~
+    }
+
+    class Envelope {
+    }
+
+    class Response {
+    }
+
+    class Frame {
+    }
+
+    WireframeClientBuilder --> ClientPoolConfig
+    WireframeClientBuilder --> WireframeClientPool
+
+    WireframeClientPool --> PoolHandle
+    PoolHandle --> PooledClientLease
+
+    PooledClientLease --> WireframeClient
+
+    ClientPoolConfig --> PoolFairnessPolicy
+```
+
+*Class diagram: `WireframeClientBuilder` creates a `WireframeClientPool` using a
+`ClientPoolConfig` (which selects a `PoolFairnessPolicy`). The pool vends
+`PoolHandle` instances; each handle yields a `PooledClientLease` on `acquire()`.
+`PooledClientLease` derefs to `WireframeClient`, exposing `call`, `send`, and
+`receive` for individual requests.*
+
+Sequence diagram showing the connection pool usage flow: building the pool,
+acquiring a PoolHandle, checking out a PooledClientLease, making a request, and
+returning the socket to the pool on drop.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Builder as WireframeClientBuilder
+    participant Pool as WireframeClientPool
+    participant Handle as PoolHandle
+    participant Lease as PooledClientLease
+    participant Client as WireframeClient
+    participant Server as WireframeServer
+
+    User->>Builder: connect_pool(addr, ClientPoolConfig)
+    Builder->>Pool: create pool with sockets
+    Pool-->>User: WireframeClientPool
+
+    User->>Pool: handle()
+    Pool-->>Handle: PoolHandle
+
+    User->>Handle: acquire()
+    Handle->>Pool: acquire_socket()
+    Pool-->>Handle: PooledClientLease
+    Handle-->>User: PooledClientLease
+
+    User->>Lease: call(request_envelope)
+    Lease->>Client: call(request_envelope)
+    Client->>Server: send request
+    Server-->>Client: send response
+    Client-->>Lease: Response
+    Lease-->>User: Response
+
+    User->>Lease: drop lease
+    Lease->>Pool: return client to pool
+```
+
+*Sequence diagram: `connect_pool` builds the pool and returns it to the caller.
+`handle()` produces a cheaply-cloneable `PoolHandle`; `acquire()` checks out a
+`PooledClientLease` from the pool, blocking if all sockets are at their
+in-flight limit. The lease delegates the call through to the underlying
+`WireframeClient`, which exchanges frames with the server. Dropping the lease
+returns the socket to the pool for reuse.*
+
+`PoolHandle` is cheaply cloneable. `PooledClientLease` implements `Deref` to
+`WireframeClient` for one-off calls via `call`, `send`, and `receive`.
+
+### Request hooks
+
+Two per-frame hook types are now available on `WireframeClientBuilder`. Hooks
+fire on every request or response frame, independent of connection lifecycle.
+
+- `before_send(f: impl Fn(&mut Vec<u8>))` – called after serialization, before
+  each frame is written to the socket. Use for authentication token prepending,
+  request metrics, or frame inspection.
+- `after_receive(f: impl Fn(&mut BytesMut))` – called after each frame is read,
+  before deserialization. Use for logging, response metrics, or decryption.
+
+Multiple hooks may be registered; they execute in registration order.
+
+```rust
+use wireframe::client::WireframeClientBuilder;
+
+let client = WireframeClientBuilder::new()
+    .before_send(|bytes: &mut Vec<u8>| {
+        bytes.splice(0..0, auth_token());
+    })
+    .after_receive(|bytes: &mut bytes::BytesMut| {
+        record_frame_size(bytes.len());
+    })
+    .connect(addr)
+    .await?;
+```
+
+### Structured tracing
+
+`TracingConfig` controls which client operations emit tracing spans, at what
+level, and whether per-operation elapsed-time events are recorded.
+
+The default configuration emits `INFO` spans for lifecycle operations (`connect`,
+`close`) and `DEBUG` spans for data operations (`send`, `receive`, `call`,
+`call_streaming`). Timing is disabled by default.
+
+```rust
+use tracing::Level;
+use wireframe::client::{TracingConfig, WireframeClientBuilder};
+
+let client = WireframeClientBuilder::new()
+    .tracing_config(
+        TracingConfig::default()
+            .with_all_levels(Level::DEBUG)
+            .with_all_timing(true),
+    )
+    .connect(addr)
+    .await?;
+```
+
+Individual operations can be configured separately using methods such as
+`with_call_level`, `with_send_timing`, and `with_streaming_level`.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -190,6 +190,67 @@ fn parse_login_params(payload: &[u8]) -> Result<LoginCredentials, TransactionErr
     })
 }
 
+/// Parse `NewsCategoryNameList` payload fields.
+fn parse_news_category_name_list_params(
+    payload: &[u8],
+    header: FrameHeader,
+) -> Result<Command, TransactionError> {
+    let params = decode_params_map(payload)?;
+    let path = first_param_string(&params, FieldId::NewsPath)?;
+    Ok(Command::GetNewsCategoryNameList { path, header })
+}
+
+/// Parse `NewsArticleNameList` payload fields.
+fn parse_news_article_name_list_params(
+    payload: &[u8],
+    header: FrameHeader,
+) -> Result<Command, TransactionError> {
+    let params = decode_params_map(payload)?;
+    let path = required_param_string(&params, FieldId::NewsPath)?;
+    Ok(Command::GetNewsArticleNameList { path, header })
+}
+
+/// Parse `NewsArticleData` payload fields.
+fn parse_news_article_data_params(
+    payload: &[u8],
+    header: FrameHeader,
+) -> Result<Command, TransactionError> {
+    let params = decode_params_map(payload)?;
+    let path = required_param_string(&params, FieldId::NewsPath)?;
+    let article_id = required_param_i32(&params, FieldId::NewsArticleId)?;
+    Ok(Command::GetNewsArticleData {
+        path,
+        article_id,
+        header,
+    })
+}
+
+/// Parse `PostNewsArticle` payload fields.
+///
+/// `NewsArticleFlags` (field 334): `0` = normal post; bit flags may indicate
+/// locked/announcement status per Hotline protocol.
+fn parse_post_news_article_params(
+    payload: &[u8],
+    header: FrameHeader,
+) -> Result<Command, TransactionError> {
+    let params = decode_params_map(payload)?;
+    let path = required_param_string(&params, FieldId::NewsPath)?;
+    let title = required_param_string(&params, FieldId::NewsTitle)?;
+    let flags = first_param_i32(&params, FieldId::NewsArticleFlags)?.unwrap_or(0);
+    let data_flavor = required_param_string(&params, FieldId::NewsDataFlavor)?;
+    let data = required_param_string(&params, FieldId::NewsArticleData)?;
+    Ok(Command::PostNewsArticle {
+        req: PostArticleRequest {
+            path,
+            title,
+            flags,
+            data_flavor,
+            data,
+        },
+        header,
+    })
+}
+
 impl Command {
     /// Convert a [`Transaction`] into a [`Command`].
     ///
@@ -213,50 +274,16 @@ impl Command {
             }
             TransactionType::GetFileNameList => Ok(Self::GetFileNameList { header: tx.header }),
             TransactionType::NewsCategoryNameList => {
-                let params = decode_params_map(&tx.payload)?;
-                let path = first_param_string(&params, FieldId::NewsPath)?;
-                Ok(Self::GetNewsCategoryNameList {
-                    path,
-                    header: tx.header,
-                })
+                parse_news_category_name_list_params(&tx.payload, tx.header)
             }
             TransactionType::NewsArticleNameList => {
-                let params = decode_params_map(&tx.payload)?;
-                let path = required_param_string(&params, FieldId::NewsPath)?;
-                Ok(Self::GetNewsArticleNameList {
-                    path,
-                    header: tx.header,
-                })
+                parse_news_article_name_list_params(&tx.payload, tx.header)
             }
             TransactionType::NewsArticleData => {
-                let params = decode_params_map(&tx.payload)?;
-                let path = required_param_string(&params, FieldId::NewsPath)?;
-                let id = required_param_i32(&params, FieldId::NewsArticleId)?;
-                Ok(Self::GetNewsArticleData {
-                    path,
-                    article_id: id,
-                    header: tx.header,
-                })
+                parse_news_article_data_params(&tx.payload, tx.header)
             }
             TransactionType::PostNewsArticle => {
-                let params = decode_params_map(&tx.payload)?;
-                let path = required_param_string(&params, FieldId::NewsPath)?;
-                let title = required_param_string(&params, FieldId::NewsTitle)?;
-                // NewsArticleFlags (field 334): 0 = normal post; bit flags may indicate
-                // locked/announcement status per Hotline protocol.
-                let flags = first_param_i32(&params, FieldId::NewsArticleFlags)?.unwrap_or(0);
-                let data_flavor = required_param_string(&params, FieldId::NewsDataFlavor)?;
-                let data = required_param_string(&params, FieldId::NewsArticleData)?;
-                Ok(Self::PostNewsArticle {
-                    req: PostArticleRequest {
-                        path,
-                        title,
-                        flags,
-                        data_flavor,
-                        data,
-                    },
-                    header: tx.header,
-                })
+                parse_post_news_article_params(&tx.payload, tx.header)
             }
             _ => Ok(Self::Unknown { header: tx.header }),
         }

--- a/src/server/wireframe/mod.rs
+++ b/src/server/wireframe/mod.rs
@@ -27,6 +27,7 @@
 )]
 
 use std::{
+    fmt::Display,
     io::{self, Write},
     net::{Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
     sync::Arc,
@@ -34,8 +35,9 @@ use std::{
 
 use anyhow::{Context, Result, anyhow};
 use argon2::Argon2;
+use thiserror::Error;
 use tokio::sync::Mutex as TokioMutex;
-use tracing::{error, warn};
+use tracing::warn;
 use wireframe::{
     app::{Envelope, Handler, WireframeApp},
     serializer::BincodeSerializer,
@@ -68,6 +70,18 @@ use crate::{
 };
 
 type HotlineApp = WireframeApp<BincodeSerializer, (), Envelope, HotlineFrameCodec>;
+
+#[derive(Debug, Error)]
+enum AppFactoryError {
+    #[error("missing handshake context in app factory")]
+    MissingHandshakeContext,
+    #[error("peer address missing in app factory")]
+    MissingPeerAddress,
+    #[error("failed to build wireframe application: {0}")]
+    BuildApplication(String),
+}
+
+fn anyhow_from_error(error: impl Display) -> anyhow::Error { anyhow!(error.to_string()) }
 
 /// Parse CLI arguments and start the Wireframe runtime.
 ///
@@ -163,46 +177,30 @@ fn build_app_for_connection(
     pool: &DbPool,
     argon2: &Arc<Argon2<'static>>,
     outbound_registry: &Arc<WireframeOutboundRegistry>,
-) -> HotlineApp {
-    build_app_with_logging(pool, argon2, outbound_registry)
-}
-
-fn build_app_with_logging(
-    pool: &DbPool,
-    argon2: &Arc<Argon2<'static>>,
-    outbound_registry: &Arc<WireframeOutboundRegistry>,
-) -> HotlineApp {
-    match try_build_app(pool, argon2, outbound_registry) {
-        Ok(app) => app,
-        Err(err) => {
-            error!(error = %err, "failed to build wireframe application");
-            fallback_app()
-        }
-    }
+) -> std::result::Result<HotlineApp, AppFactoryError> {
+    try_build_app(pool, argon2, outbound_registry)
 }
 
 fn try_build_app(
     pool: &DbPool,
     argon2: &Arc<Argon2<'static>>,
     outbound_registry: &Arc<WireframeOutboundRegistry>,
-) -> Result<HotlineApp> {
-    let build_context = build_app_context(pool, argon2, outbound_registry)
-        .context("failed to build wireframe app context")?;
-    build_app(build_context).context("failed to build wireframe application")
+) -> std::result::Result<HotlineApp, AppFactoryError> {
+    let build_context = build_app_context(pool, argon2, outbound_registry)?;
+    build_app(build_context).map_err(|error| AppFactoryError::BuildApplication(error.to_string()))
 }
 
 fn build_app_context<'a>(
     pool: &'a DbPool,
     argon2: &'a Arc<Argon2<'static>>,
     outbound_registry: &'a Arc<WireframeOutboundRegistry>,
-) -> Result<AppBuildContext<'a>> {
+) -> std::result::Result<AppBuildContext<'a>, AppFactoryError> {
     // Missing connection context indicates handshake setup failed; abort the
     // connection rather than running without routing state. Returning a
     // degraded app would accept traffic with broken routing and state.
-    let context = take_current_context()
-        .ok_or_else(|| anyhow!("missing handshake context in app factory"))?;
+    let context = take_current_context().ok_or(AppFactoryError::MissingHandshakeContext)?;
     let (handshake, peer) = context.into_parts();
-    let peer = peer.ok_or_else(|| anyhow!("peer address missing in app factory"))?;
+    let peer = peer.ok_or(AppFactoryError::MissingPeerAddress)?;
     let compat = Arc::new(XorCompatibility::from_handshake(&handshake));
     let client_compat = Arc::new(ClientCompatibility::from_handshake(&handshake));
     Ok(AppBuildContext {
@@ -282,11 +280,11 @@ fn validate_app_factory(
             &HandshakeMetadata::default(),
         )),
     };
-    build_app(build_context).context("failed to register routes or middleware")?;
+    build_app(build_context)
+        .map_err(anyhow_from_error)
+        .context("failed to register routes or middleware")?;
     Ok(())
 }
-
-fn fallback_app() -> HotlineApp { HotlineApp::default() }
 
 fn routing_placeholder_handler() -> Handler<Envelope> {
     // Wireframe requires a handler per route; transaction middleware owns replies.

--- a/src/server/wireframe/mod.rs
+++ b/src/server/wireframe/mod.rs
@@ -27,7 +27,6 @@
 )]
 
 use std::{
-    fmt::Display,
     io::{self, Write},
     net::{Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
     sync::Arc,
@@ -77,11 +76,9 @@ enum AppFactoryError {
     MissingHandshakeContext,
     #[error("peer address missing in app factory")]
     MissingPeerAddress,
-    #[error("failed to build wireframe application: {0}")]
-    BuildApplication(String),
+    #[error("failed to build wireframe application")]
+    BuildApplication(#[source] anyhow::Error),
 }
-
-fn anyhow_from_error(error: impl Display) -> anyhow::Error { anyhow!(error.to_string()) }
 
 /// Parse CLI arguments and start the Wireframe runtime.
 ///
@@ -187,7 +184,8 @@ fn try_build_app(
     outbound_registry: &Arc<WireframeOutboundRegistry>,
 ) -> std::result::Result<HotlineApp, AppFactoryError> {
     let build_context = build_app_context(pool, argon2, outbound_registry)?;
-    build_app(build_context).map_err(|error| AppFactoryError::BuildApplication(error.to_string()))
+    build_app(build_context)
+        .map_err(|e| AppFactoryError::BuildApplication(anyhow!("wireframe error: {e}")))
 }
 
 fn build_app_context<'a>(
@@ -281,7 +279,7 @@ fn validate_app_factory(
         )),
     };
     build_app(build_context)
-        .map_err(anyhow_from_error)
+        .map_err(|e| anyhow!("failed to build wireframe application: {e}"))
         .context("failed to register routes or middleware")?;
     Ok(())
 }

--- a/src/server/wireframe/mod.rs
+++ b/src/server/wireframe/mod.rs
@@ -184,8 +184,7 @@ fn try_build_app(
     outbound_registry: &Arc<WireframeOutboundRegistry>,
 ) -> std::result::Result<HotlineApp, AppFactoryError> {
     let build_context = build_app_context(pool, argon2, outbound_registry)?;
-    build_app(build_context)
-        .map_err(|e| AppFactoryError::BuildApplication(anyhow!("wireframe error: {e}")))
+    map_build_application_result(build_app(build_context))
 }
 
 fn build_app_context<'a>(
@@ -260,6 +259,12 @@ fn build_app(context: AppBuildContext<'_>) -> wireframe::app::Result<HotlineApp>
     ROUTE_IDS
         .iter()
         .try_fold(app, |app, id| app.route(*id, handler.clone()))
+}
+
+fn map_build_application_result(
+    result: wireframe::app::Result<HotlineApp>,
+) -> std::result::Result<HotlineApp, AppFactoryError> {
+    result.map_err(|e| AppFactoryError::BuildApplication(anyhow!("wireframe error: {e}")))
 }
 
 fn validate_app_factory(

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -7,12 +7,14 @@ use std::{
 
 use argon2::Argon2;
 use rstest::{fixture, rstest};
+use tokio::runtime::Builder;
 
 use super::*;
 use crate::wireframe::{
     connection::{
         ConnectionContext,
         HandshakeMetadata,
+        scope_current_context,
         store_current_context,
         take_current_context,
     },
@@ -83,13 +85,20 @@ fn app_factory_builds_when_handshake_context_is_present() {
     let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
     let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5500));
     let context = ConnectionContext::new(HandshakeMetadata::default()).with_peer(peer);
-    store_current_context(context);
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build current-thread runtime");
 
-    let app = build_app_for_connection(&pool, &argon2, &outbound_registry);
+    runtime.block_on(scope_current_context(None, async {
+        store_current_context(context);
 
-    assert!(app.is_ok());
-    assert!(
-        take_current_context().is_none(),
-        "per-connection context must be consumed by the app factory"
-    );
+        let app = build_app_for_connection(&pool, &argon2, &outbound_registry);
+
+        assert!(app.is_ok());
+        assert!(
+            take_current_context().is_none(),
+            "per-connection context must be consumed by the app factory"
+        );
+    }));
 }

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -66,6 +66,16 @@ fn bootstrap_captures_bind(bound_config: AppConfig) {
 fn run_factory_with_stored_context(
     stored: Option<ConnectionContext>,
 ) -> std::result::Result<HotlineApp, AppFactoryError> {
+    run_factory_with_stored_context_and_assertions(stored, || {})
+}
+
+fn run_factory_with_stored_context_and_assertions<F>(
+    stored: Option<ConnectionContext>,
+    assertions: F,
+) -> std::result::Result<HotlineApp, AppFactoryError>
+where
+    F: FnOnce(),
+{
     let pool = dummy_pool();
     let argon2 = Arc::new(Argon2::default());
     let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
@@ -81,7 +91,9 @@ fn run_factory_with_stored_context(
                 let _ = take_current_context();
             }
         }
-        build_app_for_connection(&pool, &argon2, &outbound_registry)
+        let app = build_app_for_connection(&pool, &argon2, &outbound_registry);
+        assertions();
+        app
     }))
 }
 
@@ -95,27 +107,17 @@ fn app_factory_rejects_missing_handshake_context() {
 
 #[rstest]
 fn app_factory_builds_when_handshake_context_is_present() {
-    let pool = dummy_pool();
-    let argon2 = Arc::new(Argon2::default());
-    let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
     let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5500));
     let context = ConnectionContext::new(HandshakeMetadata::default()).with_peer(peer);
-    let runtime = Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("build current-thread runtime");
 
-    runtime.block_on(scope_current_context(None, async {
-        store_current_context(context);
-
-        let app = build_app_for_connection(&pool, &argon2, &outbound_registry);
-
-        assert!(app.is_ok());
+    let app = run_factory_with_stored_context_and_assertions(Some(context), || {
         assert!(
             take_current_context().is_none(),
             "per-connection context must be consumed by the app factory"
         );
-    }));
+    });
+
+    assert!(app.is_ok());
 }
 
 #[rstest]

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -1,8 +1,23 @@
 //! Unit tests for the wireframe server bootstrap.
 
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
+};
+
+use argon2::Argon2;
 use rstest::{fixture, rstest};
 
 use super::*;
+use crate::wireframe::{
+    connection::{
+        ConnectionContext,
+        HandshakeMetadata,
+        store_current_context,
+        take_current_context,
+    },
+    test_helpers::dummy_pool,
+};
 
 #[fixture]
 fn bound_config() -> AppConfig {
@@ -43,4 +58,32 @@ fn bootstrap_captures_bind(bound_config: AppConfig) {
         "127.0.0.1:7777".parse().expect("valid socket address")
     );
     assert_eq!(bootstrap.config.bind, "127.0.0.1:7777");
+}
+
+#[rstest]
+fn app_factory_rejects_missing_handshake_context() {
+    let pool = dummy_pool();
+    let argon2 = Arc::new(Argon2::default());
+    let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
+
+    let Err(err) = build_app_for_connection(&pool, &argon2, &outbound_registry) else {
+        panic!("missing context must fail closed");
+    };
+
+    assert!(err.to_string().contains("missing handshake context"));
+}
+
+#[rstest]
+fn app_factory_builds_when_handshake_context_is_present() {
+    let pool = dummy_pool();
+    let argon2 = Arc::new(Argon2::default());
+    let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
+    let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 5500));
+    let context = ConnectionContext::new(HandshakeMetadata::default()).with_peer(peer);
+    store_current_context(context);
+
+    let app = build_app_for_connection(&pool, &argon2, &outbound_registry);
+    let _ = take_current_context();
+
+    assert!(app.is_ok());
 }

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -63,8 +63,9 @@ fn bootstrap_captures_bind(bound_config: AppConfig) {
     assert_eq!(bootstrap.config.bind, "127.0.0.1:7777");
 }
 
-#[rstest]
-fn app_factory_rejects_missing_handshake_context() {
+fn run_factory_with_stored_context(
+    stored: Option<ConnectionContext>,
+) -> std::result::Result<HotlineApp, AppFactoryError> {
     let pool = dummy_pool();
     let argon2 = Arc::new(Argon2::default());
     let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
@@ -74,14 +75,22 @@ fn app_factory_rejects_missing_handshake_context() {
         .expect("build current-thread runtime");
 
     runtime.block_on(scope_current_context(None, async {
-        let _ = take_current_context();
+        match stored {
+            Some(ctx) => store_current_context(ctx),
+            None => {
+                let _ = take_current_context();
+            }
+        }
+        build_app_for_connection(&pool, &argon2, &outbound_registry)
+    }))
+}
 
-        let Err(AppFactoryError::MissingHandshakeContext) =
-            build_app_for_connection(&pool, &argon2, &outbound_registry)
-        else {
-            panic!("missing context must fail closed with the proper error variant");
-        };
-    }));
+#[rstest]
+fn app_factory_rejects_missing_handshake_context() {
+    let Err(AppFactoryError::MissingHandshakeContext) = run_factory_with_stored_context(None)
+    else {
+        panic!("missing context must fail closed with the proper error variant");
+    };
 }
 
 #[rstest]
@@ -111,24 +120,11 @@ fn app_factory_builds_when_handshake_context_is_present() {
 
 #[rstest]
 fn app_factory_rejects_missing_peer_address() {
-    let pool = dummy_pool();
-    let argon2 = Arc::new(Argon2::default());
-    let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
     let context = ConnectionContext::new(HandshakeMetadata::default());
-    let runtime = Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("build current-thread runtime");
-
-    runtime.block_on(scope_current_context(None, async {
-        store_current_context(context);
-
-        let Err(AppFactoryError::MissingPeerAddress) =
-            build_app_for_connection(&pool, &argon2, &outbound_registry)
-        else {
-            panic!("missing peer address must fail closed with the proper error variant");
-        };
-    }));
+    let Err(AppFactoryError::MissingPeerAddress) = run_factory_with_stored_context(Some(context))
+    else {
+        panic!("missing peer address must fail closed with the proper error variant");
+    };
 }
 
 #[rstest]

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -62,6 +62,9 @@ fn bootstrap_captures_bind(bound_config: AppConfig) {
 
 #[rstest]
 fn app_factory_rejects_missing_handshake_context() {
+    // Clear any leftover handshake context from previous tests
+    let _ = take_current_context();
+
     let pool = dummy_pool();
     let argon2 = Arc::new(Argon2::default());
     let outbound_registry = Arc::new(WireframeOutboundRegistry::default());

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -64,18 +64,23 @@ fn bootstrap_captures_bind(bound_config: AppConfig) {
 
 #[rstest]
 fn app_factory_rejects_missing_handshake_context() {
-    // Clear any leftover handshake context from previous tests
-    let _ = take_current_context();
-
     let pool = dummy_pool();
     let argon2 = Arc::new(Argon2::default());
     let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build current-thread runtime");
 
-    let Err(AppFactoryError::MissingHandshakeContext) =
-        build_app_for_connection(&pool, &argon2, &outbound_registry)
-    else {
-        panic!("missing context must fail closed with the proper error variant");
-    };
+    runtime.block_on(scope_current_context(None, async {
+        let _ = take_current_context();
+
+        let Err(AppFactoryError::MissingHandshakeContext) =
+            build_app_for_connection(&pool, &argon2, &outbound_registry)
+        else {
+            panic!("missing context must fail closed with the proper error variant");
+        };
+    }));
 }
 
 #[rstest]

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -66,11 +66,11 @@ fn app_factory_rejects_missing_handshake_context() {
     let argon2 = Arc::new(Argon2::default());
     let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
 
-    let Err(err) = build_app_for_connection(&pool, &argon2, &outbound_registry) else {
-        panic!("missing context must fail closed");
+    let Err(AppFactoryError::MissingHandshakeContext) =
+        build_app_for_connection(&pool, &argon2, &outbound_registry)
+    else {
+        panic!("missing context must fail closed with the proper error variant");
     };
-
-    assert!(err.to_string().contains("missing handshake context"));
 }
 
 #[rstest]
@@ -83,7 +83,10 @@ fn app_factory_builds_when_handshake_context_is_present() {
     store_current_context(context);
 
     let app = build_app_for_connection(&pool, &argon2, &outbound_registry);
-    let _ = take_current_context();
 
     assert!(app.is_ok());
+    assert!(
+        take_current_context().is_none(),
+        "per-connection context must be consumed by the app factory"
+    );
 }

--- a/src/server/wireframe/tests.rs
+++ b/src/server/wireframe/tests.rs
@@ -8,6 +8,7 @@ use std::{
 use argon2::Argon2;
 use rstest::{fixture, rstest};
 use tokio::runtime::Builder;
+use wireframe::WireframeError;
 
 use super::*;
 use crate::wireframe::{
@@ -106,4 +107,48 @@ fn app_factory_builds_when_handshake_context_is_present() {
             "per-connection context must be consumed by the app factory"
         );
     }));
+}
+
+#[rstest]
+fn app_factory_rejects_missing_peer_address() {
+    let pool = dummy_pool();
+    let argon2 = Arc::new(Argon2::default());
+    let outbound_registry = Arc::new(WireframeOutboundRegistry::default());
+    let context = ConnectionContext::new(HandshakeMetadata::default());
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build current-thread runtime");
+
+    runtime.block_on(scope_current_context(None, async {
+        store_current_context(context);
+
+        let Err(AppFactoryError::MissingPeerAddress) =
+            build_app_for_connection(&pool, &argon2, &outbound_registry)
+        else {
+            panic!("missing peer address must fail closed with the proper error variant");
+        };
+    }));
+}
+
+#[rstest]
+fn app_factory_wraps_build_application_errors() {
+    let duplicate_route = FALLBACK_ROUTE_ID;
+    let result = map_build_application_result(Err(WireframeError::DuplicateRoute(duplicate_route)));
+
+    let Err(AppFactoryError::BuildApplication(error)) = result else {
+        panic!("wireframe builder errors must be wrapped in AppFactoryError::BuildApplication");
+    };
+
+    let message = error.to_string();
+    assert!(
+        message.contains("wireframe error:"),
+        "wrapped error should include the wireframe prefix"
+    );
+    assert!(
+        message.contains(&format!(
+            "route id {duplicate_route} was already registered"
+        )),
+        "wrapped error should preserve the wireframe failure details"
+    );
 }

--- a/src/wireframe/codec/frame.rs
+++ b/src/wireframe/codec/frame.rs
@@ -109,7 +109,7 @@ impl FrameCodec for HotlineFrameCodec {
 
 #[cfg(test)]
 mod tests {
-    //! Tests cover HotlineFrameCodec payload wrapping, slice access, and frame
+    //! Tests cover `HotlineFrameCodec` payload wrapping, slice access, and frame
     //! length invariants.
 
     use bytes::Bytes;

--- a/src/wireframe/codec/frame.rs
+++ b/src/wireframe/codec/frame.rs
@@ -109,6 +109,9 @@ impl FrameCodec for HotlineFrameCodec {
 
 #[cfg(test)]
 mod tests {
+    //! Tests cover HotlineFrameCodec payload wrapping, slice access, and frame
+    //! length invariants.
+
     use bytes::Bytes;
     use wireframe::codec::FrameCodec;
 

--- a/src/wireframe/codec/frame.rs
+++ b/src/wireframe/codec/frame.rs
@@ -6,7 +6,7 @@
 
 use std::io;
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 use wireframe::{
     app::{Envelope, Packet},
@@ -82,7 +82,7 @@ impl Encoder<Vec<u8>> for HotlineFrameEncoder {
     fn encode(&mut self, item: Vec<u8>, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let (envelope, _) = Envelope::from_bytes(&item)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-        let payload = envelope.into_parts().payload();
+        let payload = envelope.into_parts().into_payload();
         let parsed = parse_transaction(&payload)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         let tx = HotlineTransaction::try_from(parsed)
@@ -102,7 +102,7 @@ impl FrameCodec for HotlineFrameCodec {
 
     fn frame_payload(frame: &Self::Frame) -> &[u8] { frame.as_slice() }
 
-    fn wrap_payload(payload: Vec<u8>) -> Self::Frame { payload }
+    fn wrap_payload(&self, payload: Bytes) -> Self::Frame { payload.to_vec() }
 
     fn max_frame_length(&self) -> usize { HEADER_LEN + MAX_FRAME_DATA }
 }

--- a/src/wireframe/codec/frame.rs
+++ b/src/wireframe/codec/frame.rs
@@ -106,3 +106,68 @@ impl FrameCodec for HotlineFrameCodec {
 
     fn max_frame_length(&self) -> usize { HEADER_LEN + MAX_FRAME_DATA }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use wireframe::codec::FrameCodec;
+
+    use super::HotlineFrameCodec;
+    use crate::transaction::{HEADER_LEN, MAX_FRAME_DATA};
+
+    #[test]
+    fn wrap_payload_converts_bytes_to_vec() {
+        let codec = HotlineFrameCodec::new();
+        let data = vec![0u8, 1u8, 2u8, 3u8, 4u8];
+        let bytes = Bytes::from(data.clone());
+
+        let frame = codec.wrap_payload(bytes);
+
+        assert_eq!(frame, data);
+    }
+
+    #[test]
+    fn wrap_payload_empty_bytes() {
+        let codec = HotlineFrameCodec::new();
+        let bytes = Bytes::new();
+
+        let frame = codec.wrap_payload(bytes);
+
+        assert!(frame.is_empty());
+    }
+
+    #[test]
+    fn frame_payload_returns_slice() {
+        let data = vec![10u8, 20u8, 30u8];
+        let slice = HotlineFrameCodec::frame_payload(&data);
+
+        assert_eq!(slice, &[10u8, 20u8, 30u8]);
+    }
+
+    #[test]
+    fn frame_payload_empty_frame() {
+        let data: Vec<u8> = Vec::new();
+        let slice = HotlineFrameCodec::frame_payload(&data);
+
+        assert!(slice.is_empty());
+    }
+
+    #[test]
+    fn max_frame_length_matches_header_plus_max_data() {
+        let codec = HotlineFrameCodec::new();
+
+        assert_eq!(codec.max_frame_length(), HEADER_LEN + MAX_FRAME_DATA);
+    }
+
+    #[test]
+    fn codec_round_trip_payload_unchanged() {
+        let codec = HotlineFrameCodec::new();
+        let original = vec![0xabu8, 0xcdu8, 0xefu8];
+        let bytes = Bytes::from(original.clone());
+
+        let frame = codec.wrap_payload(bytes);
+        let extracted = HotlineFrameCodec::frame_payload(&frame);
+
+        assert_eq!(extracted, original);
+    }
+}

--- a/src/wireframe/codec/frame.rs
+++ b/src/wireframe/codec/frame.rs
@@ -113,46 +113,38 @@ mod tests {
     //! length invariants.
 
     use bytes::Bytes;
+    use rstest::{fixture, rstest};
     use wireframe::codec::FrameCodec;
 
     use super::HotlineFrameCodec;
     use crate::transaction::{HEADER_LEN, MAX_FRAME_DATA};
 
-    #[test]
-    fn wrap_payload_converts_bytes_to_vec() {
-        let codec = HotlineFrameCodec::new();
-        let data = vec![0u8, 1u8, 2u8, 3u8, 4u8];
-        let bytes = Bytes::from(data.clone());
+    #[fixture]
+    fn codec() -> HotlineFrameCodec {
+        // Provide a fresh codec instance per rstest case.
+        HotlineFrameCodec::new()
+    }
 
+    #[rstest]
+    #[case(Bytes::from(vec![0u8, 1u8, 2u8, 3u8, 4u8]), vec![0u8, 1u8, 2u8, 3u8, 4u8])]
+    #[case(Bytes::new(), Vec::new())]
+    fn wrap_payload_cases(
+        codec: HotlineFrameCodec,
+        #[case] bytes: Bytes,
+        #[case] expected: Vec<u8>,
+    ) {
         let frame = codec.wrap_payload(bytes);
 
-        assert_eq!(frame, data);
+        assert_eq!(frame, expected);
     }
 
-    #[test]
-    fn wrap_payload_empty_bytes() {
-        let codec = HotlineFrameCodec::new();
-        let bytes = Bytes::new();
-
-        let frame = codec.wrap_payload(bytes);
-
-        assert!(frame.is_empty());
-    }
-
-    #[test]
-    fn frame_payload_returns_slice() {
-        let data = vec![10u8, 20u8, 30u8];
+    #[rstest]
+    #[case(vec![10u8, 20u8, 30u8], vec![10u8, 20u8, 30u8])]
+    #[case(Vec::new(), Vec::new())]
+    fn frame_payload_cases(#[case] data: Vec<u8>, #[case] expected: Vec<u8>) {
         let slice = HotlineFrameCodec::frame_payload(&data);
 
-        assert_eq!(slice, &[10u8, 20u8, 30u8]);
-    }
-
-    #[test]
-    fn frame_payload_empty_frame() {
-        let data: Vec<u8> = Vec::new();
-        let slice = HotlineFrameCodec::frame_payload(&data);
-
-        assert!(slice.is_empty());
+        assert_eq!(slice, expected.as_slice());
     }
 
     #[test]

--- a/src/wireframe/connection.rs
+++ b/src/wireframe/connection.rs
@@ -201,9 +201,18 @@ pub fn take_current_context() -> Option<ConnectionContext> {
     })
 }
 
+/// Return the number of connection-context entries retained in the registry.
+#[must_use]
+pub fn registry_len() -> usize {
+    registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .len()
+}
+
 /// Report whether a stored connection context entry is visible to this task.
 #[must_use]
-pub fn can_see_registry() -> bool { current_context().is_some() }
+pub fn has_current_context() -> bool { current_context().is_some() }
 
 #[cfg(test)]
 mod tests {
@@ -231,7 +240,8 @@ mod tests {
             assert_eq!(context.handshake().sub_protocol_tag(), *b"CHAT");
             let _ = take_current_context();
             assert!(current_context().is_none());
-            assert!(!can_see_registry());
+            assert!(!has_current_context());
+            assert_eq!(registry_len(), 0);
         })
         .await;
     }
@@ -276,7 +286,8 @@ mod tests {
                 .map(|context| context.handshake),
             Some(metadata(2, 2))
         );
-        assert!(!can_see_registry());
+        assert!(!has_current_context());
+        assert_eq!(registry_len(), 0);
     }
 
     #[rstest]
@@ -307,6 +318,39 @@ mod tests {
                 seen.await.expect("context task panicked"),
                 Some(ConnectionContext::new(meta))
             );
+            assert_eq!(registry_len(), 0);
         });
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn reports_registry_entry_count() {
+        let first = ConnectionContext::new(metadata(1, 1));
+        let second = ConnectionContext::new(metadata(2, 2));
+
+        let first_task = task::spawn(async move {
+            scope_current_context(None, async move {
+                store_current_context(first);
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let _ = take_current_context();
+            })
+            .await;
+        });
+
+        let second_task = task::spawn(async move {
+            scope_current_context(None, async move {
+                store_current_context(second);
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let _ = take_current_context();
+            })
+            .await;
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert_eq!(registry_len(), 2);
+
+        first_task.await.expect("first task panicked");
+        second_task.await.expect("second task panicked");
+        assert_eq!(registry_len(), 0);
     }
 }

--- a/src/wireframe/connection.rs
+++ b/src/wireframe/connection.rs
@@ -217,6 +217,7 @@ pub fn has_current_context() -> bool { current_context().is_some() }
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use serial_test::serial;
     use tokio::{runtime::Builder, sync::Barrier, task};
 
     use super::*;
@@ -241,7 +242,6 @@ mod tests {
             let _ = take_current_context();
             assert!(current_context().is_none());
             assert!(!has_current_context());
-            assert_eq!(registry_len(), 0);
         })
         .await;
     }
@@ -287,7 +287,6 @@ mod tests {
             Some(metadata(2, 2))
         );
         assert!(!has_current_context());
-        assert_eq!(registry_len(), 0);
     }
 
     #[rstest]
@@ -318,13 +317,14 @@ mod tests {
                 seen.await.expect("context task panicked"),
                 Some(ConnectionContext::new(meta))
             );
-            assert_eq!(registry_len(), 0);
         });
     }
 
     #[rstest]
     #[tokio::test]
+    #[serial]
     async fn reports_registry_entry_count() {
+        let starting_registry_len = registry_len();
         let first = ConnectionContext::new(metadata(1, 1));
         let second = ConnectionContext::new(metadata(2, 2));
 
@@ -347,10 +347,10 @@ mod tests {
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        assert_eq!(registry_len(), 2);
+        assert_eq!(registry_len(), starting_registry_len + 2);
 
         first_task.await.expect("first task panicked");
         second_task.await.expect("second task panicked");
-        assert_eq!(registry_len(), 0);
+        assert_eq!(registry_len(), starting_registry_len);
     }
 }

--- a/src/wireframe/connection.rs
+++ b/src/wireframe/connection.rs
@@ -195,16 +195,15 @@ pub fn take_current_context() -> Option<ConnectionContext> {
         .try_with(|cell| cell.borrow_mut().take())
         .ok()
         .flatten();
-    let taken = from_task_local.or_else(take_registry_context);
-    if taken.is_some() {
+    from_task_local.map_or_else(take_registry_context, |context| {
         let _ = take_registry_context();
-    }
-    taken
+        Some(context)
+    })
 }
 
-/// Return the number of stored connection context entries visible to this task.
+/// Report whether a stored connection context entry is visible to this task.
 #[must_use]
-pub fn registry_len() -> usize { usize::from(current_context().is_some()) }
+pub fn can_see_registry() -> bool { current_context().is_some() }
 
 #[cfg(test)]
 mod tests {
@@ -232,7 +231,7 @@ mod tests {
             assert_eq!(context.handshake().sub_protocol_tag(), *b"CHAT");
             let _ = take_current_context();
             assert!(current_context().is_none());
-            assert_eq!(registry_len(), 0);
+            assert!(!can_see_registry());
         })
         .await;
     }
@@ -277,7 +276,7 @@ mod tests {
                 .map(|context| context.handshake),
             Some(metadata(2, 2))
         );
-        assert_eq!(registry_len(), 0);
+        assert!(!can_see_registry());
     }
 
     #[rstest]

--- a/src/wireframe/connection.rs
+++ b/src/wireframe/connection.rs
@@ -169,11 +169,9 @@ where
 /// task can still consume it after the handshake future completes.
 pub fn store_current_context(context: ConnectionContext) {
     store_registry_context(&context);
-    match CONNECTION_CONTEXT.try_with(|cell| {
+    let _ = CONNECTION_CONTEXT.try_with(|cell| {
         cell.borrow_mut().replace(context);
-    }) {
-        Ok(()) | Err(_) => {}
-    }
+    });
 }
 
 /// Retrieve connection context metadata for the current Tokio task, if present.
@@ -327,27 +325,36 @@ mod tests {
         let starting_registry_len = registry_len();
         let first = ConnectionContext::new(metadata(1, 1));
         let second = ConnectionContext::new(metadata(2, 2));
+        let registered_barrier = std::sync::Arc::new(Barrier::new(3));
+        let release_barrier = std::sync::Arc::new(Barrier::new(3));
 
+        let first_registered_barrier = registered_barrier.clone();
+        let first_release_barrier = release_barrier.clone();
         let first_task = task::spawn(async move {
             scope_current_context(None, async move {
                 store_current_context(first);
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                first_registered_barrier.wait().await;
+                first_release_barrier.wait().await;
                 let _ = take_current_context();
             })
             .await;
         });
 
+        let second_registered_barrier = registered_barrier.clone();
+        let second_release_barrier = release_barrier.clone();
         let second_task = task::spawn(async move {
             scope_current_context(None, async move {
                 store_current_context(second);
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                second_registered_barrier.wait().await;
+                second_release_barrier.wait().await;
                 let _ = take_current_context();
             })
             .await;
         });
 
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        registered_barrier.wait().await;
         assert_eq!(registry_len(), starting_registry_len + 2);
+        release_barrier.wait().await;
 
         first_task.await.expect("first task panicked");
         second_task.await.expect("second task panicked");

--- a/src/wireframe/connection.rs
+++ b/src/wireframe/connection.rs
@@ -4,12 +4,22 @@
 //! Tokio task. During the Hotline handshake we need to retain the negotiated
 //! metadata (sub-protocol ID and sub-version) so later routing and
 //! compatibility shims can branch on the client's capabilities. This module
-//! keeps a per-task/thread store of handshake metadata and peer information so
-//! connection setup can seed the app factory with the negotiated context.
+//! keeps handshake metadata and peer information in Tokio task-local storage so
+//! connection setup can seed the app factory with the negotiated context even
+//! when Tokio migrates the task across worker threads. Wireframe's synchronous
+//! app factory runs after the handshake future resolves, so this module also
+//! mirrors the scoped value in a task-ID keyed registry for that hand-off.
 
 #![expect(clippy::big_endian_bytes, reason = "network protocol uses big-endian")]
 
-use std::net::SocketAddr;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{Mutex, OnceLock},
+};
+
+use tokio::task::{self, Id};
 
 use crate::protocol::{Handshake, VERSION};
 
@@ -99,61 +109,107 @@ impl ConnectionContext {
     }
 }
 
-#[expect(
-    clippy::missing_const_for_thread_local,
-    reason = "RefCell initialisation cannot be const for thread locals"
-)]
-mod handshake_local {
-    //! Thread-local storage for handshake metadata when task-local state is absent.
+tokio::task_local! {
+    static CONNECTION_CONTEXT: RefCell<Option<ConnectionContext>>;
+}
 
-    use std::cell::RefCell;
+fn registry() -> &'static Mutex<HashMap<Id, ConnectionContext>> {
+    static CONNECTION_CONTEXT_REGISTRY: OnceLock<Mutex<HashMap<Id, ConnectionContext>>> =
+        OnceLock::new();
+    CONNECTION_CONTEXT_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
-    thread_local! {
-        pub static CONNECTION_CONTEXT: RefCell<Option<super::ConnectionContext>> =
-            RefCell::new(None);
+fn current_task_id() -> Option<Id> { task::try_id() }
+
+fn store_registry_context(context: &ConnectionContext) {
+    if let Some(task_id) = current_task_id() {
+        registry()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(task_id, context.clone());
     }
+}
+
+fn registry_context() -> Option<ConnectionContext> {
+    let task_id = current_task_id()?;
+    registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&task_id)
+        .cloned()
+}
+
+fn take_registry_context() -> Option<ConnectionContext> {
+    let task_id = current_task_id()?;
+    registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&task_id)
+}
+
+/// Scope connection context metadata for the current Tokio task.
+///
+/// The returned future installs a task-local slot before the first poll and
+/// keeps it available for the lifetime of the scoped future.
+pub fn scope_current_context<F>(
+    context: Option<ConnectionContext>,
+    future: F,
+) -> impl std::future::Future<Output = F::Output>
+where
+    F: std::future::Future,
+{
+    CONNECTION_CONTEXT.scope(RefCell::new(context), future)
 }
 
 /// Store connection context metadata for the current Tokio task.
 ///
-/// When handshake handling runs outside a Tokio task context, the context is
-/// stored in a thread-local fallback so diagnostics and tests can still
-/// observe the negotiated values.
+/// When the current code is already running inside a scoped connection task,
+/// the task-local slot is updated immediately. The value is also mirrored into
+/// a task-ID keyed registry so synchronous app-factory code in the same Tokio
+/// task can still consume it after the handshake future completes.
 pub fn store_current_context(context: ConnectionContext) {
-    handshake_local::CONNECTION_CONTEXT.with(|cell| {
+    store_registry_context(&context);
+    match CONNECTION_CONTEXT.try_with(|cell| {
         cell.borrow_mut().replace(context);
-    });
+    }) {
+        Ok(()) | Err(_) => {}
+    }
 }
 
 /// Retrieve connection context metadata for the current Tokio task, if present.
 ///
-/// Returns `None` if no metadata has been stored for this thread/task.
+/// Returns `None` if no metadata has been stored for this task.
 #[must_use]
 pub fn current_context() -> Option<ConnectionContext> {
-    handshake_local::CONNECTION_CONTEXT.with(|cell| cell.borrow().clone())
+    CONNECTION_CONTEXT
+        .try_with(|cell| cell.borrow().clone())
+        .ok()
+        .flatten()
+        .or_else(registry_context)
 }
 
 /// Take the connection context entry for the current Tokio task.
 #[must_use]
 pub fn take_current_context() -> Option<ConnectionContext> {
-    handshake_local::CONNECTION_CONTEXT.with(|cell| cell.borrow_mut().take())
+    let from_task_local = CONNECTION_CONTEXT
+        .try_with(|cell| cell.borrow_mut().take())
+        .ok()
+        .flatten();
+    let taken = from_task_local.or_else(take_registry_context);
+    if taken.is_some() {
+        let _ = take_registry_context();
+    }
+    taken
 }
 
-/// Return the number of stored connection context entries visible to this
-/// thread.
-///
-/// This reflects only the thread-local store used by the current task/thread;
-/// entries placed in other threads are intentionally ignored, so this value is
-/// suitable for diagnostics rather than global accounting.
+/// Return the number of stored connection context entries visible to this task.
 #[must_use]
-pub fn registry_len() -> usize {
-    handshake_local::CONNECTION_CONTEXT.with(|cell| usize::from(cell.borrow().is_some()))
-}
+pub fn registry_len() -> usize { usize::from(current_context().is_some()) }
 
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use tokio::task;
+    use tokio::{runtime::Builder, sync::Barrier, task};
 
     use super::*;
 
@@ -170,12 +226,15 @@ mod tests {
     async fn stores_and_reads_metadata_in_task() {
         let meta = metadata(u32::from_be_bytes(*b"CHAT"), 7);
         let context = ConnectionContext::new(meta.clone());
-        store_current_context(context.clone());
-        assert_eq!(current_context(), Some(context.clone()));
-        assert_eq!(context.handshake().sub_protocol_tag(), *b"CHAT");
-        let _ = take_current_context();
-        assert!(current_context().is_none());
-        assert_eq!(registry_len(), 0);
+        scope_current_context(None, async {
+            store_current_context(context.clone());
+            assert_eq!(current_context(), Some(context.clone()));
+            assert_eq!(context.handshake().sub_protocol_tag(), *b"CHAT");
+            let _ = take_current_context();
+            assert!(current_context().is_none());
+            assert_eq!(registry_len(), 0);
+        })
+        .await;
     }
 
     #[rstest]
@@ -184,19 +243,25 @@ mod tests {
         let first = task::spawn(async {
             let meta = metadata(1, 1);
             let context = ConnectionContext::new(meta.clone());
-            store_current_context(context.clone());
-            let seen = current_context();
-            let _ = take_current_context();
-            seen
+            scope_current_context(None, async move {
+                store_current_context(context.clone());
+                let seen = current_context();
+                let _ = take_current_context();
+                seen
+            })
+            .await
         });
 
         let second = task::spawn(async {
             let meta = metadata(2, 2);
             let context = ConnectionContext::new(meta.clone());
-            store_current_context(context.clone());
-            let seen = current_context();
-            let _ = take_current_context();
-            seen
+            scope_current_context(None, async move {
+                store_current_context(context.clone());
+                let seen = current_context();
+                let _ = take_current_context();
+                seen
+            })
+            .await
         });
 
         let (first_seen, second_seen) = tokio::join!(first, second);
@@ -213,5 +278,36 @@ mod tests {
             Some(metadata(2, 2))
         );
         assert_eq!(registry_len(), 0);
+    }
+
+    #[rstest]
+    fn preserves_context_across_await_on_multi_worker_runtime() {
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("build multi-worker runtime");
+        let barrier = std::sync::Arc::new(Barrier::new(2));
+
+        runtime.block_on(async {
+            let meta = metadata(u32::from_be_bytes(*b"CHAT"), 9);
+            let context = ConnectionContext::new(meta.clone());
+            let task_barrier = barrier.clone();
+
+            let seen = task::spawn(async move {
+                scope_current_context(Some(context.clone()), async move {
+                    task_barrier.wait().await;
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    take_current_context()
+                })
+                .await
+            });
+
+            barrier.wait().await;
+            assert_eq!(
+                seen.await.expect("context task panicked"),
+                Some(ConnectionContext::new(meta))
+            );
+        });
     }
 }

--- a/src/wireframe/connection.rs
+++ b/src/wireframe/connection.rs
@@ -169,8 +169,8 @@ where
 /// task can still consume it after the handshake future completes.
 pub fn store_current_context(context: ConnectionContext) {
     store_registry_context(&context);
-    let _ = CONNECTION_CONTEXT.try_with(|cell| {
-        cell.borrow_mut().replace(context);
+    _ = CONNECTION_CONTEXT.try_with(|cell| {
+        let _previous_context = cell.borrow_mut().replace(context);
     });
 }
 

--- a/src/wireframe/connection.rs
+++ b/src/wireframe/connection.rs
@@ -151,14 +151,16 @@ fn take_registry_context() -> Option<ConnectionContext> {
 ///
 /// The returned future installs a task-local slot before the first poll and
 /// keeps it available for the lifetime of the scoped future.
-pub fn scope_current_context<F>(
-    context: Option<ConnectionContext>,
-    future: F,
-) -> impl std::future::Future<Output = F::Output>
+pub async fn scope_current_context<F>(context: Option<ConnectionContext>, future: F) -> F::Output
 where
     F: std::future::Future,
 {
-    CONNECTION_CONTEXT.scope(RefCell::new(context), future)
+    if let Some(seed_context) = context.as_ref() {
+        store_registry_context(seed_context);
+    }
+    CONNECTION_CONTEXT
+        .scope(RefCell::new(context), future)
+        .await
 }
 
 /// Store connection context metadata for the current Tokio task.
@@ -200,8 +202,9 @@ pub fn take_current_context() -> Option<ConnectionContext> {
 }
 
 /// Return the number of connection-context entries retained in the registry.
+#[cfg(test)]
 #[must_use]
-pub fn registry_len() -> usize {
+fn registry_len() -> usize {
     registry()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -316,6 +319,22 @@ mod tests {
                 Some(ConnectionContext::new(meta))
             );
         });
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn scopes_context_for_post_handshake_handoff() {
+        let context = ConnectionContext::new(metadata(u32::from_be_bytes(*b"CHAT"), 5));
+        let scoped_context = context.clone();
+
+        let handed_off = task::spawn(async move {
+            scope_current_context(Some(scoped_context), async {}).await;
+            take_current_context()
+        })
+        .await
+        .expect("handoff task panicked");
+
+        assert_eq!(handed_off, Some(context));
     }
 
     #[rstest]

--- a/src/wireframe/handshake.rs
+++ b/src/wireframe/handshake.rs
@@ -13,10 +13,10 @@ use futures_util::{FutureExt, future::BoxFuture};
 use tokio::net::TcpStream;
 use tracing::warn;
 use wireframe::{
-    app::{Packet, WireframeApp},
+    app::Packet,
     codec::FrameCodec,
     serializer::Serializer,
-    server::{ServerState, WireframeServer},
+    server::{AppFactory, ServerState, WireframeServer},
 };
 
 use super::preamble::HotlinePreamble;
@@ -45,7 +45,7 @@ pub fn install<F, S, Ser, Ctx, E, Codec>(
     timeout: Duration,
 ) -> WireframeServer<F, HotlinePreamble, S, Ser, Ctx, E, Codec>
 where
-    F: Fn() -> WireframeApp<Ser, Ctx, E, Codec> + Send + Sync + Clone + 'static,
+    F: AppFactory<Ser, Ctx, E, Codec>,
     S: ServerState,
     Ser: Serializer + Send + Sync,
     Ctx: Send + 'static,
@@ -128,8 +128,8 @@ mod tests {
     use rstest::rstest;
     use tokio::{io::AsyncWriteExt, net::TcpStream, sync::oneshot, time::timeout};
     use wireframe::{
-        BincodeSerializer,
         app::{Envelope, WireframeApp},
+        serializer::BincodeSerializer,
         server::WireframeServer,
     };
 

--- a/src/wireframe/handshake.rs
+++ b/src/wireframe/handshake.rs
@@ -1,10 +1,8 @@
 //! Wireframe handshake hooks for Hotline connections.
 //!
-//! This module wires the Hotline handshake semantics into the Wireframe
-//! runtime by registering preamble callbacks that emit the standard 8-byte
-//! reply and by enforcing the 5-second idle timeout defined in the protocol.
-//! The hooks are reusable so tests can inject shorter timeouts without
-//! altering production defaults.
+//! This module wires the Hotline handshake semantics into the Wireframe runtime
+//! by registering preamble callbacks that emit the standard 8-byte reply and
+//! enforce the protocol's idle timeout, with reusable hooks for tests.
 
 use std::{io, time::Duration};
 
@@ -30,15 +28,20 @@ use crate::{
         HANDSHAKE_UNSUPPORTED_VERSION_TOKEN,
         write_handshake_reply,
     },
-    wireframe::connection::{ConnectionContext, HandshakeMetadata, store_current_context},
+    wireframe::connection::{
+        ConnectionContext,
+        HandshakeMetadata,
+        scope_current_context,
+        store_current_context,
+    },
 };
 
 /// Attach Hotline handshake behaviour to a [`WireframeServer`].
 ///
 /// The returned server writes the Hotline reply on success, returns Hotline
-/// error codes on decode failures, and times out idle sockets after
-/// `timeout`. Tests may call this with a shorter duration to avoid slow
-/// sleeps, while production code should use [`crate::protocol::HANDSHAKE_TIMEOUT`].
+/// error codes on decode failures, and times out idle sockets after `timeout`.
+/// Tests may call this with a shorter duration, while production code should
+/// use [`crate::protocol::HANDSHAKE_TIMEOUT`].
 #[must_use]
 pub fn install<F, S, Ser, Ctx, E, Codec>(
     server: WireframeServer<F, HotlinePreamble, S, Ser, Ctx, E, Codec>,
@@ -62,20 +65,22 @@ fn success_handler()
 -> impl for<'a> Fn(&'a HotlinePreamble, &'a mut TcpStream) -> BoxFuture<'a, io::Result<()>> + Send + Sync
 {
     move |preamble, stream| {
-        async move {
-            let mut context = ConnectionContext::new(HandshakeMetadata::from(preamble.handshake()));
-            let peer = match stream.peer_addr() {
-                Ok(peer) => peer,
-                Err(error) => {
-                    warn!(%error, "failed to retrieve peer address during handshake");
-                    return Err(error);
-                }
-            };
-            context = context.with_peer(peer);
+        let mut context = ConnectionContext::new(HandshakeMetadata::from(preamble.handshake()));
+        match stream.peer_addr() {
+            Ok(peer) => {
+                context = context.with_peer(peer);
+            }
+            Err(error) => {
+                warn!(%error, "failed to retrieve peer address during handshake");
+                return async move { Err(error) }.boxed();
+            }
+        }
+
+        scope_current_context(Some(context.clone()), async move {
             store_current_context(context);
             write_handshake_reply(stream, HANDSHAKE_OK).await?;
             Ok(())
-        }
+        })
         .boxed()
     }
 }
@@ -157,7 +162,6 @@ mod tests {
                 .unwrap_or_default();
             WireframeApp::<BincodeSerializer, (), Envelope>::default().app_data(handshake)
         })
-        .workers(1)
         .with_preamble::<HotlinePreamble>();
         let server = super::install(server, timeout);
         let server = server
@@ -246,152 +250,5 @@ mod tests {
 }
 
 #[cfg(test)]
-mod bdd {
-    use std::{cell::RefCell, net::SocketAddr, time::Duration};
-
-    use rstest::fixture;
-    use rstest_bdd::assert_step_ok;
-    use rstest_bdd_macros::{given, scenario, then, when};
-    use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
-        net::TcpStream,
-        runtime::Runtime,
-        sync::oneshot,
-        time::timeout,
-    };
-
-    use crate::{
-        protocol::{PROTOCOL_ID, REPLY_LEN, VERSION},
-        wireframe::test_helpers::preamble_bytes,
-    };
-
-    async fn perform_handshake(
-        addr: SocketAddr,
-        bytes: Option<Vec<u8>>,
-    ) -> Result<[u8; REPLY_LEN], String> {
-        let mut stream = TcpStream::connect(addr).await.expect("connect");
-        send_handshake_bytes(&mut stream, bytes).await;
-        read_handshake_reply(&mut stream).await
-    }
-
-    async fn send_handshake_bytes(stream: &mut TcpStream, bytes: Option<Vec<u8>>) {
-        if let Some(data) = bytes {
-            stream.write_all(&data).await.expect("write handshake");
-        }
-    }
-
-    async fn read_handshake_reply(stream: &mut TcpStream) -> Result<[u8; REPLY_LEN], String> {
-        let mut buf = [0u8; REPLY_LEN];
-        timeout(Duration::from_secs(1), stream.read_exact(&mut buf))
-            .await
-            .map(|res| {
-                res.expect("read reply");
-                buf
-            })
-            .map_err(|err| err.to_string())
-    }
-
-    struct HandshakeWorld {
-        rt: Runtime,
-        addr: RefCell<Option<SocketAddr>>,
-        shutdown: RefCell<Option<oneshot::Sender<()>>>,
-        reply: RefCell<Option<Result<[u8; REPLY_LEN], String>>>,
-    }
-
-    impl HandshakeWorld {
-        fn new() -> Self {
-            Self {
-                rt: Runtime::new().expect("runtime"),
-                addr: RefCell::new(None),
-                shutdown: RefCell::new(None),
-                reply: RefCell::new(None),
-            }
-        }
-
-        fn start_server(&self) {
-            let (addr, shutdown) = self
-                .rt
-                .block_on(async { super::tests::start_server(Duration::from_millis(100)) });
-            self.addr.borrow_mut().replace(addr);
-            self.shutdown.borrow_mut().replace(shutdown);
-        }
-
-        fn connect_and_maybe_send(&self, bytes: Option<Vec<u8>>) {
-            let addr = self.addr.borrow().expect("server not started");
-            let reply = self.rt.block_on(perform_handshake(addr, bytes));
-            self.reply.borrow_mut().replace(reply);
-        }
-
-        fn reply_code(&self) -> Result<u32, String> {
-            let reply = self.reply.borrow();
-            let Some(reply) = reply.as_ref() else {
-                return Err("missing reply".into());
-            };
-            reply
-                .as_ref()
-                .map(|buf| {
-                    u32::from_be_bytes(
-                        buf[4..8]
-                            .try_into()
-                            .expect("convert reply slice to array (bdd reply)"),
-                    )
-                })
-                .map_err(ToString::to_string)
-        }
-    }
-
-    impl Drop for HandshakeWorld {
-        fn drop(&mut self) {
-            if let Some(tx) = self.shutdown.borrow_mut().take() {
-                let _ = tx.send(());
-            }
-        }
-    }
-
-    #[expect(
-        clippy::allow_attributes,
-        reason = "rustc compiler does not emit expected lint"
-    )]
-    #[allow(unused_braces, reason = "rstest-bdd macro expansion produces braces")]
-    #[fixture]
-    fn world() -> HandshakeWorld { HandshakeWorld::new() }
-
-    #[given("a wireframe server handling handshakes")]
-    fn given_server(world: &HandshakeWorld) { world.start_server(); }
-
-    #[when("I send a valid Hotline handshake")]
-    fn when_valid(world: &HandshakeWorld) {
-        let bytes = preamble_bytes(*PROTOCOL_ID, *b"CHAT", VERSION, 0);
-        world.connect_and_maybe_send(Some(bytes.to_vec()));
-    }
-
-    #[when("I send a Hotline handshake with protocol \"{tag}\" and version {version}")]
-    fn when_custom(world: &HandshakeWorld, tag: String, version: u16) {
-        let mut protocol = [0u8; 4];
-        protocol.copy_from_slice(tag.as_bytes());
-        let bytes = preamble_bytes(protocol, *b"CHAT", version, 0);
-        world.connect_and_maybe_send(Some(bytes.to_vec()));
-    }
-
-    #[when("I connect without sending a handshake")]
-    fn when_idle(world: &HandshakeWorld) { world.connect_and_maybe_send(None); }
-
-    #[then("the handshake reply code is {code}")]
-    fn then_code(world: &HandshakeWorld, code: u32) {
-        let reply = world.reply_code();
-        let value = assert_step_ok!(reply);
-        assert_eq!(value, code);
-    }
-
-    #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 0)]
-    fn replies_ok(world: HandshakeWorld) { let _ = world; }
-
-    #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 1)]
-    fn invalid_protocol(world: HandshakeWorld) { let _ = world; }
-
-    #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 2)]
-    fn unsupported_version(world: HandshakeWorld) { let _ = world; }
-
-    #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 3)]
-    fn handshake_timeout(world: HandshakeWorld) { let _ = world; }
-}
+#[path = "handshake_bdd.rs"]
+mod bdd;

--- a/src/wireframe/handshake.rs
+++ b/src/wireframe/handshake.rs
@@ -77,8 +77,8 @@ fn success_handler()
         }
 
         scope_current_context(Some(context.clone()), async move {
-            store_current_context(context);
             write_handshake_reply(stream, HANDSHAKE_OK).await?;
+            store_current_context(context);
             Ok(())
         })
         .boxed()

--- a/src/wireframe/handshake_bdd.rs
+++ b/src/wireframe/handshake_bdd.rs
@@ -150,13 +150,29 @@ fn then_code(world: &HandshakeWorld, code: u32) {
 }
 
 #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 0)]
-fn replies_ok(world: HandshakeWorld) { let _ = world; }
+fn replies_ok(world: HandshakeWorld) {
+    given_server(&world);
+    assert_step_ok!(when_valid(&world));
+    then_code(&world, 0);
+}
 
 #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 1)]
-fn invalid_protocol(world: HandshakeWorld) { let _ = world; }
+fn invalid_protocol(world: HandshakeWorld) {
+    given_server(&world);
+    assert_step_ok!(when_custom(&world, "WRNG".into(), 1));
+    then_code(&world, 1);
+}
 
 #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 2)]
-fn unsupported_version(world: HandshakeWorld) { let _ = world; }
+fn unsupported_version(world: HandshakeWorld) {
+    given_server(&world);
+    assert_step_ok!(when_custom(&world, "TRTP".into(), 2));
+    then_code(&world, 2);
+}
 
 #[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 3)]
-fn handshake_timeout(world: HandshakeWorld) { let _ = world; }
+fn handshake_timeout(world: HandshakeWorld) {
+    given_server(&world);
+    assert_step_ok!(when_idle(&world));
+    then_code(&world, 3);
+}

--- a/src/wireframe/handshake_bdd.rs
+++ b/src/wireframe/handshake_bdd.rs
@@ -134,6 +134,13 @@ fn when_valid(world: &HandshakeWorld) -> Result<(), String> {
 #[when("I send a Hotline handshake with protocol \"{tag}\" and version {version}")]
 fn when_custom(world: &HandshakeWorld, tag: String, version: u16) -> Result<(), String> {
     let mut protocol = [0u8; 4];
+    if tag.len() != protocol.len() {
+        return Err(format!(
+            "protocol tag must be exactly {} bytes, got {}",
+            protocol.len(),
+            tag.len()
+        ));
+    }
     protocol.copy_from_slice(tag.as_bytes());
     let bytes = preamble_bytes(protocol, *b"CHAT", version, 0);
     world.connect_and_maybe_send(Some(bytes.to_vec()))

--- a/src/wireframe/handshake_bdd.rs
+++ b/src/wireframe/handshake_bdd.rs
@@ -1,0 +1,149 @@
+//! BDD coverage for Wireframe handshake hooks.
+
+use std::{cell::RefCell, net::SocketAddr, time::Duration};
+
+use rstest::fixture;
+use rstest_bdd::assert_step_ok;
+use rstest_bdd_macros::{given, scenario, then, when};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    runtime::Runtime,
+    sync::oneshot,
+    time::timeout,
+};
+
+use crate::{
+    protocol::{PROTOCOL_ID, REPLY_LEN, VERSION},
+    wireframe::test_helpers::preamble_bytes,
+};
+
+async fn perform_handshake(
+    addr: SocketAddr,
+    bytes: Option<Vec<u8>>,
+) -> Result<[u8; REPLY_LEN], String> {
+    let mut stream = TcpStream::connect(addr).await.expect("connect");
+    send_handshake_bytes(&mut stream, bytes).await;
+    read_handshake_reply(&mut stream).await
+}
+
+async fn send_handshake_bytes(stream: &mut TcpStream, bytes: Option<Vec<u8>>) {
+    if let Some(data) = bytes {
+        stream.write_all(&data).await.expect("write handshake");
+    }
+}
+
+async fn read_handshake_reply(stream: &mut TcpStream) -> Result<[u8; REPLY_LEN], String> {
+    let mut buf = [0u8; REPLY_LEN];
+    timeout(Duration::from_secs(1), stream.read_exact(&mut buf))
+        .await
+        .map(|res| {
+            res.expect("read reply");
+            buf
+        })
+        .map_err(|err| err.to_string())
+}
+
+struct HandshakeWorld {
+    rt: Runtime,
+    addr: RefCell<Option<SocketAddr>>,
+    shutdown: RefCell<Option<oneshot::Sender<()>>>,
+    reply: RefCell<Option<Result<[u8; REPLY_LEN], String>>>,
+}
+
+impl HandshakeWorld {
+    fn new() -> Self {
+        Self {
+            rt: Runtime::new().expect("runtime"),
+            addr: RefCell::new(None),
+            shutdown: RefCell::new(None),
+            reply: RefCell::new(None),
+        }
+    }
+
+    fn start_server(&self) {
+        let (addr, shutdown) = self
+            .rt
+            .block_on(async { super::tests::start_server(Duration::from_millis(100)) });
+        self.addr.borrow_mut().replace(addr);
+        self.shutdown.borrow_mut().replace(shutdown);
+    }
+
+    fn connect_and_maybe_send(&self, bytes: Option<Vec<u8>>) {
+        let addr = self.addr.borrow().expect("server not started");
+        let reply = self.rt.block_on(perform_handshake(addr, bytes));
+        self.reply.borrow_mut().replace(reply);
+    }
+
+    fn reply_code(&self) -> Result<u32, String> {
+        let reply = self.reply.borrow();
+        let Some(reply) = reply.as_ref() else {
+            return Err("missing reply".into());
+        };
+        reply
+            .as_ref()
+            .map(|buf| {
+                u32::from_be_bytes(
+                    buf[4..8]
+                        .try_into()
+                        .expect("convert reply slice to array (bdd reply)"),
+                )
+            })
+            .map_err(ToString::to_string)
+    }
+}
+
+impl Drop for HandshakeWorld {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.borrow_mut().take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+#[expect(
+    clippy::allow_attributes,
+    reason = "rustc compiler does not emit expected lint"
+)]
+#[allow(unused_braces, reason = "rstest-bdd macro expansion produces braces")]
+#[fixture]
+fn world() -> HandshakeWorld { HandshakeWorld::new() }
+
+#[given("a wireframe server handling handshakes")]
+fn given_server(world: &HandshakeWorld) { world.start_server(); }
+
+#[when("I send a valid Hotline handshake")]
+fn when_valid(world: &HandshakeWorld) {
+    let bytes = preamble_bytes(*PROTOCOL_ID, *b"CHAT", VERSION, 0);
+    world.connect_and_maybe_send(Some(bytes.to_vec()));
+}
+
+#[when("I send a Hotline handshake with protocol \"{tag}\" and version {version}")]
+fn when_custom(world: &HandshakeWorld, tag: String, version: u16) {
+    let mut protocol = [0u8; 4];
+    protocol.copy_from_slice(tag.as_bytes());
+    let bytes = preamble_bytes(protocol, *b"CHAT", version, 0);
+    world.connect_and_maybe_send(Some(bytes.to_vec()));
+}
+
+#[when("I connect without sending a handshake")]
+fn when_idle(world: &HandshakeWorld) { world.connect_and_maybe_send(None); }
+
+#[then("the handshake reply code is {code}")]
+fn then_code(world: &HandshakeWorld, code: u32) {
+    let reply = world.reply_code();
+    let value = assert_step_ok!(reply);
+    assert_eq!(value, code);
+}
+
+#[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 0)]
+fn replies_ok(world: HandshakeWorld) { let _ = world; }
+
+#[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 1)]
+fn invalid_protocol(world: HandshakeWorld) { let _ = world; }
+
+#[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 2)]
+fn unsupported_version(world: HandshakeWorld) { let _ = world; }
+
+#[scenario(path = "tests/features/wireframe_handshake_hooks.feature", index = 3)]
+fn handshake_timeout(world: HandshakeWorld) { let _ = world; }

--- a/src/wireframe/handshake_bdd.rs
+++ b/src/wireframe/handshake_bdd.rs
@@ -22,26 +22,33 @@ async fn perform_handshake(
     addr: SocketAddr,
     bytes: Option<Vec<u8>>,
 ) -> Result<[u8; REPLY_LEN], String> {
-    let mut stream = TcpStream::connect(addr).await.expect("connect");
-    send_handshake_bytes(&mut stream, bytes).await;
+    let mut stream = TcpStream::connect(addr)
+        .await
+        .map_err(|err| err.to_string())?;
+    send_handshake_bytes(&mut stream, bytes).await?;
     read_handshake_reply(&mut stream).await
 }
 
-async fn send_handshake_bytes(stream: &mut TcpStream, bytes: Option<Vec<u8>>) {
+async fn send_handshake_bytes(
+    stream: &mut TcpStream,
+    bytes: Option<Vec<u8>>,
+) -> Result<(), String> {
     if let Some(data) = bytes {
-        stream.write_all(&data).await.expect("write handshake");
+        stream
+            .write_all(&data)
+            .await
+            .map_err(|err| err.to_string())?;
     }
+    Ok(())
 }
 
 async fn read_handshake_reply(stream: &mut TcpStream) -> Result<[u8; REPLY_LEN], String> {
     let mut buf = [0u8; REPLY_LEN];
     timeout(Duration::from_secs(1), stream.read_exact(&mut buf))
         .await
-        .map(|res| {
-            res.expect("read reply");
-            buf
-        })
-        .map_err(|err| err.to_string())
+        .map_err(|err| err.to_string())?
+        .map_err(|err| err.to_string())?;
+    Ok(buf)
 }
 
 struct HandshakeWorld {
@@ -69,10 +76,16 @@ impl HandshakeWorld {
         self.shutdown.borrow_mut().replace(shutdown);
     }
 
-    fn connect_and_maybe_send(&self, bytes: Option<Vec<u8>>) {
-        let addr = self.addr.borrow().expect("server not started");
+    fn connect_and_maybe_send(&self, bytes: Option<Vec<u8>>) -> Result<(), String> {
+        let addr = self
+            .addr
+            .borrow()
+            .as_ref()
+            .copied()
+            .ok_or_else(|| "server not started".to_string())?;
         let reply = self.rt.block_on(perform_handshake(addr, bytes));
         self.reply.borrow_mut().replace(reply);
+        Ok(())
     }
 
     fn reply_code(&self) -> Result<u32, String> {
@@ -113,21 +126,21 @@ fn world() -> HandshakeWorld { HandshakeWorld::new() }
 fn given_server(world: &HandshakeWorld) { world.start_server(); }
 
 #[when("I send a valid Hotline handshake")]
-fn when_valid(world: &HandshakeWorld) {
+fn when_valid(world: &HandshakeWorld) -> Result<(), String> {
     let bytes = preamble_bytes(*PROTOCOL_ID, *b"CHAT", VERSION, 0);
-    world.connect_and_maybe_send(Some(bytes.to_vec()));
+    world.connect_and_maybe_send(Some(bytes.to_vec()))
 }
 
 #[when("I send a Hotline handshake with protocol \"{tag}\" and version {version}")]
-fn when_custom(world: &HandshakeWorld, tag: String, version: u16) {
+fn when_custom(world: &HandshakeWorld, tag: String, version: u16) -> Result<(), String> {
     let mut protocol = [0u8; 4];
     protocol.copy_from_slice(tag.as_bytes());
     let bytes = preamble_bytes(protocol, *b"CHAT", version, 0);
-    world.connect_and_maybe_send(Some(bytes.to_vec()));
+    world.connect_and_maybe_send(Some(bytes.to_vec()))
 }
 
 #[when("I connect without sending a handshake")]
-fn when_idle(world: &HandshakeWorld) { world.connect_and_maybe_send(None); }
+fn when_idle(world: &HandshakeWorld) -> Result<(), String> { world.connect_and_maybe_send(None) }
 
 #[then("the handshake reply code is {code}")]
 fn then_code(world: &HandshakeWorld, code: u32) {

--- a/src/wireframe/outbound.rs
+++ b/src/wireframe/outbound.rs
@@ -12,9 +12,8 @@ use std::sync::{
 use async_trait::async_trait;
 use tracing::warn;
 use wireframe::{
-    ConnectionId,
-    SessionRegistry,
     push::{PushError, PushHandle},
+    session::{ConnectionId, SessionRegistry},
 };
 
 use crate::{

--- a/src/wireframe/protocol.rs
+++ b/src/wireframe/protocol.rs
@@ -47,7 +47,10 @@ use std::sync::Arc;
 
 use argon2::Argon2;
 use tracing::info;
-use wireframe::{ConnectionContext, WireframeProtocol, push::PushHandle};
+use wireframe::{
+    hooks::{ConnectionContext, WireframeProtocol},
+    push::PushHandle,
+};
 
 use crate::{
     db::DbPool,
@@ -166,7 +169,7 @@ impl WireframeProtocol for HotlineProtocol {
 #[cfg(test)]
 mod tests {
     use rstest::{fixture, rstest};
-    use wireframe::ConnectionContext;
+    use wireframe::hooks::ConnectionContext;
 
     use super::*;
     use crate::wireframe::{

--- a/tests/runtime_selection_bdd.rs
+++ b/tests/runtime_selection_bdd.rs
@@ -44,9 +44,15 @@ fn then_runtime(world: &RuntimeWorld, runtime: NetworkRuntime) {
 #[cfg(feature = "legacy-networking")]
 #[tokio::test(flavor = "current_thread")]
 #[scenario(path = "tests/features/runtime_selection.feature", index = 0)]
-async fn legacy_runtime_enabled(#[from(world)] _world: RuntimeWorld) {}
+async fn legacy_runtime_enabled(#[from(world)] world: RuntimeWorld) {
+    given_runtime(&world);
+    then_runtime(&world, NetworkRuntime::Legacy);
+}
 
 #[cfg(not(feature = "legacy-networking"))]
 #[tokio::test(flavor = "current_thread")]
 #[scenario(path = "tests/features/runtime_selection.feature", index = 1)]
-async fn legacy_runtime_disabled(#[from(world)] _world: RuntimeWorld) {}
+async fn legacy_runtime_disabled(#[from(world)] world: RuntimeWorld) {
+    given_runtime(&world);
+    then_runtime(&world, NetworkRuntime::Wireframe);
+}

--- a/tests/wireframe_handshake_metadata.rs
+++ b/tests/wireframe_handshake_metadata.rs
@@ -10,7 +10,7 @@ use std::{
 use mxd::{
     protocol::{PROTOCOL_ID, REPLY_LEN, VERSION},
     wireframe::{
-        connection::{HandshakeMetadata, registry_len, take_current_context},
+        connection::{HandshakeMetadata, can_see_registry, take_current_context},
         handshake,
         preamble::HotlinePreamble,
         test_helpers::preamble_bytes,
@@ -210,7 +210,10 @@ fn then_sub_version(world: &MetadataWorld, sub_version: u16) {
 
 #[then("the handshake registry is cleared after teardown")]
 fn then_registry_cleared(world: &MetadataWorld) {
-    assert_eq!(registry_len(), 0, "handshake registry should be empty");
+    assert!(
+        !can_see_registry(),
+        "handshake registry should not be visible"
+    );
     // Reset captured metadata to prevent cross-scenario leakage when the fixture is reused.
     world
         .recorded
@@ -222,7 +225,7 @@ fn then_registry_cleared(world: &MetadataWorld) {
 #[then("no handshake metadata is recorded")]
 fn then_no_metadata(world: &MetadataWorld) {
     assert!(world.recorded().is_none());
-    assert_eq!(registry_len(), 0);
+    assert!(!can_see_registry());
 }
 
 scenarios!(

--- a/tests/wireframe_handshake_metadata.rs
+++ b/tests/wireframe_handshake_metadata.rs
@@ -10,7 +10,7 @@ use std::{
 use mxd::{
     protocol::{PROTOCOL_ID, REPLY_LEN, VERSION},
     wireframe::{
-        connection::{HandshakeMetadata, can_see_registry, take_current_context},
+        connection::{HandshakeMetadata, has_current_context, take_current_context},
         handshake,
         preamble::HotlinePreamble,
         test_helpers::preamble_bytes,
@@ -211,7 +211,7 @@ fn then_sub_version(world: &MetadataWorld, sub_version: u16) {
 #[then("the handshake registry is cleared after teardown")]
 fn then_registry_cleared(world: &MetadataWorld) {
     assert!(
-        !can_see_registry(),
+        !has_current_context(),
         "handshake registry should not be visible"
     );
     // Reset captured metadata to prevent cross-scenario leakage when the fixture is reused.
@@ -225,7 +225,7 @@ fn then_registry_cleared(world: &MetadataWorld) {
 #[then("no handshake metadata is recorded")]
 fn then_no_metadata(world: &MetadataWorld) {
     assert!(world.recorded().is_none());
-    assert!(!can_see_registry());
+    assert!(!has_current_context());
 }
 
 scenarios!(


### PR DESCRIPTION
## Summary by Sourcery

Migrate to wireframe v0.3.0 and adopt scoped task-local context with a fallible app factory. Context is carried through wiring rather than TLS and into the app factory; missing handshake context now fails closed and surfaces app-factory errors.

Enhancements:
- Introduce a scoped task-local context model for per-connection state (DbPool, Session, and related per-task state) via a fallible app factory path.
- Replace per-connection thread-local state with a task-local model; context is carried through wiring and into the app factory.
- Introduce a fallible app factory in the server bootstrap; missing handshake context fails closed instead of silently falling back to a default app.
- Propagate task-local context through wiring; update bootstrap integration to carry task-local context into the app factory and per-connection flow.
- Align wireframe integration points (codecs, frame handling, and protocol hooks) with the v0.3.0 runtime so that ConnectionContext and session types operate within a task-local model.
- Tighten server bootstrap validation by surfacing app factory errors and add tests for handshake-context handling in the app factory.
- Build: bump the wireframe dependency from v0.2.0 to v0.3.0 and refresh Cargo.lock to pull in the new runtime and testing capabilities.

Documentation:
- Extend the wireframe user guide and migration guides to cover v0.3.0 concepts, including API discovery, vocabulary, codecs, testing utilities, fragmentation, memory budgets, client features, streaming APIs, and error handling.
- Add a comprehensive v0.2.0→v0.3.0 wireframe migration guide and an execution plan describing how mxd adopts v0.3.0.
- Introduce repository-level documentation indices describing the documentation set and repository layout.
- Update the roadmap with a milestone for adopting the v0.3.0 runtime, testkit, observability helpers, and client features.

Tests:
- Add unit tests around the wireframe app factory to verify behaviour when handshake context is missing or present, ensuring connections fail closed without context.

📎 Task: https://www.devboxer.com/task/c03db20c-c80d-44ef-a47b-0d19b243a551

📎 Task: https://www.devboxer.com/task/d2ea300b-4053-498c-9a59-8d51982e0aca

📎 Task: https://www.devboxer.com/task/fd9d959e-d88b-42ad-bcb4-d3361f4178d0