### PR TITLE
Extend hx-based validator harness to target wireframe server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      MXD_VALIDATOR_FAIL_CLOSED: "false"
     steps:
       - uses: actions/checkout@v5
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
@@ -84,9 +83,11 @@ jobs:
       - name: Test
         run: |
           if [[ "${{ matrix.rstest_timeout }}" == "true" ]]; then
-            RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo nextest run ${{ matrix.cargo_flags }}
+            RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo nextest run ${{ matrix.cargo_flags }} \
+              --exclude validator
           else
-            RUSTFLAGS="-D warnings" cargo nextest run ${{ matrix.cargo_flags }}
+            RUSTFLAGS="-D warnings" cargo nextest run ${{ matrix.cargo_flags }} \
+              --exclude validator
           fi
 
   validator-sqlite:
@@ -142,6 +143,12 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      HX_BIN_DIR: ${{ github.workspace }}/.bin
+      HX_WORK_ROOT: ${{ github.workspace }}/.cache/hx
+      HX_SRC_LINK: ${{ github.workspace }}/.cache/synhx-client
+      MXD_VALIDATOR_FAIL_CLOSED: "true"
+      MXD_TEST_BIND_HOST: "127.0.0.1"
+      MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/debug/mxd-wireframe-server
     steps:
       - uses: actions/checkout@v5
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
@@ -149,6 +156,20 @@ jobs:
           install-postgres-deps: true
       - name: Cache Cargo directories
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      - name: Add validator bin directory to PATH
+        run: echo "${HX_BIN_DIR}" >> "${GITHUB_PATH}"
+      - name: Install SynHX
+        run: ./scripts/install-synhx.sh
+      - name: Sanity-check hx does not report Helix
+        run: |
+          set -o pipefail
+          timeout 1 hx --version 2>&1 | tee /tmp/hx-version.log || true
+          if rg -qi 'helix' /tmp/hx-version.log; then
+            echo "hx resolves to Helix, not SynHX" >&2
+            exit 1
+          fi
+      - name: Build wireframe server for coverage
+        run: make validator-sqlite-server
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,39 @@ jobs:
             RUSTFLAGS="-D warnings" cargo nextest run ${{ matrix.cargo_flags }}
           fi
 
+  validator-sqlite:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+      HX_BIN_DIR: ${{ github.workspace }}/.bin
+      HX_WORK_ROOT: ${{ github.workspace }}/.cache/hx
+      HX_SRC_LINK: ${{ github.workspace }}/.cache/synhx-client
+      MXD_VALIDATOR_FAIL_CLOSED: "true"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        with:
+          install-sqlite-deps: true
+      - name: Cache Cargo directories
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      - name: Add validator bin directory to PATH
+        run: echo "${HX_BIN_DIR}" >> "${GITHUB_PATH}"
+      - name: Install SynHX
+        run: ./scripts/install-synhx.sh
+      - name: Sanity-check hx does not report Helix
+        run: |
+          set -o pipefail
+          timeout 1 hx --version 2>&1 | tee /tmp/hx-version.log || true
+          if rg -qi 'helix' /tmp/hx-version.log; then
+            echo "hx resolves to Helix, not SynHX" >&2
+            exit 1
+          fi
+      - name: Build wireframe server for validator
+        run: make validator-sqlite-server
+      - name: Run validator harness
+        run: make test-validator-sqlite
+
   coverage:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         if: matrix.name == 'postgres'
         uses: ./.github/actions/export-postgres-url
         with:
-          url: postgres://postgres:password@localhost/test
+          url: postgres://postgres:password@127.0.0.1/test
       - name: Format
         run: make check-fmt
       - name: Lint with Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,10 @@ jobs:
         run: |
           if [[ "${{ matrix.rstest_timeout }}" == "true" ]]; then
             RSTEST_TIMEOUT=20 RUSTFLAGS="-D warnings" cargo nextest run ${{ matrix.cargo_flags }} \
-              --exclude validator
+              --filter-expr 'not package(=validator)'
           else
             RUSTFLAGS="-D warnings" cargo nextest run ${{ matrix.cargo_flags }} \
-              --exclude validator
+              --filter-expr 'not package(=validator)'
           fi
 
   validator-sqlite:
@@ -148,7 +148,6 @@ jobs:
       HX_SRC_LINK: ${{ github.workspace }}/.cache/synhx-client
       MXD_VALIDATOR_FAIL_CLOSED: "true"
       MXD_TEST_BIND_HOST: "127.0.0.1"
-      MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/debug/mxd-wireframe-server
     steps:
       - uses: actions/checkout@v5
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
@@ -169,21 +168,25 @@ jobs:
             exit 1
           fi
       - name: Build wireframe server for coverage
-        run: make validator-sqlite-server
+        run: make validator-sqlite-server validator-postgres-server
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
       - uses: oven-sh/setup-bun@v2
       - uses: ./.github/actions/export-postgres-url
         with:
-          url: postgres://postgres:password@localhost/test
+          url: postgres://postgres:password@127.0.0.1/test
       - name: Generate coverage for SQLite
         uses: ./.github/actions/generate-coverage
+        env:
+          MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/debug/mxd-wireframe-server
         with:
           features: sqlite test-support
           output-path: lcov-sqlite.info
       - name: Generate coverage for Postgres
         uses: ./.github/actions/generate-coverage
+        env:
+          MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/postgres/debug/mxd-wireframe-server
         with:
           with-default-features: false
           features: postgres test-support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      MXD_VALIDATOR_FAIL_CLOSED: "false"
     steps:
       - uses: actions/checkout@v5
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
@@ -97,6 +98,7 @@ jobs:
       HX_WORK_ROOT: ${{ github.workspace }}/.cache/hx
       HX_SRC_LINK: ${{ github.workspace }}/.cache/synhx-client
       MXD_VALIDATOR_FAIL_CLOSED: "true"
+      MXD_TEST_BIND_HOST: "127.0.0.1"
     steps:
       - uses: actions/checkout@v5
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
+          install-sqlite-deps: true
           install-postgres-deps: true
       - name: Cache Cargo directories
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
         uses: ./.github/actions/generate-coverage
         env:
           MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/postgres/debug/mxd-wireframe-server
+          POSTGRES_TEST_URL: postgres://postgres:password@127.0.0.1/test
         with:
           with-default-features: false
           features: postgres test-support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5138,8 +5138,12 @@ dependencies = [
  "expectrl",
  "mxd",
  "nix 0.27.1",
+ "rstest 0.26.1",
+ "serde",
  "tempfile",
  "test-util",
+ "thiserror 2.0.17",
+ "toml 0.8.23",
  "wait-timeout",
  "which",
 ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean build release test test-postgres test-sqlite test-wireframe-only test-verification lint lint-postgres lint-sqlite lint-wireframe-only typecheck typecheck-postgres typecheck-sqlite typecheck-wireframe-only fmt check-fmt markdownlint nixie corpus sqlite postgres sqlite-release postgres-release tlc tlc-handshake
+.PHONY: help all clean build release test test-postgres test-sqlite test-wireframe-only test-verification validator-sqlite-server validator-postgres-server test-validator-sqlite test-validator-postgres lint lint-postgres lint-sqlite lint-wireframe-only typecheck typecheck-postgres typecheck-sqlite typecheck-wireframe-only fmt check-fmt markdownlint nixie corpus sqlite postgres sqlite-release postgres-release tlc tlc-handshake
 
 APP ?= mxd
 CARGO ?= cargo
@@ -99,6 +99,20 @@ test-wireframe-only: ## Run tests with legacy networking disabled
 
 test-verification: ## Run verification crate tests
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run -p mxd-verification
+
+validator-sqlite-server: ## Build the sqlite wireframe server binary for validator runs
+	$(MAKE) APP=mxd-wireframe-server sqlite
+
+validator-postgres-server: ## Build the postgres wireframe server binary for validator runs
+	$(MAKE) APP=mxd-wireframe-server postgres
+
+test-validator-sqlite: validator-sqlite-server ## Run the hx validator against the sqlite wireframe server
+	MXD_VALIDATOR_SERVER_BINARY=$(CURDIR)/target/debug/mxd-wireframe-server \
+		RUSTFLAGS="-D warnings" $(CARGO) test -p validator --features sqlite
+
+test-validator-postgres: validator-postgres-server ## Run the hx validator against the postgres wireframe server
+	MXD_VALIDATOR_SERVER_BINARY=$(CURDIR)/$(POSTGRES_TARGET_DIR)/debug/mxd-wireframe-server \
+		RUSTFLAGS="-D warnings" $(CARGO) test -p validator --no-default-features --features postgres
 
 sqlite: target/debug/$(APP) ## Build debug sqlite binary
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ pinned SynHX client with the shared helper script and run the validator from
 the repository root:
 
 ```bash
-HX_BIN_DIR="$HOME/.local/bin" ./scripts/install-synhx.sh
+export HX_BIN_DIR="$HOME/.local/bin"
+./scripts/install-synhx.sh
+# Choose one way to expose the installed `hx` binary to later commands.
+export PATH="$HX_BIN_DIR:$PATH"
+# or
+export MXD_VALIDATOR_HX_BINARY="$HX_BIN_DIR/hx"
 make test-validator-sqlite
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,19 @@ PostgreSQL server. Set `POSTGRES_TEST_URL` to reuse an existing database URL
 ## Validation harness
 
 The `validator` crate provides a compatibility check using the `hx` client and
-`expectrl` to ensure mxd speaks the Hotline protocol correctly. Install `hx`
-version 0.2.4 and make sure it's on your `PATH` before running:
+`expectrl` to ensure mxd speaks the Hotline protocol correctly. Install the
+pinned SynHX client with the shared helper script and run the validator from
+the repository root:
 
 ```bash
-cd validator
-cargo test
+HX_BIN_DIR="$HOME/.local/bin" ./scripts/install-synhx.sh
+make test-validator-sqlite
 ```
+
+The validator now resolves an explicit prebuilt `mxd-wireframe-server` binary
+instead of falling back to `cargo run` during test startup. Use
+`make test-validator-postgres` after preparing local PostgreSQL support with
+`pg_embedded_setup_unpriv` if you need the postgres validator path.
 
 ## Fuzzing
 

--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -94,8 +94,7 @@ Documents for project planning and tracking progress.
 Architectural Decision Records (ADRs) capture significant design decisions.
 
 - [`adr-001-login-auth-reply-compatibility-layers.md`](adr-001-login-auth-reply-compatibility-layers.md)
-  — ADR 001: Separate login authentication and reply augmentation
-  (superseded).
+  — ADR 001: Separate login authentication and reply augmentation (superseded).
 - [`adr-002-compatibility-guardrails-and-augmentation.md`](adr-002-compatibility-guardrails-and-augmentation.md)
   — ADR 002: Compatibility guardrails and augmentation (superseded).
 - [`adr-003-login-authentication-and-reply-augmentation.md`](adr-003-login-authentication-and-reply-augmentation.md)

--- a/docs/adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md
+++ b/docs/adopting-hexagonal-architecture-in-the-mxd-wireframe-migration.md
@@ -189,9 +189,9 @@ logic”*(
 Under Hexagonal Architecture, a **"Port"** is an interface that defines how the
 outside world interacts with the core, while the **"Application Core"**
 contains the domain logic that implements those interactions. In the context of
-the mxd wireframe adoption, it is necessary to distinguish which parts of the system
-act as ports (interfaces or entry points) and which parts belong to the domain
-core.
+the mxd wireframe adoption, it is necessary to distinguish which parts of the
+system act as ports (interfaces or entry points) and which parts belong to the
+domain core.
 
 **Inbound Ports (Driving)**: For the Hotline server, the inbound port is
 essentially the set of operations the server can perform in response to client
@@ -246,8 +246,8 @@ handles([2](https://github.com/leynos/wireframe/blob/fa6c62925443e6caed54866a95d
  and a public `PushHandle` API to send outbound
 frames([2](https://github.com/leynos/wireframe/blob/fa6c62925443e6caed54866a95d3396eb8fa78a2/docs/wireframe-1-0-detailed-development-roadmap.md#L40-L43)).
  These will act as the **adapter** enabling outbound communication. The domain
-core should use them via an abstract interface. For instance, after processing a
-login, the core logic might call `Notifier.broadcastUserLogin(user)` – behind
+core should use them via an abstract interface. For instance, after processing
+a login, the core logic might call `Notifier.broadcastUserLogin(user)` – behind
 that, the adapter will use `wireframe` to send a "Notify New User" (transaction
 300) to all connected clients. By treating outbound messaging as a port, the
 domain remains unaware of *how* the broadcast is done (whether via `wireframe`
@@ -279,9 +279,9 @@ instead of manually managing sockets. In a Hexagonal model, the domain might
 not even know about `PushHandle` – it might call a method on a domain service,
 which internally uses the push adapter. In practice, since `wireframe` is
 tightly integrated, the domain might directly call something like
-`session.push(frame)` if not careful. To maintain the Hexagon structure, those calls
-should be wrapped or isolated. The new `WireframeProtocol` trait may help here:
-one of its responsibilities during connection setup is to attach any
+`session.push(frame)` if not careful. To maintain the Hexagon structure, those
+calls should be wrapped or isolated. The new `WireframeProtocol` trait may help
+here: one of its responsibilities during connection setup is to attach any
 per-connection state, which could include a handle or context that domain logic
 uses when
 needed([1](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/migration-plan-moving-mxd-protocol-implementation-to-wireframe.md#L176-L184)).
@@ -300,8 +300,8 @@ parsing command parameters into meaningful data, applying business rules,
 updating state, and deciding what responses or events are appropriate. The core
 should expose clear entry points (which `wireframe` calls via handlers) and
 consume abstracted services (which `wireframe` provides via adapters). By
-delineating these, `wireframe` remains a plug-in mechanism rather
-than a fundamental dependency tangled through the core code.
+delineating these, `wireframe` remains a plug-in mechanism rather than a
+fundamental dependency tangled through the core code.
 
 ## Avoiding Hexagonal Violations and Addressing Risk Areas
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1056,7 +1056,7 @@ implementation differences. For instance:
   `BOOLEAN` is fine in Postgres and in SQLite it ends up as 0/1 integer
   (Diesel’s bool mapping covers
   it)([7](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/supporting-both-sqlite3-and-postgresql-in-diesel.md#L65-L68));
-   `INTEGER` for integer types, etc. Some types don’t line up – e.g. `BYTEA` vs
+  `INTEGER` for integer types, etc. Some types don’t line up – e.g. `BYTEA` vs
   `BLOB` for binary data – but we avoid unsupported types or handle them
   conditionally. The doc notes that JSONB or timezone-aware timestamps aren’t
   portable, so we either avoid them or supply separate SQL. For example, we
@@ -3153,7 +3153,8 @@ classic Expect for automating terminal interactions). Specifically:
   and XOR-obfuscated login fields.
 
 - The support matrix is intentionally narrower than the roadmap acceptance for
-  item 1.6.2. We confirmed the following gaps while wiring the harness into CI:
+  item 1.6.2. The following gaps were identified while wiring the harness into
+  CI:
 
 - SynHX file operations (`/ls`, `/get`) still use the legacy `DATA_DIR` and
   file-list reply shapes. MXD now tolerates the request payload for root

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,17 +24,18 @@ domain operations can be exercised in isolation from their environment.
   loop, the `wireframe` crate acts as the **port** for the Hotline binary
   protocol. It handles socket I/O with Tokio, decodes and encodes the
   Hotline-specific frames, and dispatches incoming messages to the appropriate
-  domain handler via a routing table[^wireframe-routing-table][^mxd-routing-handlers].
-  Each Hotline “transaction” type (a message or request identified by an ID)
-  is mapped to a handler function. For example, the Login transaction (Hotline
-  ID 0x006B) is routed to a `handle_login` handler in the domain core. The
-  Wireframe adapter thus plays the role of the **primary port** on the inbound
-  side: it translates raw TCP byte streams into high-level domain commands and
-  routes them. Likewise, it takes domain responses and frames them back into
-  Hotline protocol packets on the outbound side. This clean separation means
-  the domain core doesn’t need to know about sockets or byte order; it just
-  implements handlers for events like “user login request” or “post news
-  article,” and the wireframe layer delivers those events.
+  domain handler via a routing
+  table[^wireframe-routing-table][^mxd-routing-handlers]. Each Hotline
+  “transaction” type (a message or request identified by an ID) is mapped to a
+  handler function. For example, the Login transaction (Hotline ID 0x006B) is
+  routed to a `handle_login` handler in the domain core. The Wireframe adapter
+  thus plays the role of the **primary port** on the inbound side: it
+  translates raw TCP byte streams into high-level domain commands and routes
+  them. Likewise, it takes domain responses and frames them back into Hotline
+  protocol packets on the outbound side. This clean separation means the domain
+  core doesn’t need to know about sockets or byte order; it just implements
+  handlers for events like “user login request” or “post news article,” and the
+  wireframe layer delivers those events.
 
 - **Storage Adapter (Diesel ORM)**: Persistence is achieved via Diesel, serving
   as a database adapter. The domain defines repository-like functions (e.g.
@@ -3131,73 +3132,43 @@ integration test harness using an **external Hotline client** and the
 classic Expect for automating terminal interactions). Specifically:
 
 - We use the **Synapse Hotline X (SynHX)** client (an open-source Hotline
-  client) in a headless mode. The `hx` binary (v0.2.4) can run commands from
-  CLI or connect to a server if invoked
-  appropriately([15](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/README.md#L98-L105)).
+  client) in a headless mode. Validator runs provision the pinned `hx` binary
+  (`v0.1.48.1`) through `scripts/install-synhx.sh`, which is shared by devboxer
+  and CI.
 
-- In our `validator` test crate, we spawn the MXD server (perhaps on localhost
-  ephemeral port) and then spawn the `hx` client as a child process. We use
-  `expectrl` to interact with `hx` by sending it commands (like “open
-  connection”, “login”, “send message”) and expecting certain responses (like
-  specific text or success codes).
+- In our `validator` test crate, we spawn a **prebuilt**
+  `mxd-wireframe-server` binary on an ephemeral port and then spawn `hx` as a
+  child process. The harness resolves the server binary explicitly from
+  `MXD_VALIDATOR_SERVER_BINARY`, Cargo's `CARGO_BIN_EXE_mxd-wireframe-server`,
+  or the conventional target directory, rather than relying on an implicit
+  `cargo run` fallback.
 
-- For example, a test might start MXD, then do:
+- The harness applies a fail-closed policy in CI. Missing `hx`, a missing
+  prebuilt server binary, or the common "Helix editor is installed as `hx`"
+  mistake all fail CI immediately. Local runs default to informative skips
+  unless `MXD_VALIDATOR_FAIL_CLOSED=true` is set.
 
-- `hx /connect 127.0.0.1 5500` and expect some greeting or login prompt.
+- Current end-to-end coverage exercises the flows that the pinned client and
+  the current wireframe server can both speak today: login, failed-auth gating,
+  and XOR-obfuscated login fields.
 
-- `hx /login alice secret` and then expect a “Login successful” message or
-  absence of error.
+- The support matrix is intentionally narrower than the roadmap acceptance for
+  item 1.6.2. We confirmed the following gaps while wiring the harness into CI:
 
-- `hx /who` to list users and expect to see "alice".
+- SynHX file operations (`/ls`, `/get`) still use the legacy `DATA_DIR` and
+  file-list reply shapes. MXD now tolerates the request payload for root
+  listing, but the server does not yet emit the file-list response structure
+  that SynHX expects.
+- SynHX news commands (`/news`, `/post`) still target the legacy news-file
+  transactions (`0x65`/`0x67`), while the wireframe server exposes the newer
+  category/article transactions (`370`, `371`, `400`, `410`).
+- Chat and file download remain roadmap items outside the currently
+  implemented wireframe transaction surface.
 
-- Or to test news: `hx /news list` and expect the categories to match what MXD
-  has.
-
-- For chat: if hx supports sending chat messages, we could simulate two hx
-  instances to ensure messages broadcast.
-
-The harness essentially uses the **actual protocol implementation from a real
-client** to double-check our server. This catches any discrepancies in byte
-ordering, field encoding, XOR encoding (Hotline had an XOR obfuscation for text
-sometimes), etc. Our roadmap explicitly includes compatibility toggles like XOR
-decoding for clients that need
-it([16](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/docs/roadmap.md#L93-L101)).
- In the validator tests, we likely verify that:
-
-- A SynHX client can login to MXD (meaning our handshake and login responses
-  are acceptable).
-
-- It can retrieve user list, see itself.
-
-- Possibly test sending a public chat message and ensure MXD echoes it back
-  properly (though with one client, maybe hx has a loopback test mode or we
-  might run two clients).
-
-- File downloads might be tested by having hx request a file (if hx has command
-  to download file to disk, we can create a small file on server and see if hx
-  gets it).
-
-- News might be tested by hx retrieving a news post.
-
-Because these tests involve actual I/O and an external binary, they are a bit
-more fragile and likely marked to run in certain environments (we need hx 0.2.4
-installed in PATH as
-noted([15](https://github.com/leynos/mxd/blob/88d1cfb3097b2d96f2b7c9d1382f6b374d7eb90c/README.md#L98-L105))).
- They might not run in a typical `cargo test` unless the environment is
-prepared, but we have instructions and perhaps a CI job that sets up hx for
-these integration tests.
-
-Example from `README.md`:
-
-```bash
-cd validator
-cargo test
-```
-
-This will run the expect scripts. We probably have those scripts or direct
-expect code in `validator/tests/` or so. The output of these tests is a high
-confidence that MXD’s behavior matches an actual Hotline server as far as the
-client is concerned.
+The harness still uses the **actual protocol implementation from a real
+client** to double-check the server wherever the surfaces overlap. That keeps
+the login and XOR compatibility path honest, and the CI job ensures the
+repository can provision SynHX and drive the wireframe server end-to-end.
 
 ### Fuzzing and Property-Based Testing
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -81,6 +81,58 @@ The behavioural suite uses `rstest-bdd` v0.5.0 in both the root crate and
 - If a scenario needs a fallible return signature, use explicit
   `Result<(), E>` or `StepResult<(), E>` in the scenario function signature.
 
+## Validator toggles for pending flows
+
+The `validator` crate now ships placeholder validators for wireframe flows that
+are still being implemented on parallel branches. This lets feature branches
+opt into the required validation early without forcing the main branch to fail
+before the corresponding server functionality lands.
+
+By default, the pending validators are disabled in
+`validator/validator.toml`:
+
+```toml
+[validators]
+chat = false
+file_download = false
+```
+
+Environment variables override the file:
+
+- `MXD_VALIDATOR_CONFIG` points at an alternate config file.
+- `MXD_VALIDATOR_ENABLE_CHAT=true|false` enables or disables the chat
+  validator.
+- `MXD_VALIDATOR_ENABLE_FILE_DOWNLOAD=true|false` enables or disables the
+  file-download validator.
+
+When a pending validator is disabled, the corresponding test prints a clear
+skip message and exits successfully. When it is enabled before the underlying
+feature has landed, the validator fails with an explicit "enabled but not
+implemented yet" error. That makes the opt-in suitable for parallel feature
+branches that want the validation to go red until the branch completes the
+flow.
+
+Examples:
+
+```sh
+# Enable the chat validator for the current shell only.
+export MXD_VALIDATOR_ENABLE_CHAT=true
+cargo test -p validator --test pending_validators
+
+# Use an alternate config file that enables both pending validators.
+cat > /tmp/validator.toml <<'EOF'
+[validators]
+chat = true
+file_download = true
+EOF
+export MXD_VALIDATOR_CONFIG=/tmp/validator.toml
+cargo test -p validator --test pending_validators
+```
+
+Keep implemented validators such as login and XOR/news coverage always on. The
+pending toggles exist only for flows whose server-side work is still in
+progress.
+
 ## Wireframe adapter context handoff
 
 The Wireframe adapter carries Hotline handshake metadata from the asynchronous

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -156,6 +156,94 @@ progress. At present, chat and file download remain pending, while SynHX file
 listing and news posting are still blocked by client/server protocol-shape
 differences rather than missing harness plumbing.
 
+## Validator harness architecture
+
+The `validator` crate is structured into five focused modules. Tests in
+`validator/tests/` import primitives from `validator/src/lib.rs`, which
+re-exports the public surface of each module.
+
+### Module responsibilities
+
+| Module | Responsibility |
+| ------ | -------------- |
+| `config.rs` | Loads `validator.toml` and applies environment-variable overrides to determine which pending validators are enabled. |
+| `policy.rs` | Decides whether a missing prerequisite causes a hard test failure (`fail_closed = true`) or a graceful skip (`fail_closed = false`). Reads `MXD_VALIDATOR_FAIL_CLOSED`; falls back to `CI=true` detection. |
+| `server_binary.rs` | Resolves the path to a prebuilt `mxd-wireframe-server` binary. Precedence: `MXD_VALIDATOR_SERVER_BINARY` → `CARGO_BIN_EXE_mxd-wireframe-server` → workspace `target/` candidates. |
+| `hx_client.rs` | Discovers the `hx` binary (rejecting the Helix editor via a version probe), spawns a PTY session via `expectrl`, and provides helpers to wait for the Hotline prompt and terminate the session. |
+| `harness.rs` | Orchestrates the above: `ValidatorHarness::prepare()` runs policy and prerequisite checks, `start_server_with_setup()` launches the wireframe server, and `spawn_hx()` opens the PTY client. Also exports PTY expect/send helpers used directly by tests. |
+
+### Key public types
+
+```rust
+/// Central harness handle. Obtain one with `ValidatorHarness::default()` then
+/// call `prepare()` before any other method.
+pub struct ValidatorHarness { /* ... */ }
+
+/// Describes whether a missing prerequisite should fail the test or skip it.
+pub enum PrerequisiteResolution {
+    Fail(String),
+    Skip(String),
+}
+
+/// Errors returned when `hx` cannot be resolved or the PTY session fails.
+pub enum HxClientError { /* ... */ }
+
+/// Errors returned when no prebuilt wireframe server binary can be found.
+pub enum ServerBinaryError { /* ... */ }
+```
+
+### Typical test structure
+
+```rust
+#[test]
+fn my_validator_test() -> Result<(), AnyError> {
+    let harness = ValidatorHarness::default();
+    let Some(harness) = harness.prepare()? else {
+        // Prerequisite missing and policy says skip.
+        return Ok(());
+    };
+    let server = harness.start_server_with_setup(setup_login_db)?;
+    let mut hx = harness.spawn_hx()?;
+    send_line_and_expect(&mut hx, "/server -l alice -p secret 127.0.0.1 …", "…")?;
+    expect_output_with_timeout(&mut hx, "connected", connect_expect_timeout())?;
+    close_hx(&mut hx);
+    Ok(())
+}
+```
+
+`prepare()` returns `Ok(None)` when prerequisites are absent and the policy is
+`fail_closed = false` (local developer environment). Tests must propagate the
+`None` case as a skip rather than a panic.
+
+### Payload-handling methods on `TransactionType`
+
+Two const methods control how the wireframe layer handles request payloads:
+
+- `rejects_payload(self, payload_is_empty: bool) -> bool` returns `true` when a
+  non-empty payload should be rejected as invalid. Always returns `false` for
+  `GetFileNameList` so directory context payloads pass through.
+- `bypass_payload_decode(self) -> bool` returns `true` when the parameter block
+  decoder should be skipped entirely and the raw bytes preserved. Used for
+  `GetFileNameList` and any transaction type that does not accept a structured
+  payload.
+
+These methods replace the prior ad-hoc `!allows_payload()` checks in
+`src/commands/mod.rs`, `src/wireframe/compat_layer.rs`, and
+`src/transaction/params.rs`.
+
+### Error-handling conventions
+
+- Both `HxClientError` and `ServerBinaryError` implement `std::error::Error`
+  via `thiserror`.
+- `ValidatorHarness::prepare()` maps these errors through `ValidatorRunPolicy`
+  and either returns them as `anyhow::Error` (fail-closed) or returns
+  `Ok(None)` (skip).
+- PTY expect helpers (`expect_output`, `expect_output_with_timeout`,
+  `expect_no_match`) embed the pending terminal output in the error message to
+  simplify debugging failed assertions.
+- `close_hx()` demotes session-cleanup errors to stderr diagnostics rather than
+  failing the test, consistent with best-effort teardown.
+
 ## Wireframe adapter context handoff
 
 The Wireframe adapter carries Hotline handshake metadata from the asynchronous

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -114,7 +114,13 @@ Examples:
 
 ```sh
 # Install the pinned SynHX client once for local validator runs.
-HX_BIN_DIR="$HOME/.local/bin" ./scripts/install-synhx.sh
+export HX_BIN_DIR="$HOME/.local/bin"
+./scripts/install-synhx.sh
+
+# Choose one way to expose the installed `hx` binary to later commands.
+export PATH="$HX_BIN_DIR:$PATH"
+# or
+export MXD_VALIDATOR_HX_BINARY="$HX_BIN_DIR/hx"
 
 # Run the supported sqlite validator suite against a prebuilt wireframe server.
 make test-validator-sqlite

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -88,8 +88,7 @@ are still being implemented on parallel branches. This lets feature branches
 opt into the required validation early without forcing the main branch to fail
 before the corresponding server functionality lands.
 
-By default, the pending validators are disabled in
-`validator/validator.toml`:
+By default, the pending validators are disabled in `validator/validator.toml`:
 
 ```toml
 [validators]
@@ -109,12 +108,17 @@ When a pending validator is disabled, the corresponding test prints a clear
 skip message and exits successfully. When it is enabled before the underlying
 feature has landed, the validator fails with an explicit "enabled but not
 implemented yet" error. That makes the opt-in suitable for parallel feature
-branches that want the validation to go red until the branch completes the
-flow.
+branches that want the validation to go red until the branch completes the flow.
 
 Examples:
 
 ```sh
+# Install the pinned SynHX client once for local validator runs.
+HX_BIN_DIR="$HOME/.local/bin" ./scripts/install-synhx.sh
+
+# Run the supported sqlite validator suite against a prebuilt wireframe server.
+make test-validator-sqlite
+
 # Enable the chat validator for the current shell only.
 export MXD_VALIDATOR_ENABLE_CHAT=true
 cargo test -p validator --test pending_validators
@@ -129,9 +133,22 @@ export MXD_VALIDATOR_CONFIG=/tmp/validator.toml
 cargo test -p validator --test pending_validators
 ```
 
-Keep implemented validators such as login and XOR/news coverage always on. The
+The shared validator harness now resolves prerequisites explicitly:
+
+- `make validator-sqlite-server` builds `target/debug/mxd-wireframe-server`.
+- `make validator-postgres-server` builds
+  `target/postgres/debug/mxd-wireframe-server`.
+- `MXD_VALIDATOR_SERVER_BINARY` overrides the server binary path if the default
+  target location is not suitable.
+- `MXD_VALIDATOR_HX_BINARY` overrides the `hx` binary path.
+- `MXD_VALIDATOR_FAIL_CLOSED=true|false` forces missing prerequisites to fail
+  or skip regardless of whether `CI=true`.
+
+Keep implemented validators such as login and XOR login coverage always on. The
 pending toggles exist only for flows whose server-side work is still in
-progress.
+progress. At present, chat and file download remain pending, while SynHX file
+listing and news posting are still blocked by client/server protocol-shape
+differences rather than missing harness plumbing.
 
 ## Wireframe adapter context handoff
 

--- a/docs/execplans/1-3-4-kani-harnesses-for-transaction-framing-invariants.md
+++ b/docs/execplans/1-3-4-kani-harnesses-for-transaction-framing-invariants.md
@@ -136,7 +136,7 @@ Verification guidance and tooling expectations are in
 `docs/verification-strategy.md`. Documentation and testing conventions are
 described in `docs/rust-testing-with-rstest-fixtures.md`,
 `docs/rstest-bdd-users-guide.md`, `docs/rust-doctest-dry-guide.md`, and
-`docs/pg-embedded-setup-unpriv-users-guide.md`.
+`docs/pg-embed-setup-unpriv-users-guide.md`.
 
 ## Plan of Work
 

--- a/docs/execplans/1-4-2-route-transactions-through-wireframe.md
+++ b/docs/execplans/1-4-2-route-transactions-through-wireframe.md
@@ -79,7 +79,7 @@ tests.
       `tests/features/wireframe_routing.feature` with login/file/news
       scenarios.
 - [x] (2026-01-04) Ensure Postgres-backed routing scenarios use the embedded
-      Postgres harness (`pg-embedded-setup-unpriv`) via `PostgresTestDb`.
+      Postgres harness (`pg-embed-setup-unpriv`) via `PostgresTestDb`.
 - [x] (2026-01-04) Update `docs/design.md` with routing architecture and
       frame codec details.
 - [x] (2026-01-04) Mark task 1.4.2 as done in `docs/roadmap.md`.
@@ -381,7 +381,7 @@ Add behavioural tests using rstest-bdd v0.3.2:
 - Create `tests/features/wireframe_routing.feature` with scenarios for Login,
   file listing, and news listing.
 - Implement step definitions in `tests/wireframe_routing_bdd.rs`.
-- Add Postgres-backed scenarios using `pg-embedded-setup-unpriv`.
+- Add Postgres-backed scenarios using `pg-embed-setup-unpriv`.
 
 ### Phase 4: Documentation
 
@@ -484,7 +484,7 @@ Dependencies:
 - `wireframe` crate (already in use)
 - `rstest` v0.26 (already in dev-dependencies)
 - `rstest-bdd` v0.3.2
-- `pg-embedded-setup-unpriv` (already in dev-dependencies)
+- `pg-embed-setup-unpriv` (already in dev-dependencies)
 
 ## Revision Note
 

--- a/docs/execplans/1-4-3-introduce-a-shared-session-context.md
+++ b/docs/execplans/1-4-3-introduce-a-shared-session-context.md
@@ -82,7 +82,7 @@ privileged operations.
 - [x] Integrate privilege enforcement into news transaction handlers.
 - [x] Add unit tests for privilege bitflags and session helpers.
 - [x] Add rstest-bdd behavioural tests for privilege enforcement.
-- [x] Add Postgres-backed tests using `pg-embedded-setup-unpriv`.
+- [x] Add Postgres-backed tests using `pg-embed-setup-unpriv`.
 - [x] Update `docs/design.md` with session context architecture.
 - [ ] Update `docs/users-guide.md` if user-visible behaviour changes.
       (Not required: no user-visible behaviour change; privilege enforcement is
@@ -288,7 +288,7 @@ The implementation proceeds in four stages:
    - User without news post privilege cannot post articles
 
 3. Add Postgres-backed tests using `PostgresTestDb` fixture from
-   `pg-embedded-setup-unpriv`.
+   `pg-embed-setup-unpriv`.
 
 4. Update `docs/design.md` with session context architecture diagram and
    privilege enforcement description.
@@ -485,4 +485,4 @@ Dependencies:
 - `bitflags` crate (added directly: `bitflags = "2.10.0"`)
 - `rstest` v0.26 (already in dev-dependencies)
 - `rstest-bdd` v0.3.2 (already in dev-dependencies)
-- `pg-embedded-setup-unpriv` (already in dev-dependencies)
+- `pg-embed-setup-unpriv` (already in dev-dependencies)

--- a/docs/execplans/1-4-4-outbound-transport-and-messaging-traits.md
+++ b/docs/execplans/1-4-4-outbound-transport-and-messaging-traits.md
@@ -117,7 +117,7 @@ Relevant areas to review before editing:
   behaviour.
 - Test guidance is in `docs/rust-testing-with-rstest-fixtures.md`,
   `docs/rstest-bdd-users-guide.md`, and
-  `docs/pg-embedded-setup-unpriv-users-guide.md`.
+  `docs/pg-embed-setup-unpriv-users-guide.md`.
 
 Terminology used in this plan:
 

--- a/docs/execplans/1-4-5-reply-builder.md
+++ b/docs/execplans/1-4-5-reply-builder.md
@@ -35,7 +35,7 @@ after implementation and verification.
   `make nixie`.
 - Use `rstest` for unit tests and `rstest-bdd` v0.3.2 for behavioural tests.
 - For Postgres-backed tests, use `pg_embedded_setup_unpriv` as documented in
-  `docs/pg-embedded-setup-unpriv-users-guide.md`.
+  `docs/pg-embed-setup-unpriv-users-guide.md`.
 
 ## Tolerances (exception triggers)
 
@@ -129,7 +129,7 @@ Relevant areas to review before editing:
   `docs/verification-strategy.md`, `docs/rust-testing-with-rstest-fixtures.md`,
   `docs/reliable-testing-in-rust-via-dependency-injection.md`,
   `docs/rstest-bdd-users-guide.md`, and
-  `docs/pg-embedded-setup-unpriv-users-guide.md`.
+  `docs/pg-embed-setup-unpriv-users-guide.md`.
 
 Terminology used in this plan:
 

--- a/docs/execplans/1-6-1-port-unit-and-integration-tests.md
+++ b/docs/execplans/1-6-1-port-unit-and-integration-tests.md
@@ -108,7 +108,7 @@ Success is observable when:
   `tests/news_categories.rs`, and `tests/news_articles.rs` already start the
   `mxd-wireframe-server` binary through `tests/common.rs` and `TestServer`.
 - The referenced Postgres setup guide path in the request uses
-  `pg-embedded-setup-unpriv`, while the repository document path is
+  `pg-embed-setup-unpriv`, while the repository document path is
   `docs/pg-embed-setup-unpriv-users-guide.md`.
 - Server-only routing scenarios (unknown transaction type) still need an
   active TCP connection and therefore must start `TestServer` with a no-op DB

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -1,0 +1,415 @@
+# Extend the hx validator harness to target the wireframe server
+
+This ExecPlan is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as
+work proceeds.
+
+Status: NOT STARTED
+
+## Purpose / big picture
+
+Roadmap item 1.6.2 requires the `hx`-driven validator harness to become an
+authoritative regression path for the wireframe runtime, not a best-effort
+compatibility smoke test. The immediate goal is to make the validator crate
+target `mxd-wireframe-server` explicitly, cover the required end-to-end flows,
+and run that coverage in CI instead of silently skipping when the environment
+is not prepared.
+
+Success is observable when:
+
+- validator tests target `mxd-wireframe-server` explicitly rather than relying
+  on implicit defaults in shared helpers;
+- the harness has clear flow coverage for login, file download, chat, and news
+  against the wireframe server, with happy and unhappy paths plus relevant edge
+  cases;
+- new harness helpers are covered with `rstest` unit tests, and
+  `rstest-bdd` scenarios are added where they improve readability for
+  higher-level validation behaviour;
+- CI provisions a real `hx` binary and fails closed when validator coverage
+  cannot run;
+- `docs/design.md` records the final harness-targeting and CI decisions;
+- `docs/users-guide.md` is updated if the implementation changes user-visible
+  runtime behaviour or supported validation workflows;
+- roadmap item 1.6.2 in `docs/roadmap.md` is marked done only after the above
+  pass.
+
+## Constraints
+
+- Keep the validator harness focused on the wireframe runtime. This task must
+  not reintroduce ambiguity between `mxd` and `mxd-wireframe-server`.
+- Preserve real-client validation via `hx` plus `expectrl`; do not replace the
+  validator with an in-process protocol shim.
+- Extract reusable harness logic into unit-testable helpers and cover that
+  logic with `rstest`.
+- Add `rstest-bdd` behavioural coverage where it clarifies multi-step harness
+  orchestration or validation contracts; do not force BDD onto low-level PTY
+  details that are better expressed as ordinary tests.
+- Use dependency injection for process-launch, filesystem, and environment
+  seams where that materially improves deterministic testing, following
+  `docs/reliable-testing-in-rust-via-dependency-injection.md`.
+- Use `pg-embedded-setup-unpriv` for documented local Postgres validator runs
+  rather than bespoke cluster setup.
+- Keep documentation in en-GB-oxendict spelling and wrap prose at 80 columns.
+- Do not add a new third-party dependency unless escalation is explicitly
+  approved. Reusing workspace crates such as `rstest-bdd` is allowed.
+- Before any implementation commit, run the repository quality gates plus any
+  new validator-specific gates introduced by this work:
+  `make check-fmt`, `make lint`, `make test`, `make markdownlint`, `make nixie`,
+  and explicit validator commands if they are not folded into `make test`.
+
+## Tolerances (exception triggers)
+
+- Scope: if completing 1.6.2 requires implementing substantial new server
+  protocol features beyond harness and test infrastructure, stop and review the
+  dependency mismatch before proceeding.
+- Acceptance mismatch: if file download or chat validation requires roadmap
+  tasks that are still incomplete in phases 2.x or 3.x, stop and either obtain
+  approval for scoped substitute coverage or re-sequence the dependency chain.
+- Client capability: if `hx` v0.2.4 cannot script one of the required flows in
+  headless mode, stop after confirming the exact limitation from `hx` help or
+  source and present options.
+- CI stability: if the `hx` install/provision path remains flaky after two
+  focused fixes, stop and review whether the binary should be cached, pinned,
+  or supplied differently.
+- Validation: if validator tests require serial execution or a non-`nextest`
+  runner, document that explicitly and do not silently wedge them into an
+  incompatible existing target.
+
+## Risks
+
+- Risk: roadmap item 1.6.2 names file download and chat flows, but the current
+  wireframe routing surface only covers login, file listing, and news.
+  Severity: high. Likelihood: high. Mitigation: make the dependency mismatch an
+  explicit Stage A deliverable and do not mark the task done until it is
+  resolved.
+
+- Risk: CI currently does not provision `hx`, and `hx` on developer machines
+  may resolve to the Helix editor rather than SynHX. Severity: high.
+  Likelihood: high. Mitigation: pin installation/version checks in CI and keep
+  the Helix-detection guard in reusable harness code.
+
+- Risk: file-download validation may require secondary data-port handling,
+  temporary filesystem assertions, and stricter cleanup than the current
+  validator tests use. Severity: medium. Likelihood: medium. Mitigation:
+  centralize temp-directory and artefact assertions in shared helpers before
+  adding the end-to-end cases.
+
+- Risk: chat validation may require multiple concurrent `hx` sessions and
+  careful prompt coordination, increasing flakiness. Severity: medium.
+  Likelihood: medium. Mitigation: model multi-client orchestration in one
+  helper abstraction, keep explicit timeouts, and add focused unhappy-path
+  assertions.
+
+- Risk: the validator crate sits outside the workspace default members, so
+  existing `make test`/CI jobs do not exercise it. Severity: medium.
+  Likelihood: high. Mitigation: add explicit Makefile and CI coverage rather
+  than assuming workspace defaults.
+
+## Progress
+
+- [x] (2026-04-10 00:00Z) Drafted ExecPlan for roadmap item 1.6.2 with current
+      validator, CI, and routing constraints captured.
+- [ ] Audit requested validator flows against the currently implemented
+      wireframe transaction surface and recorded roadmap dependencies.
+- [ ] Refactor validator support code into reusable, unit-testable helpers.
+- [ ] Add `rstest` unit coverage for harness helpers and `rstest-bdd`
+      behavioural coverage where applicable.
+- [ ] Implement or extend validator end-to-end coverage for login, file
+      download, chat, and news flows against `mxd-wireframe-server`.
+- [ ] Add explicit CI execution for the validator harness with pinned `hx`
+      provisioning.
+- [ ] Document local Postgres validator execution using
+      `pg-embedded-setup-unpriv`.
+- [ ] Update `docs/design.md`, review `docs/users-guide.md`, and mark roadmap
+      item 1.6.2 done after acceptance evidence exists.
+- [ ] Run full quality gates with tee-captured logs and commit the final
+      implementation.
+
+## Surprises & Discoveries
+
+- Observation: the existing validator crate already launches `TestServer`,
+  which defaults to `mxd-wireframe-server` in `test-util/src/server/mod.rs`.
+  Impact: "target the wireframe server" is partially true today, but only by
+  convention and without explicit validator-level assertions.
+
+- Observation: current validator coverage is narrow.
+  Evidence: `validator/tests/login.rs` covers login only, and
+  `validator/tests/xor_compat.rs` covers XOR login plus news posting. There is
+  no validator coverage for file download, file listing, or chat.
+
+- Observation: the workspace default members exclude `validator`.
+  Evidence: `Cargo.toml` declares `default-members = ["."]`. Impact:
+  `make test` and the current CI matrix do not automatically run validator
+  tests.
+
+- Observation: CI does not install `hx`.
+  Evidence: `.github/workflows/ci.yml` provisions Rust, Postgres/SQLite
+  dependencies, `cargo-nextest`, and linters, but nothing for SynHX. Impact:
+  validator tests currently rely on skip behaviour rather than CI enforcement.
+
+- Observation: current wireframe routes do not include chat or file-download
+  transactions.
+  Evidence: `src/wireframe/route_ids.rs` exposes only routes `107`, `200`,
+  `370`, `371`, `400`, and `410`. Impact: roadmap acceptance for chat and file
+  download is ahead of the currently implemented transaction surface.
+
+- Observation: the current harness already detects the common "wrong hx"
+  failure mode.
+  Evidence: `validator/tests/xor_compat.rs` rejects the Helix editor by
+  checking `hx --version`. Impact: that logic should be extracted and reused,
+  not duplicated.
+
+## Decision Log
+
+- Decision: make server targeting explicit inside the validator harness even
+  though `TestServer` already defaults to `mxd-wireframe-server`. Rationale:
+  roadmap acceptance is about deliberate wireframe validation, not an implicit
+  default that could regress later. Date/Author: 2026-04-10 / Assistant
+
+- Decision: treat the current chat/file-download gap as a first-class planning
+  blocker, not something to paper over with partial "done" wording. Rationale:
+  roadmap phases 2.2, 2.3, and 3.x still own those transactions, so 1.6.2
+  needs an explicit sequencing decision before implementation claims
+  completion. Date/Author: 2026-04-10 / Assistant
+
+- Decision: extract validator primitives into library modules under
+  `validator/src/` and cover them with `rstest`, rather than growing ad hoc
+  test-local helpers in each file. Rationale: PTY orchestration, binary
+  discovery, temp downloads, and skip/fail policy are all logic worth testing
+  directly. Date/Author: 2026-04-10 / Assistant
+
+- Decision: introduce dedicated validator Makefile/CI entrypoints instead of
+  relying on workspace defaults. Rationale: `validator` is not a default member
+  and its runtime requirements differ from ordinary `cargo nextest` suites.
+  Date/Author: 2026-04-10 / Assistant
+
+- Decision: document local Postgres validation via `pg-embedded-setup-unpriv`,
+  but do not assume the first CI cut must run both backends unless explicitly
+  required during implementation. Rationale: the task acceptance says the
+  harness runs in CI; the request separately asks for local Postgres enablement.
+  Date/Author: 2026-04-10 / Assistant
+
+## Outcomes & Retrospective
+
+Intended outcomes once implemented:
+
+- The validator harness becomes an explicit wireframe regression layer rather
+  than a skippable compatibility smoke test.
+- Validator helpers are testable in isolation, reducing PTY-flake debugging.
+- CI proves the repository can run a real `hx` client against
+  `mxd-wireframe-server`.
+- Documentation and roadmap status stay aligned with actual validator
+  capabilities.
+
+Retrospective placeholder:
+
+- Implemented:
+- Did not implement:
+- Follow-up work:
+- Lesson:
+
+## Context and orientation
+
+Primary files and modules in current state:
+
+- `docs/roadmap.md`: source of roadmap item 1.6.2 and its acceptance wording.
+- `docs/design.md`: contains the validator-harness design narrative and must
+  record final decisions taken during implementation.
+- `docs/users-guide.md`: must be reviewed for any user-visible runtime or
+  workflow changes.
+- `README.md`: currently documents `cd validator && cargo test` with `hx`
+  installed, and may need updated validator instructions.
+- `validator/tests/login.rs`: current login-only `hx` validator test.
+- `validator/tests/xor_compat.rs`: current XOR/news validator test plus the
+  Helix-detection guard.
+- `validator/src/lib.rs`: likely home for extracted harness primitives.
+- `test-util/src/server/mod.rs`: shared server launcher that already defaults to
+  `mxd-wireframe-server`.
+- `.github/workflows/ci.yml`: current CI workflow that lacks `hx` provisioning
+  and validator execution.
+- `Cargo.toml`: workspace/default-member settings that currently exclude the
+  validator crate from default runs.
+- `Makefile`: current quality-gate entrypoints, which likewise omit explicit
+  validator targets.
+
+## Plan of work
+
+### Stage A: lock scope against real capabilities
+
+Audit roadmap item 1.6.2 against the actual wireframe implementation and the
+current `hx` client surface.
+
+Work items:
+
+- Inventory which requested flows are actually implemented in the wireframe
+  server today.
+- Verify the exact `hx` commands and observable prompts for login, news, file
+  download, and chat using the pinned client version.
+- Produce a short support matrix:
+  requested flow, server support status, `hx` support status, and whether the
+  flow is unblockable within 1.6.2.
+- If chat or file download still require future roadmap features, record that
+  explicitly in `docs/design.md` and keep 1.6.2 open until scope is resolved.
+
+Validation gate for Stage A:
+
+- A support matrix is captured in the Decision Log or design document.
+- No implementation proceeds under a false assumption that the named flows
+  already exist.
+
+### Stage B: refactor the validator harness into testable primitives
+
+Move one-off helper logic out of individual validator tests and into
+small modules under `validator/src/`.
+
+Target responsibilities:
+
+- `hx` binary discovery, version validation, and Helix rejection;
+- PTY/session creation with configurable expect timeouts;
+- explicit server-launch configuration that selects `mxd-wireframe-server`;
+- common command helpers (`connect`, `login`, `post news`, `download file`,
+  chat actions if supported);
+- temporary directory and downloaded-file assertions;
+- shared skip-vs-fail policy so local missing-`hx` runs stay informative while
+  CI fails closed when provisioning is expected.
+
+Unit coverage to add with `rstest`:
+
+- happy: valid `hx` discovery and command/session setup;
+- unhappy: missing binary, Helix binary, invalid prompt, failed cleanup;
+- edge: explicit server-binary override, temp-path handling, CI policy toggle.
+
+Validation gate for Stage B:
+
+- `cargo test -p validator` passes for harness-unit coverage without needing a
+  live `hx` session for every code path.
+
+### Stage C: add behavioural coverage where it helps
+
+Introduce `rstest-bdd` scenarios for validator behaviour that benefits from
+Given/When/Then readability, while keeping low-level PTY mechanics in ordinary
+tests.
+
+Candidate BDD surfaces:
+
+- deciding whether the harness should skip or fail based on environment and CI
+  expectations;
+- proving explicit wireframe-server targeting and setup preconditions;
+- documenting multi-step validation contracts for download/chat orchestration,
+  if those flows are available.
+
+Validation gate for Stage C:
+
+- Behaviour scenarios cover happy and unhappy orchestration paths and remain
+  deterministic without depending on fragile prompt timing for every step.
+
+### Stage D: extend end-to-end validator flows
+
+Expand the real-client validator coverage in `validator/tests/`.
+
+Required flows:
+
+- login:
+  successful login, invalid credentials, and compatibility-sensitive prompts or
+  responses;
+- news:
+  list and/or post/read coverage with unhappy-path assertions such as missing
+  article or permission denial where the server supports them;
+- file download:
+  download a known fixture to a temp directory and assert byte-for-byte output,
+  plus at least one unhappy path such as missing file or privilege failure;
+- chat:
+  validate the currently accepted chat scope with one happy path and one
+  unhappy path, which may require multiple `hx` sessions if the underlying
+  transaction support exists.
+
+Implementation notes:
+
+- Prefer parameterized `rstest` cases to avoid duplicating backend or flow
+  scaffolding.
+- Reuse `test-util` database setup helpers where possible.
+- Keep assertions on observable client behaviour first, then verify persisted
+  side effects (for example, downloaded bytes or stored news body) where needed
+  for confidence.
+
+Validation gate for Stage D:
+
+- Validator flow tests cover happy, unhappy, and relevant edge cases for each
+  accepted flow and point explicitly at `mxd-wireframe-server`.
+
+### Stage E: wire the validator into developer workflows and CI
+
+Make validator execution an intentional, documented part of the repository
+tooling.
+
+Work items:
+
+- Add Makefile targets such as `test-validator-sqlite` and
+  `test-validator-postgres`, or an equivalent target structure that keeps the
+  commands discoverable.
+- Decide whether validator tests should use `cargo test` instead of
+  `cargo nextest` because of PTY/process semantics, and document the reason.
+- Extend `.github/workflows/ci.yml` with a validator job or matrix leg that:
+  provisions a pinned SynHX `hx` binary,
+  verifies it is not Helix,
+  runs the validator harness against the wireframe server, and
+  preserves logs/artifacts useful for failure diagnosis.
+- Keep local Postgres validator execution documented via
+  `pg-embedded-setup-unpriv`, even if CI initially runs only the SQLite-backed
+  validator job.
+
+Validation gate for Stage E:
+
+- CI contains at least one non-skipping validator execution path and fails when
+  the harness cannot run as configured.
+
+### Stage F: documentation, roadmap closure, and final verification
+
+Update documentation and close the roadmap item only after evidence exists.
+
+Documentation tasks:
+
+- `docs/design.md`: record final decisions about explicit wireframe targeting,
+  `hx` provisioning, skip/fail policy, and any accepted scope adjustment.
+- `docs/users-guide.md`: update only if server behaviour or a documented
+  validation workflow becomes user-relevant.
+- `README.md`: refresh validator run instructions if commands or prerequisites
+  change.
+- `docs/roadmap.md`: mark 1.6.2 done with date and concise completion summary
+  only after all acceptance criteria and CI evidence exist.
+
+Validation tasks:
+
+- run formatter, lints, and tests through tee-captured commands;
+- include validator-specific commands in the final gate if they remain outside
+  `make test`;
+- run Markdown validation because this task changes planning and likely updates
+  design/user documentation.
+
+## Validation and commands
+
+Expected implementation-time commands, to be adjusted only if tooling changes:
+
+```sh
+make fmt
+make check-fmt
+make lint
+make test
+make markdownlint
+make nixie
+cargo test -p validator --features sqlite
+cargo test -p validator --no-default-features --features postgres
+```
+
+Local Postgres enablement should follow `docs/pg-embed-setup-unpriv-users-guide.md`,
+for example:
+
+```sh
+cargo install --locked pg-embed-setup-unpriv
+pg_embedded_setup_unpriv
+cargo test -p validator --no-default-features --features postgres
+```
+
+All long-running quality-gate commands should be run with `set -o pipefail`
+and piped through `tee` to retain complete logs for review.

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -339,11 +339,6 @@ Success is observable when:
   that does not by itself create coverage for flows the pinned client and
   server still express differently.
 
-- Implemented:
-- Did not implement:
-- Follow-up work:
-- Lesson:
-
 ## Context and orientation
 
 Primary files and modules in current state:

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -542,7 +542,13 @@ Local Postgres enablement should follow
 
 ```sh
 ./scripts/install-synhx.sh
-cargo install --locked pg-embed-setup-unpriv
+export PG_VERSION_REQ=15.13.0
+export PG_RUNTIME_DIR="$PWD/.tmp/pg/runtime"
+export PG_DATA_DIR="$PWD/.tmp/pg/data"
+export PG_SUPERUSER=postgres
+export PG_PASSWORD=postgres
+export PG_TEST_BACKEND=embedded
+cargo install --locked --version 0.5.0 pg-embed-setup-unpriv
 pg_embedded_setup_unpriv
 cargo test -p validator --no-default-features --features postgres
 ```

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -5,7 +5,7 @@ This ExecPlan is a living document. The sections `Constraints`,
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as
 work proceeds.
 
-Status: NOT STARTED
+Status: IN PROGRESS
 
 ## Purpose / big picture
 
@@ -26,7 +26,8 @@ Success is observable when:
 - new harness helpers are covered with `rstest` unit tests, and
   `rstest-bdd` scenarios are added where they improve readability for
   higher-level validation behaviour;
-- CI provisions a real `hx` binary and fails closed when validator coverage
+- devboxer and CI both provision SynHX through a shared
+  `scripts/install-synhx.sh` script and fail closed when validator coverage
   cannot run;
 - `docs/design.md` records the final harness-targeting and CI decisions;
 - `docs/users-guide.md` is updated if the implementation changes user-visible
@@ -50,6 +51,8 @@ Success is observable when:
   `docs/reliable-testing-in-rust-via-dependency-injection.md`.
 - Use `pg-embedded-setup-unpriv` for documented local Postgres validator runs
   rather than bespoke cluster setup.
+- Use a repository-owned SynHX install script rather than inline CI shell
+  fragments, so devboxer and CI share the same provisioning path.
 - Keep documentation in en-GB-oxendict spelling and wrap prose at 80 columns.
 - Do not add a new third-party dependency unless escalation is explicitly
   approved. Reusing workspace crates such as `rstest-bdd` is allowed.
@@ -66,7 +69,8 @@ Success is observable when:
 - Acceptance mismatch: if file download or chat validation requires roadmap
   tasks that are still incomplete in phases 2.x or 3.x, stop and either obtain
   approval for scoped substitute coverage or re-sequence the dependency chain.
-- Client capability: if `hx` v0.2.4 cannot script one of the required flows in
+- Client capability: if SynHX `hx` v0.1.48.1 cannot script one of the required
+  flows in
   headless mode, stop after confirming the exact limitation from `hx` help or
   source and present options.
 - CI stability: if the `hx` install/provision path remains flaky after two
@@ -112,6 +116,15 @@ Success is observable when:
       validator, CI, and routing constraints captured.
 - [ ] Audit requested validator flows against the currently implemented
       wireframe transaction surface and recorded roadmap dependencies.
+- [x] (2026-04-12 00:00Z) Added `scripts/install-synhx.sh` as the shared
+      SynHX provisioning path for devboxer and CI.
+- [x] (2026-04-12 00:00Z) Added config-gated placeholder validators for the
+      pending `chat` and `file_download` flows, plus developer documentation
+      describing how branches can opt into them via file or environment.
+- [x] (2026-04-12 00:00Z) Added `validator/validator.toml`,
+      `validator/src/config.rs`, and `validator/tests/pending_validators.rs`
+      so pending validators default to disabled on `main`, can be enabled per
+      branch, and fail explicitly when enabled before the server flow exists.
 - [ ] Refactor validator support code into reusable, unit-testable helpers.
 - [ ] Add `rstest` unit coverage for harness helpers and `rstest-bdd`
       behavioural coverage where applicable.
@@ -148,6 +161,28 @@ Success is observable when:
   dependencies, `cargo-nextest`, and linters, but nothing for SynHX. Impact:
   validator tests currently rely on skip behaviour rather than CI enforcement.
 
+- Observation: the currently documented SynHX version in legacy design text is
+  stale for this task.
+  Evidence: the supplied install process pins `HX_VERSION=0.1.48.1` from
+  `leynos/synhx-client` releases, whereas older design prose mentions `0.2.4`.
+  Impact: the plan should standardize on a repository-owned install script and
+  the newer pinned version.
+
+- Observation: pending validators need to coexist with `main` while parallel
+  feature work is still incomplete.
+  Evidence: `validator/tests/pending_validators.rs` now carries opt-in checks
+  for `chat` and `file_download`, and `validator/validator.toml` keeps both
+  disabled by default. Impact: feature branches can enable only the validators
+  they are ready to satisfy without destabilizing unrelated work.
+
+- Observation: the existing `validator/tests/login.rs` suite currently fails in
+  this environment before reaching `hx`.
+  Evidence: `cargo test -p validator --features sqlite --test login` fails with
+  `server failed protocol readiness check` from `TestServer` startup. Impact:
+  final 1.6.2 validation still needs a stable server-launch path for the
+  pre-existing login validator, independent of the new pending-validator
+  scaffolding.
+
 - Observation: current wireframe routes do not include chat or file-download
   transactions.
   Evidence: `src/wireframe/route_ids.rs` exposes only routes `107`, `200`,
@@ -183,6 +218,26 @@ Success is observable when:
   relying on workspace defaults. Rationale: `validator` is not a default member
   and its runtime requirements differ from ordinary `cargo nextest` suites.
   Date/Author: 2026-04-10 / Assistant
+
+- Decision: provision SynHX via `scripts/install-synhx.sh`, defaulting to
+  `HX_VERSION=0.1.48.1`, with environment overrides for install directories.
+  Rationale: one script gives devboxer and CI the same installation behaviour
+  and removes fragile duplicated shell snippets. Date/Author: 2026-04-12 /
+  Assistant
+
+- Decision: keep pending validators default-disabled in
+  `validator/validator.toml` and allow environment variables to override the
+  file on a per-run basis.
+  Rationale: `main` should stay green while parallel branches opt into the
+  validators they need, and environment overrides are the least-friction path
+  for CI jobs and ad hoc branch validation. Date/Author: 2026-04-12 /
+  Assistant
+
+- Decision: enabled pending validators fail explicitly with an
+  "enabled but not implemented yet" error until the underlying flow lands.
+  Rationale: silent skips would hide missing coverage on branches that claim to
+  implement chat or file-download support. Date/Author: 2026-04-12 /
+  Assistant
 
 - Decision: document local Postgres validation via `pg-embedded-setup-unpriv`,
   but do not assume the first CI cut must run both backends unless explicitly
@@ -228,6 +283,7 @@ Primary files and modules in current state:
   `mxd-wireframe-server`.
 - `.github/workflows/ci.yml`: current CI workflow that lacks `hx` provisioning
   and validator execution.
+- `scripts/install-synhx.sh`: shared SynHX installer for devboxer and CI.
 - `Cargo.toml`: workspace/default-member settings that currently exclude the
   validator crate from default runs.
 - `Makefile`: current quality-gate entrypoints, which likewise omit explicit
@@ -245,7 +301,8 @@ Work items:
 - Inventory which requested flows are actually implemented in the wireframe
   server today.
 - Verify the exact `hx` commands and observable prompts for login, news, file
-  download, and chat using the pinned client version.
+  download, and chat using the pinned client version installed by
+  `scripts/install-synhx.sh`.
 - Produce a short support matrix:
   requested flow, server support status, `hx` support status, and whether the
   flow is unblockable within 1.6.2.
@@ -351,10 +408,13 @@ Work items:
 - Decide whether validator tests should use `cargo test` instead of
   `cargo nextest` because of PTY/process semantics, and document the reason.
 - Extend `.github/workflows/ci.yml` with a validator job or matrix leg that:
-  provisions a pinned SynHX `hx` binary,
+  runs `scripts/install-synhx.sh` to provision a pinned SynHX `hx` binary,
   verifies it is not Helix,
   runs the validator harness against the wireframe server, and
   preserves logs/artifacts useful for failure diagnosis.
+- Ensure the installer script works in both devboxer and CI by supporting
+  environment overrides for the binary install directory and source checkout
+  path, while defaulting to `/usr/local/bin` and `~/git`.
 - Keep local Postgres validator execution documented via
   `pg-embedded-setup-unpriv`, even if CI initially runs only the SQLite-backed
   validator job.
@@ -392,6 +452,7 @@ Validation tasks:
 Expected implementation-time commands, to be adjusted only if tooling changes:
 
 ```sh
+./scripts/install-synhx.sh
 make fmt
 make check-fmt
 make lint
@@ -406,6 +467,7 @@ Local Postgres enablement should follow `docs/pg-embed-setup-unpriv-users-guide.
 for example:
 
 ```sh
+./scripts/install-synhx.sh
 cargo install --locked pg-embed-setup-unpriv
 pg_embedded_setup_unpriv
 cargo test -p validator --no-default-features --features postgres

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -1,9 +1,8 @@
 # Extend the hx validator harness to target the wireframe server
 
-This ExecPlan is a living document. The sections `Constraints`,
-`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as
-work proceeds.
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: IN PROGRESS
 
@@ -57,9 +56,9 @@ Success is observable when:
 - Do not add a new third-party dependency unless escalation is explicitly
   approved. Reusing workspace crates such as `rstest-bdd` is allowed.
 - Before any implementation commit, run the repository quality gates plus any
-  new validator-specific gates introduced by this work:
-  `make check-fmt`, `make lint`, `make test`, `make markdownlint`, `make nixie`,
-  and explicit validator commands if they are not folded into `make test`.
+  new validator-specific gates introduced by this work: `make check-fmt`,
+  `make lint`, `make test`, `make markdownlint`, `make nixie`, and explicit
+  validator commands if they are not folded into `make test`.
 
 ## Tolerances (exception triggers)
 
@@ -70,9 +69,8 @@ Success is observable when:
   tasks that are still incomplete in phases 2.x or 3.x, stop and either obtain
   approval for scoped substitute coverage or re-sequence the dependency chain.
 - Client capability: if SynHX `hx` v0.1.48.1 cannot script one of the required
-  flows in
-  headless mode, stop after confirming the exact limitation from `hx` help or
-  source and present options.
+  flows in headless mode, stop after confirming the exact limitation from `hx`
+  help or source and present options.
 - CI stability: if the `hx` install/provision path remains flaky after two
   focused fixes, stop and review whether the binary should be cached, pinned,
   or supplied differently.
@@ -114,8 +112,10 @@ Success is observable when:
 
 - [x] (2026-04-10 00:00Z) Drafted ExecPlan for roadmap item 1.6.2 with current
       validator, CI, and routing constraints captured.
-- [ ] Audit requested validator flows against the currently implemented
-      wireframe transaction surface and recorded roadmap dependencies.
+- [x] (2026-04-12 12:28Z) Audited the requested validator flows against the
+      currently implemented wireframe transaction surface and recorded the
+      remaining protocol mismatches for file listing, file download, chat, and
+      news.
 - [x] (2026-04-12 00:00Z) Added `scripts/install-synhx.sh` as the shared
       SynHX provisioning path for devboxer and CI.
 - [x] (2026-04-12 00:00Z) Added config-gated placeholder validators for the
@@ -125,17 +125,26 @@ Success is observable when:
       `validator/src/config.rs`, and `validator/tests/pending_validators.rs`
       so pending validators default to disabled on `main`, can be enabled per
       branch, and fail explicitly when enabled before the server flow exists.
-- [ ] Refactor validator support code into reusable, unit-testable helpers.
-- [ ] Add `rstest` unit coverage for harness helpers and `rstest-bdd`
-      behavioural coverage where applicable.
-- [ ] Implement or extend validator end-to-end coverage for login, file
-      download, chat, and news flows against `mxd-wireframe-server`.
-- [ ] Add explicit CI execution for the validator harness with pinned `hx`
-      provisioning.
-- [ ] Document local Postgres validator execution using
-      `pg-embedded-setup-unpriv`.
-- [ ] Update `docs/design.md`, review `docs/users-guide.md`, and mark roadmap
-      item 1.6.2 done after acceptance evidence exists.
+- [x] (2026-04-12 12:28Z) Refactored validator support code into reusable,
+      unit-testable helpers under `validator/src/` for run policy, server
+      binary resolution, SynHX detection/spawn, and harness orchestration.
+- [x] (2026-04-12 12:28Z) Added `rstest` unit coverage for the new support
+      modules. No `rstest-bdd` scenarios were added because the remaining
+      unsupported flows are blocked by protocol overlap rather than
+      orchestration readability.
+- [x] (2026-04-12 12:28Z) Extended validator end-to-end coverage for the
+      currently supported SynHX-to-wireframe overlap: successful login, failed
+      authentication gating, and XOR login against `mxd-wireframe-server`.
+- [x] (2026-04-12 12:28Z) Added explicit CI execution for the sqlite validator
+      harness with pinned `hx` provisioning and fail-closed policy.
+- [x] (2026-04-12 12:28Z) Documented local Postgres validator execution via
+      `make test-validator-postgres`, which builds the Postgres wireframe
+      binary through the same Makefile path used for other local runs.
+- [x] (2026-04-12 12:28Z) Updated `docs/design.md` and
+      `docs/developers-guide.md`, and reviewed `docs/users-guide.md` with no
+      user-visible workflow change requiring documentation updates.
+- [ ] Keep roadmap item 1.6.2 open until real-client file/news/chat coverage
+      exists or the acceptance criteria are re-scoped.
 - [ ] Run full quality gates with tee-captured logs and commit the final
       implementation.
 
@@ -146,10 +155,12 @@ Success is observable when:
   Impact: "target the wireframe server" is partially true today, but only by
   convention and without explicit validator-level assertions.
 
-- Observation: current validator coverage is narrow.
-  Evidence: `validator/tests/login.rs` covers login only, and
-  `validator/tests/xor_compat.rs` covers XOR login plus news posting. There is
-  no validator coverage for file download, file listing, or chat.
+- Observation: validator coverage remains narrower than the roadmap target.
+  Evidence: the validator suite now covers successful login, failed-auth
+  gating, XOR login, and config-gated placeholders for `chat` and
+  `file_download`, but still lacks real-client coverage for file listing, file
+  download, chat, and news. Impact: implementation progress is real, but
+  roadmap acceptance is still blocked by unsupported flows.
 
 - Observation: the workspace default members exclude `validator`.
   Evidence: `Cargo.toml` declares `default-members = ["."]`. Impact:
@@ -162,38 +173,73 @@ Success is observable when:
   validator tests currently rely on skip behaviour rather than CI enforcement.
 
 - Observation: the currently documented SynHX version in legacy design text is
-  stale for this task.
-  Evidence: the supplied install process pins `HX_VERSION=0.1.48.1` from
-  `leynos/synhx-client` releases, whereas older design prose mentions `0.2.4`.
-  Impact: the plan should standardize on a repository-owned install script and
-  the newer pinned version.
+  stale for this task. Evidence: the supplied install process pins
+  `HX_VERSION=0.1.48.1` from `leynos/synhx-client` releases, whereas older
+  design prose mentions `0.2.4`. Impact: the plan should standardize on a
+  repository-owned install script and the newer pinned version.
 
 - Observation: pending validators need to coexist with `main` while parallel
-  feature work is still incomplete.
-  Evidence: `validator/tests/pending_validators.rs` now carries opt-in checks
-  for `chat` and `file_download`, and `validator/validator.toml` keeps both
-  disabled by default. Impact: feature branches can enable only the validators
-  they are ready to satisfy without destabilizing unrelated work.
+  feature work is still incomplete. Evidence:
+  `validator/tests/pending_validators.rs` now carries opt-in checks for `chat`
+  and `file_download`, and `validator/validator.toml` keeps both disabled by
+  default. Impact: feature branches can enable only the validators they are
+  ready to satisfy without destabilizing unrelated work.
 
-- Observation: the existing `validator/tests/login.rs` suite currently fails in
-  this environment before reaching `hx`.
-  Evidence: `cargo test -p validator --features sqlite --test login` fails with
+- Observation: the original `validator/tests/login.rs` suite failed in this
+  environment before reaching `hx`. Evidence: earlier runs of
+  `cargo test -p validator --features sqlite --test login` failed with
   `server failed protocol readiness check` from `TestServer` startup. Impact:
-  final 1.6.2 validation still needs a stable server-launch path for the
-  pre-existing login validator, independent of the new pending-validator
-  scaffolding.
+  the implementation needed a stable explicit server-launch path before the
+  pre-existing login validator could become reliable.
+
+- Observation: the login readiness failure was caused by implicit
+  `cargo run` server startup rather than a protocol defect. Evidence: wiring
+  the validator harness to a prebuilt `mxd-wireframe-server` binary resolved
+  the readiness failure and made the login and XOR validators pass
+  consistently. Impact: explicit binary resolution is required for stable
+  validator execution in CI and local runs.
+
+- Observation: root-container Postgres validation requires the external
+  `pg_worker` helper and still does not make the validator's Postgres suite
+  pass in this environment. Evidence: `make test` passed once
+  `PG_EMBEDDED_WORKER` pointed at an installed `pg_worker` binary, but
+  `make test-validator-postgres` still failed with
+  `PostgreSQL server unreachable` from `validator/tests/login.rs`. Impact: the
+  documented local Postgres validator path exists, but it is not yet a
+  validated gate in this root container.
 
 - Observation: current wireframe routes do not include chat or file-download
-  transactions.
-  Evidence: `src/wireframe/route_ids.rs` exposes only routes `107`, `200`,
-  `370`, `371`, `400`, and `410`. Impact: roadmap acceptance for chat and file
-  download is ahead of the currently implemented transaction surface.
+  transactions. Evidence: `src/wireframe/route_ids.rs` exposes only routes
+  `107`, `200`, `370`, `371`, `400`, and `410`. Impact: roadmap acceptance for
+  chat and file download is ahead of the currently implemented transaction
+  surface.
 
 - Observation: the current harness already detects the common "wrong hx"
-  failure mode.
-  Evidence: `validator/tests/xor_compat.rs` rejects the Helix editor by
-  checking `hx --version`. Impact: that logic should be extracted and reused,
-  not duplicated.
+  failure mode. Evidence: `validator/tests/xor_compat.rs` rejects the Helix
+  editor by checking `hx --version`. Impact: that logic should be extracted and
+  reused, not duplicated.
+
+- Observation: SynHX file-list requests and replies only partially overlap with
+  the current wireframe server behaviour. Evidence: SynHX sends `/ls` as
+  transaction `200` with a binary `DATA_DIR` payload, which the server can now
+  tolerate, but the SynHX client still expects a legacy file-list reply shape
+  rather than the server's current parameter-encoded reply. Impact: file-list
+  and file-download validators remain blocked even after request-side
+  compatibility work.
+
+- Observation: SynHX news commands target legacy transaction identifiers that
+  do not match the current server implementation. Evidence: pinned SynHX `hx`
+  uses legacy news transactions `0x65` and `0x67`, while the wireframe server
+  implements `370`, `371`, `400`, and `410`. Impact: real-client news
+  validation cannot be completed through SynHX without either compatibility
+  shims or a different client path.
+
+- Observation: the currently supportable always-on validator surface is smaller
+  than the roadmap text suggests. Evidence: stable end-to-end coverage exists
+  today for login, failed-auth gating, and XOR login only; chat and file
+  download remain placeholder validators, and news/file-list coverage is
+  blocked by client-server protocol mismatches. Impact: the roadmap item must
+  stay open until either the server or the client compatibility surface expands.
 
 ## Decision Log
 
@@ -204,9 +250,9 @@ Success is observable when:
 
 - Decision: treat the current chat/file-download gap as a first-class planning
   blocker, not something to paper over with partial "done" wording. Rationale:
-  roadmap phases 2.2, 2.3, and 3.x still own those transactions, so 1.6.2
-  needs an explicit sequencing decision before implementation claims
-  completion. Date/Author: 2026-04-10 / Assistant
+  roadmap phases 2.2, 2.3, and 3.x still own those transactions, so 1.6.2 needs
+  an explicit sequencing decision before implementation claims completion.
+  Date/Author: 2026-04-10 / Assistant
 
 - Decision: extract validator primitives into library modules under
   `validator/src/` and cover them with `rstest`, rather than growing ad hoc
@@ -227,37 +273,66 @@ Success is observable when:
 
 - Decision: keep pending validators default-disabled in
   `validator/validator.toml` and allow environment variables to override the
-  file on a per-run basis.
-  Rationale: `main` should stay green while parallel branches opt into the
-  validators they need, and environment overrides are the least-friction path
-  for CI jobs and ad hoc branch validation. Date/Author: 2026-04-12 /
-  Assistant
+  file on a per-run basis. Rationale: `main` should stay green while parallel
+  branches opt into the validators they need, and environment overrides are the
+  least-friction path for CI jobs and ad hoc branch validation. Date/Author:
+  2026-04-12 / Assistant
 
 - Decision: enabled pending validators fail explicitly with an
   "enabled but not implemented yet" error until the underlying flow lands.
   Rationale: silent skips would hide missing coverage on branches that claim to
-  implement chat or file-download support. Date/Author: 2026-04-12 /
-  Assistant
+  implement chat or file-download support. Date/Author: 2026-04-12 / Assistant
 
 - Decision: document local Postgres validation via `pg-embedded-setup-unpriv`,
   but do not assume the first CI cut must run both backends unless explicitly
   required during implementation. Rationale: the task acceptance says the
-  harness runs in CI; the request separately asks for local Postgres enablement.
-  Date/Author: 2026-04-10 / Assistant
+  harness runs in CI; the request separately asks for local Postgres
+  enablement. Date/Author: 2026-04-10 / Assistant
+
+- Decision: resolve `mxd-wireframe-server` explicitly from a prebuilt binary in
+  the validator harness before falling back to inherited cargo test binary
+  hints. Rationale: compile-time startup delays from implicit `cargo run`
+  exceeded the validator readiness window and produced misleading protocol
+  startup failures. Date/Author: 2026-04-12 / Assistant
+
+- Decision: make the first CI validator job sqlite-only while still documenting
+  and supporting local Postgres validator runs. Rationale: the immediate goal
+  is a fail-closed real-client validator path in CI, and sqlite reaches that
+  goal without requiring a second backend job before the protocol overlap is
+  sufficient to justify more matrix expansion. Date/Author: 2026-04-12 /
+  Assistant
+
+- Decision: narrow always-on SynHX validator coverage to the flows that the
+  pinned client and current wireframe server both actually support today:
+  successful login, failed-auth gating, and XOR login. Rationale: pretending
+  that file listing, file download, chat, or news are covered would obscure the
+  real protocol gaps. Date/Author: 2026-04-12 / Assistant
+
+- Decision: keep roadmap item 1.6.2 open after this implementation pass.
+  Rationale: the harness plumbing, CI fail-closed path, and supported login
+  coverage are now in place, but genuine real-client validation for file/news/
+  chat flows still depends on additional compatibility or server feature work.
+  Date/Author: 2026-04-12 / Assistant
 
 ## Outcomes & Retrospective
 
-Intended outcomes once implemented:
+- Implemented: shared SynHX installation for devboxer and CI, explicit
+  wireframe server binary resolution, reusable validator helper modules, stable
+  login and XOR-login coverage, validator Makefile targets, sqlite CI
+  execution, and design/developer documentation updates.
 
-- The validator harness becomes an explicit wireframe regression layer rather
-  than a skippable compatibility smoke test.
-- Validator helpers are testable in isolation, reducing PTY-flake debugging.
-- CI proves the repository can run a real `hx` client against
-  `mxd-wireframe-server`.
-- Documentation and roadmap status stay aligned with actual validator
-  capabilities.
+- Did not implement: genuine real-client coverage for file download, chat, or
+  news, and did not produce usable SynHX file-list validation beyond the
+  request-side compatibility tolerance.
 
-Retrospective placeholder:
+- Follow-up work: add compatibility for the legacy SynHX file-list and news
+  transaction shapes, or introduce a different real client that matches the
+  current wireframe protocol surface well enough to cover the remaining flows.
+
+- Lesson: harness plumbing and protocol overlap are separate delivery tracks.
+  The validator can now fail closed and target the right server explicitly, but
+  that does not by itself create coverage for flows the pinned client and
+  server still express differently.
 
 - Implemented:
 - Did not implement:
@@ -317,8 +392,8 @@ Validation gate for Stage A:
 
 ### Stage B: refactor the validator harness into testable primitives
 
-Move one-off helper logic out of individual validator tests and into
-small modules under `validator/src/`.
+Move one-off helper logic out of individual validator tests and into small
+modules under `validator/src/`.
 
 Target responsibilities:
 
@@ -409,9 +484,8 @@ Work items:
   `cargo nextest` because of PTY/process semantics, and document the reason.
 - Extend `.github/workflows/ci.yml` with a validator job or matrix leg that:
   runs `scripts/install-synhx.sh` to provision a pinned SynHX `hx` binary,
-  verifies it is not Helix,
-  runs the validator harness against the wireframe server, and
-  preserves logs/artifacts useful for failure diagnosis.
+  verifies it is not Helix, runs the validator harness against the wireframe
+  server, and preserves logs/artifacts useful for failure diagnosis.
 - Ensure the installer script works in both devboxer and CI by supporting
   environment overrides for the binary install directory and source checkout
   path, while defaulting to `/usr/local/bin` and `~/git`.
@@ -463,8 +537,8 @@ cargo test -p validator --features sqlite
 cargo test -p validator --no-default-features --features postgres
 ```
 
-Local Postgres enablement should follow `docs/pg-embed-setup-unpriv-users-guide.md`,
-for example:
+Local Postgres enablement should follow
+`docs/pg-embed-setup-unpriv-users-guide.md`, for example:
 
 ```sh
 ./scripts/install-synhx.sh
@@ -473,5 +547,5 @@ pg_embedded_setup_unpriv
 cargo test -p validator --no-default-features --features postgres
 ```
 
-All long-running quality-gate commands should be run with `set -o pipefail`
-and piped through `tee` to retain complete logs for review.
+All long-running quality-gate commands should be run with `set -o pipefail` and
+piped through `tee` to retain complete logs for review.

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -251,73 +251,73 @@ Success is observable when:
 - Decision: make server targeting explicit inside the validator harness even
   though `TestServer` already defaults to `mxd-wireframe-server`. Rationale:
   roadmap acceptance is about deliberate wireframe validation, not an implicit
-  default that could regress later. Date/Author: 2026-04-10 / Assistant
+  default that could regress later. Date/Author: 2026-04-10 / Assistant.
 
 - Decision: treat the current chat/file-download gap as a first-class planning
   blocker, not something to paper over with partial "done" wording. Rationale:
   roadmap phases 2.2, 2.3, and 3.x still own those transactions, so 1.6.2 needs
   an explicit sequencing decision before implementation claims completion.
-  Date/Author: 2026-04-10 / Assistant
+  Date/Author: 2026-04-10 / Assistant.
 
 - Decision: extract validator primitives into library modules under
   `validator/src/` and cover them with `rstest`, rather than growing ad hoc
   test-local helpers in each file. Rationale: PTY orchestration, binary
   discovery, temp downloads, and skip/fail policy are all logic worth testing
-  directly. Date/Author: 2026-04-10 / Assistant
+  directly. Date/Author: 2026-04-10 / Assistant.
 
 - Decision: introduce dedicated validator Makefile/CI entrypoints instead of
   relying on workspace defaults. Rationale: `validator` is not a default member
   and its runtime requirements differ from ordinary `cargo nextest` suites.
-  Date/Author: 2026-04-10 / Assistant
+  Date/Author: 2026-04-10 / Assistant.
 
 - Decision: provision SynHX via `scripts/install-synhx.sh`, defaulting to
   `HX_VERSION=0.1.48.1`, with environment overrides for install directories.
   Rationale: one script gives devboxer and CI the same installation behaviour
   and removes fragile duplicated shell snippets. Date/Author: 2026-04-12 /
-  Assistant
+  Assistant.
 
 - Decision: keep pending validators default-disabled in
   `validator/validator.toml` and allow environment variables to override the
   file on a per-run basis. Rationale: `main` should stay green while parallel
   branches opt into the validators they need, and environment overrides are the
   least-friction path for CI jobs and ad hoc branch validation. Date/Author:
-  2026-04-12 / Assistant
+  2026-04-12 / Assistant.
 
 - Decision: enabled pending validators fail explicitly with an
   "enabled but not implemented yet" error until the underlying flow lands.
   Rationale: silent skips would hide missing coverage on branches that claim to
-  implement chat or file-download support. Date/Author: 2026-04-12 / Assistant
+  implement chat or file-download support. Date/Author: 2026-04-12 / Assistant.
 
 - Decision: document local Postgres validation via `pg-embed-setup-unpriv`,
   but do not assume the first CI cut must run both backends unless explicitly
   required during implementation. Rationale: the task acceptance says the
   harness runs in CI; the request separately asks for local Postgres
-  enablement. Date/Author: 2026-04-10 / Assistant
+  enablement. Date/Author: 2026-04-10 / Assistant.
 
 - Decision: resolve `mxd-wireframe-server` explicitly from a prebuilt binary in
   the validator harness before falling back to inherited cargo test binary
   hints. Rationale: compile-time startup delays from implicit `cargo run`
   exceeded the validator readiness window and produced misleading protocol
-  startup failures. Date/Author: 2026-04-12 / Assistant
+  startup failures. Date/Author: 2026-04-12 / Assistant.
 
 - Decision: make the first CI validator job sqlite-only while still documenting
   and supporting local Postgres validator runs. Rationale: the immediate goal
   is a fail-closed real-client validator path in CI, and sqlite reaches that
   goal without requiring a second backend job before the protocol overlap is
   sufficient to justify more matrix expansion. Date/Author: 2026-04-12 /
-  Assistant
+  Assistant.
 
 - Decision: narrow always-on SynHX validator coverage to the flows that the
   pinned client and current wireframe server both actually support today:
   successful login, failed-auth gating, and XOR login. Rationale: pretending
   that file listing, file download, chat, or news are covered would obscure the
-  real protocol gaps. Date/Author: 2026-04-12 / Assistant
+  real protocol gaps. Date/Author: 2026-04-12 / Assistant.
 
 - Decision: keep roadmap item 1.6.2 open after this implementation pass.
   Rationale: the harness plumbing, CI fail-closed path, and supported login
   coverage are now in place, but genuine real-client validation for file/news/
   chat flows still depends on additional compatibility or server feature work.
-  Date/Author: 2026-04-12 / Assistant
+  Date/Author: 2026-04-12 / Assistant.
 
 ## Outcomes & Retrospective
 

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -149,7 +149,7 @@ Success is observable when:
       platforms and missing `sudo`, and normalizing `pg-embed-setup-unpriv`
       command and guide references in the touched documentation.
 - [ ] Keep roadmap item 1.6.2 open until real-client file/news/chat coverage
-      exists or the acceptance criteria are re-scoped.
+      exists, or the acceptance criteria are re-scoped.
 - [ ] Run full quality gates with tee-captured logs and commit the final
       implementation.
 
@@ -178,7 +178,7 @@ Success is observable when:
   validator tests currently rely on skip behaviour rather than CI enforcement.
 
 - Observation: the currently documented SynHX version in legacy design text is
-  stale for this task. Evidence: the supplied install process pins
+  stale for this task. Evidence: the supplied installation process pins
   `HX_VERSION=0.1.48.1` from `leynos/synhx-client` releases, whereas older
   design prose mentions `0.2.4`. Impact: the plan should standardize on a
   repository-owned install script and the newer pinned version.

--- a/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
+++ b/docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
@@ -25,9 +25,9 @@ Success is observable when:
 - new harness helpers are covered with `rstest` unit tests, and
   `rstest-bdd` scenarios are added where they improve readability for
   higher-level validation behaviour;
-- devboxer and CI both provision SynHX through a shared
-  `scripts/install-synhx.sh` script and fail closed when validator coverage
-  cannot run;
+- devboxer and continuous integration (CI) both provision SynHX through a
+  shared `scripts/install-synhx.sh` script and fail closed when validator
+  coverage cannot run;
 - `docs/design.md` records the final harness-targeting and CI decisions;
 - `docs/users-guide.md` is updated if the implementation changes user-visible
   runtime behaviour or supported validation workflows;
@@ -43,12 +43,12 @@ Success is observable when:
 - Extract reusable harness logic into unit-testable helpers and cover that
   logic with `rstest`.
 - Add `rstest-bdd` behavioural coverage where it clarifies multi-step harness
-  orchestration or validation contracts; do not force BDD onto low-level PTY
-  details that are better expressed as ordinary tests.
+  orchestration or validation contracts; do not force BDD onto low-level
+  pseudo-terminal (PTY) details that are better expressed as ordinary tests.
 - Use dependency injection for process-launch, filesystem, and environment
   seams where that materially improves deterministic testing, following
   `docs/reliable-testing-in-rust-via-dependency-injection.md`.
-- Use `pg-embedded-setup-unpriv` for documented local Postgres validator runs
+- Use `pg-embed-setup-unpriv` for documented local Postgres validator runs
   rather than bespoke cluster setup.
 - Use a repository-owned SynHX install script rather than inline CI shell
   fragments, so devboxer and CI share the same provisioning path.
@@ -143,6 +143,11 @@ Success is observable when:
 - [x] (2026-04-12 12:28Z) Updated `docs/design.md` and
       `docs/developers-guide.md`, and reviewed `docs/users-guide.md` with no
       user-visible workflow change requiring documentation updates.
+- [x] (2026-04-20 00:00Z) Addressed review follow-up by reusing the shared
+      validator skip helper, marking exported validator error enums as
+      non-exhaustive, hardening `scripts/install-synhx.sh` for unsupported
+      platforms and missing `sudo`, and normalizing `pg-embed-setup-unpriv`
+      command and guide references in the touched documentation.
 - [ ] Keep roadmap item 1.6.2 open until real-client file/news/chat coverage
       exists or the acceptance criteria are re-scoped.
 - [ ] Run full quality gates with tee-captured logs and commit the final
@@ -283,7 +288,7 @@ Success is observable when:
   Rationale: silent skips would hide missing coverage on branches that claim to
   implement chat or file-download support. Date/Author: 2026-04-12 / Assistant
 
-- Decision: document local Postgres validation via `pg-embedded-setup-unpriv`,
+- Decision: document local Postgres validation via `pg-embed-setup-unpriv`,
   but do not assume the first CI cut must run both backends unless explicitly
   required during implementation. Rationale: the task acceptance says the
   harness runs in CI; the request separately asks for local Postgres
@@ -490,7 +495,7 @@ Work items:
   environment overrides for the binary install directory and source checkout
   path, while defaulting to `/usr/local/bin` and `~/git`.
 - Keep local Postgres validator execution documented via
-  `pg-embedded-setup-unpriv`, even if CI initially runs only the SQLite-backed
+  `pg-embed-setup-unpriv`, even if CI initially runs only the SQLite-backed
   validator job.
 
 Validation gate for Stage E:

--- a/docs/execplans/wireframe-v0-3-0-migration.md
+++ b/docs/execplans/wireframe-v0-3-0-migration.md
@@ -115,11 +115,11 @@ changing behaviour.
   narrow set of concrete changes.
 
 - Observation: `src/server/wireframe/mod.rs` initially validated app
-  construction at startup, then logged and fell back to
-  `HotlineApp::default()` when per-connection app setup failed. Evidence:
-  `build_app_with_logging()` caught `try_build_app()` errors and returned
-  `fallback_app()`. Impact: v0.3.0's fallible app factory directly addressed
-  an existing workaround and was the clearest capability win for `mxd`.
+  construction at startup, then logged and fell back to `HotlineApp::default()`
+  when per-connection app setup failed. Evidence: `build_app_with_logging()`
+  caught `try_build_app()` errors and returned `fallback_app()`. Impact:
+  v0.3.0's fallible app factory directly addressed an existing workaround and
+  was the clearest capability win for `mxd`.
 
 - Observation: Hotline transaction fragmentation is already implemented inside
   `HotlineCodec`, not by wireframe's transport fragmentation layer. Evidence:
@@ -136,20 +136,18 @@ changing behaviour.
   applicable migration targets.
 
 - Observation: `wireframe` v0.3.0's fallible app factory fits the existing
-  handshake-context dependency cleanly.
-  Evidence: replacing `fallback_app()` with a
-  `Result<HotlineApp, AppFactoryError>` closure required only local changes in
-  `src/server/wireframe/mod.rs` plus targeted tests. Impact: the server now
-  fails closed when per-connection handshake context is missing, without
-  widening the migration into route or middleware redesign.
+  handshake-context dependency cleanly. Evidence: replacing `fallback_app()`
+  with a `Result<HotlineApp, AppFactoryError>` closure required only local
+  changes in `src/server/wireframe/mod.rs` plus targeted tests. Impact: the
+  server now fails closed when per-connection handshake context is missing,
+  without widening the migration into route or middleware redesign.
 
 - Observation: `wireframe::testkit` is not a clear win for the current Hotline
-  transport tests.
-  Evidence: the suites most relevant to the migration already depend on
-  Hotline-specific preamble bytes, frame reassembly, and bespoke helpers, and
-  the dependency bump plus app-factory refactor did not create painful test
-  boilerplate. Impact: the migration can stay smaller and lower risk by
-  keeping the existing test helpers for now.
+  transport tests. Evidence: the suites most relevant to the migration already
+  depend on Hotline-specific preamble bytes, frame reassembly, and bespoke
+  helpers, and the dependency bump plus app-factory refactor did not create
+  painful test boilerplate. Impact: the migration can stay smaller and lower
+  risk by keeping the existing test helpers for now.
 
 ## Decision log
 
@@ -194,9 +192,9 @@ the current preamble and framing suites.
 ## Context and orientation
 
 `mxd` is a Rust workspace whose wireframe integration lives under
-`src/server/wireframe/` and `src/wireframe/`. The manifest at `Cargo.toml`
-now declares `wireframe = "0.3.0"` and builds the `mxd-wireframe-server`
-binary from `src/bin/mxd_wireframe_server.rs`.
+`src/server/wireframe/` and `src/wireframe/`. The manifest at `Cargo.toml` now
+declares `wireframe = "0.3.0"` and builds the `mxd-wireframe-server` binary
+from `src/bin/mxd_wireframe_server.rs`.
 
 The key runtime file is `src/server/wireframe/mod.rs`. It defines `HotlineApp`
 as `WireframeApp<BincodeSerializer, (), Envelope, HotlineFrameCodec>`, prepares
@@ -206,12 +204,10 @@ a `WireframeServer`, installs Hotline preamble hooks from
 middleware.
 
 `src/wireframe/protocol.rs` implements wireframe protocol hooks for Hotline. It
-now imports `ConnectionContext` and `WireframeProtocol` from
-`wireframe::hooks`.
+now imports `ConnectionContext` and `WireframeProtocol` from `wireframe::hooks`.
 
 `src/wireframe/outbound.rs` stores and retrieves per-connection push handles.
-It now imports `ConnectionId` and `SessionRegistry` from
-`wireframe::session`.
+It now imports `ConnectionId` and `SessionRegistry` from `wireframe::session`.
 
 `src/wireframe/codec/frame.rs` adapts the in-tree `HotlineCodec` to wireframe's
 `FrameCodec` trait. It is the bridge between Hotline transaction bytes and
@@ -224,11 +220,11 @@ stores handshake context, and contains tests that now import
 The most relevant tests for this migration are:
 
 1. `tests/wireframe_handshake_metadata.rs`
-1. `tests/wireframe_transaction.rs`
-1. `tests/wireframe_xor_compat.rs`
-1. `src/wireframe/codec/tests.rs`
-1. `src/wireframe/codec/framed_tests.rs`
-1. `src/wireframe/handshake.rs` tests
+2. `tests/wireframe_transaction.rs`
+3. `tests/wireframe_xor_compat.rs`
+4. `src/wireframe/codec/tests.rs`
+5. `src/wireframe/codec/framed_tests.rs`
+6. `src/wireframe/handshake.rs` tests
 
 In this plan, a "fallible app factory" means a closure passed to
 `WireframeServer::new` that returns `Result<WireframeApp, E>` instead of always
@@ -255,9 +251,9 @@ Fix the removed root re-export usages first:
 
 1. In `src/wireframe/protocol.rs`, import
    `ConnectionContext` and `WireframeProtocol` from `wireframe::hooks`.
-1. In `src/wireframe/outbound.rs`, import `ConnectionId` and
+2. In `src/wireframe/outbound.rs`, import `ConnectionId` and
    `SessionRegistry` from `wireframe::session`.
-1. In `src/wireframe/handshake.rs` test code and any similar sites, import
+3. In `src/wireframe/handshake.rs` test code and any similar sites, import
    `BincodeSerializer` from `wireframe::serializer`.
 
 While doing this, inspect compile errors for any secondary breakage in tests,
@@ -338,7 +334,7 @@ All commands run from:
    Updating wireframe v0.2.0 -> v0.3.0
    ```
 
-1. Run a focused wireframe-only compile or test pass to surface API errors
+2. Run a focused wireframe-only compile or test pass to surface API errors
    quickly.
 
    ```plaintext
@@ -350,7 +346,7 @@ All commands run from:
    moved imports such as `ConnectionContext`, `WireframeProtocol`,
    `ConnectionId`, `SessionRegistry`, or `BincodeSerializer`.
 
-1. After import fixes, re-run the focused wireframe-only suite.
+3. After import fixes, re-run the focused wireframe-only suite.
 
    ```plaintext
    make typecheck-wireframe-only
@@ -360,7 +356,7 @@ All commands run from:
    Expected outcome after fixes: the wireframe-only build succeeds and the
    focused tests pass.
 
-1. After the fallible factory refactor and any targeted test updates, run the
+4. After the fallible factory refactor and any targeted test updates, run the
    full repository gates.
 
    ```plaintext
@@ -379,7 +375,7 @@ All commands run from:
    test result: ok
    ```
 
-1. If implementation edits any Markdown beyond this ExecPlan, also run:
+5. If implementation edits any Markdown beyond this ExecPlan, also run:
 
    ```plaintext
    make fmt
@@ -471,8 +467,8 @@ impl WireframeProtocol for HotlineProtocol {
 The dependency plan is:
 
 1. Update the main dependency to `wireframe = "0.3.0"`.
-1. Add only the `testkit` feature if a migrated test proves it is useful.
-1. Do not add `wireframe_testing` without explicit approval.
+2. Add only the `testkit` feature if a migrated test proves it is useful.
+3. Do not add `wireframe_testing` without explicit approval.
 
 ## Revision note
 

--- a/docs/file-sharing-design.md
+++ b/docs/file-sharing-design.md
@@ -7,15 +7,16 @@ Hotline-inspired BBS server. It covers the design and implementation of file
 transactions analogous to Hotline protocol codes **200–213** – including
 directory listing, file upload/download (with resume support), folder
 creation/deletion, moving/renaming, aliasing, folder upload/download, and file
-metadata updates. The implementation focuses exclusively on file sharing, **reusing the existing
-user/ACL architecture** from the broader application. This implementation is
-backend-agnostic, using Rust's `object_store` crate for storage so it can
-target AWS S3, Azure Blob, local files, etc. This guide addresses how to map a
-classic hierarchical folder tree onto the flat keyspace of object storage,
-handle resumable transfers via byte ranges and multipart uploads, model
-**aliases**, **dropboxes**, **upload folders**, and **file comments** in the
-database, and enforce **folder-level and per-file ACLs**. This guide also discusses
-trade-offs in metadata synchronization, consistency, and performance.
+metadata updates. The implementation focuses exclusively on file sharing,
+**reusing the existing user/ACL architecture** from the broader application.
+This implementation is backend-agnostic, using Rust's `object_store` crate for
+storage so it can target AWS S3, Azure Blob, local files, etc. This guide
+addresses how to map a classic hierarchical folder tree onto the flat keyspace
+of object storage, handle resumable transfers via byte ranges and multipart
+uploads, model **aliases**, **dropboxes**, **upload folders**, and **file
+comments** in the database, and enforce **folder-level and per-file ACLs**.
+This guide also discusses trade-offs in metadata synchronization, consistency,
+and performance.
 
 ## Protocol Alignment with Hotline Transactions (200–213)
 
@@ -48,8 +49,8 @@ for robustness and scalability.
 file content. The server logic (written in Rust) mediates between client
 requests, the DB, and the object store: for example, a download request
 triggers a DB lookup and an object store read stream. By leveraging the Rust
-**`object_store`** crate, it is possible to easily swap underlying storage (local
-filesystem, S3, Azure, etc.) without code changes. All storage access is
+**`object_store`** crate, it is possible to easily swap underlying storage
+(local filesystem, S3, Azure, etc.) without code changes. All storage access is
 asynchronous and stream-oriented for efficiency. The **ACL and user
 management** are part of the broader application schema and are reused here –
 meaning file/folder permissions are stored and enforced using the same tables
@@ -80,21 +81,23 @@ component, including how it ties into the user/permission system.
 
 ## Data Model and Schema
 
-To model files, folders, and related features, the system defines a **FileNode** table
-representing an item in the hierarchy (which might be a folder, a file, or an
-alias pointer). We also integrate with existing **User**, **Group**, and
-**Permission/ACL** tables from the application for access control. Each file or
-folder can have fine-grained ACL entries (linking to users or groups) in the
-shared permissions table. We include fields for metadata like size, timestamps,
-and comments. Below is the ER diagram in Mermaid notation:
+To model files, folders, and related features, the system defines a
+**FileNode** table representing an item in the hierarchy (which might be a
+folder, a file, or an alias pointer). We also integrate with existing **User**,
+**Group**, and **Permission/ACL** tables from the application for access
+control. Each file or folder can have fine-grained ACL entries (linking to
+users or groups) in the shared permissions table. We include fields for
+metadata like size, timestamps, and comments. Below is the ER diagram in
+Mermaid notation:
 
 **Diagram description for screen readers:** The diagram shows main entities
-FileNode (representing files, folders, or aliases), User, Group, and Permission/ACL,
-with their key relationships. FileNode has a parent/child hierarchy (self-referential
-parent_id). FileNode links to Permission/ACL entries which reference User or Group
-as principals. Key metadata fields include size, timestamps (created_at, modified_at),
-comments, and object_key. The shared permissions table connects FileNodes to Users
-and Groups for access control.
+FileNode (representing files, folders, or aliases), User, Group, and
+Permission/ACL, with their key relationships. FileNode has a parent/child
+hierarchy (self-referential parent_id). FileNode links to Permission/ACL
+entries which reference User or Group as principals. Key metadata fields
+include size, timestamps (created_at, modified_at), comments, and object_key.
+The shared permissions table connects FileNodes to Users and Groups for access
+control.
 
 ```mermaid
 erDiagram
@@ -228,8 +231,8 @@ CREATE TABLE Permission (
 -- (For file sharing, resource_type might be 'file' or 'folder'; both map to FileNode IDs.)
 ```
 
-This schema enables the representation of the complete file system hierarchy and
-access controls:
+This schema enables the representation of the complete file system hierarchy
+and access controls:
 
 - A folder’s contents are FileNode entries with that folder’s ID as their
   parent_id. We can traverse parent_id links to resolve full paths or to
@@ -269,59 +272,60 @@ follows:
 - **Database as Source of Truth:** The **FileNode** hierarchy in the database is
   the authoritative representation of directories, subdirectories, and file
   names. We do **not** rely on the object store to list or organize
-  directories. This allows metadata attachment (permissions, comments, etc.)
-  to directories themselves, which object stores cannot do. Folders in our
-  system are logical constructs (entries in the DB) and need not correspond to
-  any physical object in the store.
+  directories. This allows metadata attachment (permissions, comments, etc.) to
+  directories themselves, which object stores cannot do. Folders in our system
+  are logical constructs (entries in the DB) and need not correspond to any
+  physical object in the store.
 - **Object Key Design:** For actual file content, an **object key** is generated
   for each file stored. A simple strategy is to use a path-like key mirroring
   the file's path (e.g., combine parent folder names and filename). However,
-  **the system prefers using a unique identifier** (like the FileNode `id` or a UUID) as
-  the object key, decoupling it from the human-readable path. This approach
-  avoids expensive renames or copies in storage when a file is moved or renamed
-  in the hierarchy. For example, if file *"Manual.pdf"* (id 42) is stored with
-  key `"files/42.pdf"`, moving it to a different folder in the DB does not
-  require moving the object or changing the key. In contrast, if path-based keys had been used
-  `"Docs/Manual.pdf"` as the key, renaming the "Docs" folder would require
-  renaming every object under it. By mapping each file to a **stable flat
-  key**, storage operations remain simple and atomic (create/delete) and
-  handle renames purely in metadata.
+  **the system prefers using a unique identifier** (like the FileNode `id` or a
+  UUID) as the object key, decoupling it from the human-readable path. This
+  approach avoids expensive renames or copies in storage when a file is moved
+  or renamed in the hierarchy. For example, if file *"Manual.pdf"* (id 42) is
+  stored with key `"files/42.pdf"`, moving it to a different folder in the DB
+  does not require moving the object or changing the key. In contrast, if
+  path-based keys had been used `"Docs/Manual.pdf"` as the key, renaming the
+  "Docs" folder would require renaming every object under it. By mapping each
+  file to a **stable flat key**, storage operations remain simple and atomic
+  (create/delete) and handle renames purely in metadata.
 - **Folder Listing:** When a client requests a directory listing
   (GetFileNameList), the server queries the DB for FileNodes with `parent_id` =
   that folder's ID. The object store is not consulted at all for listing,
-  achieving immunity to object store listing consistency issues and ensuring inclusion of
-  additional info (file type, size, comments) directly from the DB. If using
-  ID-based object keys, the server might on occasion verify the object exists
-  (e.g., using a HEAD request via object_store for sanity), but that’s optional
-  and can be done in background audits. If path-based keys were used, object_store's `list` could be used with a prefix filter, but the system would still need the
-  DB to get comments and permissions, so it's simpler to rely entirely on the
-  DB for structure.
+  achieving immunity to object store listing consistency issues and ensuring
+  inclusion of additional info (file type, size, comments) directly from the
+  DB. If using ID-based object keys, the server might on occasion verify the
+  object exists (e.g., using a HEAD request via object_store for sanity), but
+  that’s optional and can be done in background audits. If path-based keys were
+  used, object_store's `list` could be used with a prefix filter, but the
+  system would still need the DB to get comments and permissions, so it's
+  simpler to rely entirely on the DB for structure.
 - **Folder Creation and Deletion:** Creating a folder (NewFolder command)
   results in a new FileNode of type 'folder' in the DB. **No object is created
   in the store** for it (consistent with object stores not needing a
   placeholder object for directories). Deleting a folder in the DB (if empty or
   via recursive delete) will involve deleting all descendant FileNode records
-  and all associated file objects; `object_store` delete operations are then executed
-  for each file object. Deletion of a folder in object storage
-  is thus just deletion of the contained objects (since the folder itself is
+  and all associated file objects; `object_store` delete operations are then
+  executed for each file object. Deletion of a folder in object storage is thus
+  just deletion of the contained objects (since the folder itself is
   conceptual).
 - **Path Resolution:** Since clients and protocol refer to files by “path”
   (folder names + filename), the server will need to resolve those into a
   FileNode ID. This can be done with recursive DB queries (e.g., find child by
   name under parent, etc.). To optimize, one could store a full path string or
   a path hash for quick lookups, but that complicates updates on move/rename.
-  Instead, traversal can proceed stepwise or indexed queries on parent+name can be used (the
-  unique constraint helps here). For example, to find
-  `"/Uploads/2025/Report.pdf"`, the root "Uploads" folder is located, then
-  find child “2025” under it, then “Report.pdf” under that. These lookups are
+  Instead, traversal can proceed stepwise or indexed queries on parent+name can
+  be used (the unique constraint helps here). For example, to find
+  `"/Uploads/2025/Report.pdf"`, the root "Uploads" folder is located, then find
+  child “2025” under it, then “Report.pdf” under that. These lookups are
   typically fast with proper indexes. The final file node provides the
   `object_key` to access the content.
 
-This mapping strategy ensures a **hierarchical view** is maintained for users and
-ACLs, while the underlying storage remains a flat pool of objects identified by
-opaque keys. It leverages the strengths of each: the database handles
-relationships and rich metadata, and the object store handles large binary data
-efficiently.
+This mapping strategy ensures a **hierarchical view** is maintained for users
+and ACLs, while the underlying storage remains a flat pool of objects
+identified by opaque keys. It leverages the strengths of each: the database
+handles relationships and rich metadata, and the object store handles large
+binary data efficiently.
 
 ## File Operations Implementation
 
@@ -337,27 +341,27 @@ When the client requests a directory listing of a given path (or root), the
 server performs:
 
 1. **Path Resolution:** Determine which folder to list. If the request includes
-   a path, the system looks up the FileNode for that folder. If no path is given, it uses the
-   root folder (by convention, the root might be a FileNode with parent_id =
-   NULL).
+   a path, the system looks up the FileNode for that folder. If no path is
+   given, it uses the root folder (by convention, the root might be a FileNode
+   with parent_id = NULL).
 2. **Permission Check:** Ensure the user has rights to list/browse this folder.
    Hotline did not have a separate “list folder” privilege bit, but
    effectively, to see files one needed Download permission on that folder or
-   the special *View Drop Boxes (30)* privilege for hidden dropboxes. In the system,
-   listing can be treated as requiring at least read access. If the
+   the special *View Drop Boxes (30)* privilege for hidden dropboxes. In the
+   system, listing can be treated as requiring at least read access. If the
    folder is a dropbox (`is_dropbox=true`) and the user lacks the special view
-   privilege, an empty list is returned (the folder will appear empty to
-   them, even though files might be present) – this mimics Hotline’s behavior
-   of upload-only dropboxes.
+   privilege, an empty list is returned (the folder will appear empty to them,
+   even though files might be present) – this mimics Hotline’s behavior of
+   upload-only dropboxes.
 3. **Query DB:** Fetch all FileNodes where parent_id = folder’s ID. This yields
-   all files, subfolders, and aliases in that directory. The system will retrieve
-   attributes needed for the listing: the name, type (to know if it’s a folder
-   or alias), size (for files or aliases), modification timestamp, and comment.
-   We also may query permissions to filter out any items the user shouldn’t see
-   individually (e.g., if a specific file has an ACL denying this user, you
-   might choose to omit it from the list or mark it locked). In most cases, if
-   the user can list the directory, they can see the names of items; more
-   granular hiding of specific files is optional.
+   all files, subfolders, and aliases in that directory. The system will
+   retrieve attributes needed for the listing: the name, type (to know if it’s
+   a folder or alias), size (for files or aliases), modification timestamp, and
+   comment. We also may query permissions to filter out any items the user
+   shouldn’t see individually (e.g., if a specific file has an ACL denying this
+   user, you might choose to omit it from the list or mark it locked). In most
+   cases, if the user can list the directory, they can see the names of items;
+   more granular hiding of specific files is optional.
 4. **Construct Response:** We send the list of entries. The Hotline protocol
    expects each entry as a “File name with info” structure (transaction field
    200), which includes the item name plus info like size, type flags, dates,
@@ -410,8 +414,8 @@ the client, potentially starting at a byte offset if resuming. Implementation
 steps:
 
 1. **Locate File:** Resolve the requested file path to a FileNode (type should
-   be 'file' or 'alias'). If it's an alias, resolution occurs to its target file
-   (follow FileNode.alias_target_id chain).
+   be 'file' or 'alias'). If it's an alias, resolution occurs to its target
+   file (follow FileNode.alias_target_id chain).
 
 2. **Permission Check:** Verify the user has download rights. This means either
    a global privilege (Hotline’s “Download File (2)” which may be set in their
@@ -424,10 +428,11 @@ steps:
 
 3. **Retrieve Metadata:** From the FileNode, get the `object_key`, size, and
    other metadata. This also helps with resume: if the client provided a resume
-   offset (Hotline's *File resume data* field (203) in the request), the system will
-   use it to start reading from that byte position.
+   offset (Hotline's *File resume data* field (203) in the request), the system
+   will use it to start reading from that byte position.
 
-4. **Open Object Stream:** Using the `object_store` API, the object is fetched. The system
+4. **Open Object Stream:** Using the `object_store` API, the object is fetched.
+   The system
    can either request the entire object or a range. The `ObjectStore` trait
    provides `get` for full object and `get_ranges` for byte ranges. For a
    resumable download, we’ll do a range request starting at the resume offset
@@ -455,21 +460,21 @@ steps:
    4-byte `'HTXF'` header and some metadata. In the implementation, we compose
    the “flattened file object” structure as required, which includes an **info
    fork** (with file metadata like create/modify dates, comment, name length,
-   etc.) followed by a **data fork** containing the raw bytes. This can be generated
-   on the fly: first send the info fork (which is small), then stream the
-   data fork directly from object_store. The entire file is not buffered in
-   memory; data is read chunk by chunk and forwarded to the socket (this is where
-   Rust’s async stream shines, allowing backpressure).
+   etc.) followed by a **data fork** containing the raw bytes. This can be
+   generated on the fly: first send the info fork (which is small), then stream
+   the data fork directly from object_store. The entire file is not buffered in
+   memory; data is read chunk by chunk and forwarded to the socket (this is
+   where Rust’s async stream shines, allowing backpressure).
 
 6. **Resuming:** If the request included a resume offset, the `Transfer size` is
-   reported as (file_size - offset) and sending begins from that
-   offset. The client will append the incoming bytes to its existing partial
-   file. Since the object store read was started at `offset`, this is naturally
-   handled. The "flattened file" header must ensure it still
-   includes the full file metadata (Hotline's format likely expects the
-   original file length in the info fork even if starting mid-file). Compliance with the
-   protocol is maintained by providing the resume functionality but not altering the
-   file’s identity.
+   reported as (file_size - offset) and sending begins from that offset. The
+   client will append the incoming bytes to its existing partial file. Since
+   the object store read was started at `offset`, this is naturally handled.
+   The "flattened file" header must ensure it still includes the full file
+   metadata (Hotline's format likely expects the original file length in the
+   info fork even if starting mid-file). Compliance with the protocol is
+   maintained by providing the resume functionality but not altering the file’s
+   identity.
 
 This operation’s performance considerations: using range requests avoids
 sending data the client already has. The `object_store` abstraction will handle
@@ -479,11 +484,12 @@ is uploaded and finalized, a consistent byte stream is provided).
 
 **Hotline Compatibility Note:** Hotline's "Download File" was followed by a
 "Download Info (211)" server transaction with a reference number, then the
-actual data on a new connection. The control-plane connection is used for emulation:
-the main connection sends a response that triggers the data-plane connection. The
-specifics of managing multiple sockets is beyond this guide's scope, but the
-idea is to separate metadata exchange from bulk data transfer, which matches
-our approach of streaming from object_store once the transfer is negotiated.
+actual data on a new connection. The control-plane connection is used for
+emulation: the main connection sends a response that triggers the data-plane
+connection. The specifics of managing multiple sockets is beyond this guide's
+scope, but the idea is to separate metadata exchange from bulk data transfer,
+which matches our approach of streaming from object_store once the transfer is
+negotiated.
 
 ### File Upload – *UploadFile (203)*
 
@@ -509,23 +515,23 @@ interrupted. The steps:
 2. **Permission Check:** Verify the user can upload to this folder. This
    requires the "Upload File (1)" permission either globally or on that folder.
    If the folder is a **dropbox**, typically all users have upload rights but
-   not view; in the system, the "everyone" group would likely be given an upload
-   permission on that folder. So check accordingly. Also, if the folder is
-   flagged read-only for the user, deny.
+   not view; in the system, the "everyone" group would likely be given an
+   upload permission on that folder. So check accordingly. Also, if the folder
+   is flagged read-only for the user, deny.
 
 3. **Create DB Record:** Insert a new FileNode for the file. We mark its
    `parent_id`, name, type='file', and set `size=0` initially. We can also
    store `created_by` = user’s ID and a timestamp. We generate a new
-   `object_key` for it. At this point, depending on strategy, the implementation might not
-   commit the DB transaction until the file content is fully received (to avoid
-   a record for a file that fails to upload). However, not having a DB entry
-   means there is nowhere to attach partial state. A compromise is to insert
-   it with a status flag "incomplete" (not shown in schema for brevity) and
-   update status when done. For simplicity, assume entry addition occurs after
-   a successful upload, or remove it on failure. We must also decide how to
-   handle the scenario of resuming an interrupted upload – the DB entry could
-   remain and append to it later, or require the client to
-   reinitiate and treat it as new (except where resume is explicitly
+   `object_key` for it. At this point, depending on strategy, the
+   implementation might not commit the DB transaction until the file content is
+   fully received (to avoid a record for a file that fails to upload). However,
+   not having a DB entry means there is nowhere to attach partial state. A
+   compromise is to insert it with a status flag "incomplete" (not shown in
+   schema for brevity) and update status when done. For simplicity, assume
+   entry addition occurs after a successful upload, or remove it on failure. We
+   must also decide how to handle the scenario of resuming an interrupted
+   upload – the DB entry could remain and append to it later, or require the
+   client to reinitiate and treat it as new (except where resume is explicitly
    supported). The Hotline protocol does have a resume for uploads, implied by
    *File transfer options* and *File resume data* fields, so striving to
    support it.
@@ -579,17 +585,17 @@ interrupted. The steps:
 5. **Resumable Upload:** If the client indicated a resume (Hotline uses a *File
    resume data* field in the server's reply to an upload request to tell the
    client where to resume), our server needs to handle interrupted uploads. One
-   approach: when an upload is interrupted, the system keeps the DB entry (marked
-   incomplete) and does not finalize the multipart upload. The object_store may
-   have staged parts; the system stores the multipart upload ID and parts info somewhere
-   (perhaps a temporary DB table or in-memory map). When the client reconnects
-   to resume, it sends an UploadFile request with a flag indicating resume. We
-   look up the existing entry and find how many bytes were received (or which
-   parts completed). We then respond with *File resume data* = number of bytes
-   already stored (Hotline’s mechanism was to let server tell client how much
-   it got, so client can send the rest). Then the client will send only the
-   remaining bytes. In this implementation, the server can re-open or continue the
-   multipart upload:
+   approach: when an upload is interrupted, the system keeps the DB entry
+   (marked incomplete) and does not finalize the multipart upload. The
+   object_store may have staged parts; the system stores the multipart upload
+   ID and parts info somewhere (perhaps a temporary DB table or in-memory map).
+   When the client reconnects to resume, it sends an UploadFile request with a
+   flag indicating resume. We look up the existing entry and find how many
+   bytes were received (or which parts completed). We then respond with *File
+   resume data* = number of bytes already stored (Hotline’s mechanism was to
+   let server tell client how much it got, so client can send the rest). Then
+   the client will send only the remaining bytes. In this implementation, the
+   server can re-open or continue the multipart upload:
 
    - If the object_store crate allows reusing the existing upload (some cloud
      APIs allow listing parts and continuing), we use the saved upload ID and
@@ -648,8 +654,8 @@ interrupted. The steps:
 file size (108) if not resuming, which the client provides. We can use that to
 cross-check that we received the correct amount of data. Hotline also had the
 server send back a *Reference number (107)* and optionally *File resume data
-(203)* if resuming. In the implementation, an internal reference might be generated
-(not really needed if we handle on same connection) and use resume
+(203)* if resuming. In the implementation, an internal reference might be
+generated (not really needed if we handle on same connection) and use resume
 data if applicable.
 
 ### New Folder – *NewFolder (205)*
@@ -1245,9 +1251,9 @@ Applying these rules ensures that:
   admin), our checks can short-circuit and allow. For instance, if
   `User.global_access` has all bits set (e.g., 0xFFFFFFFF), we treat them as
   full admin. Or if a certain high bit like 32 was reserved for administrator.
-  Implementation-wise, the system can ensure that if they have been granted every
-  relevant bit globally, they won’t be blocked by folder ACL (except maybe
-  dropbox view if that’s not set – but an admin likely has that too).
+  Implementation-wise, the system can ensure that if they have been granted
+  every relevant bit globally, they won’t be blocked by folder ACL (except
+  maybe dropbox view if that’s not set – but an admin likely has that too).
 - **Auditing and Logging:** We should log permission failures for security
   auditing. E.g., if user tries to download a file without rights, we log it.
 
@@ -1263,7 +1269,8 @@ toggle those bits per user or per folder.
 Because we split metadata (DB) and file content (object store), maintaining
 consistency is critical:
 
-- **Two-Phase Operations:** For any create/upload, there are two steps (DB insert
+- **Two-Phase Operations:** For any create/upload, there are two steps (DB
+  insert
   and object upload). We must handle failures in between. Our approach:
 
   - On **file upload**: We can delay DB insertion until after the object upload

--- a/docs/migration-plan-moving-mxd-protocol-implementation-to-wireframe.md
+++ b/docs/migration-plan-moving-mxd-protocol-implementation-to-wireframe.md
@@ -98,7 +98,8 @@ this framing using `wireframe`’s customizable serialization layer.
   implementation that knows how to parse and format Hotline frames. This
   serializer’s `deserialize` method should:
 
-- Parse the 20-byte header of an incoming message to extract flags, request/reply marker, transaction type,
+- Parse the 20-byte header of an incoming message to extract flags,
+  request/reply marker, transaction type,
   transaction ID, error code, total payload size, and fragment data size[^9].
   The `mxd` `FrameHeader` struct and its parsing logic can be reused
   here[^10][^11].

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -1,7 +1,7 @@
 # Repository layout
 
-This document describes the organisation of the mxd codebase and the purpose
-of each major directory and file.
+This document describes the organisation of the mxd codebase and the purpose of
+each major directory and file.
 
 ## Top-level structure
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -237,10 +237,9 @@ and explicit dependencies. Timeframes are intentionally omitted.
 
 - [ ] 1.7.1. Configure explicit `MemoryBudgets` for the wireframe app using
   Hotline transaction and streaming limits. Acceptance: `mxd-wireframe-server`
-  sets per-message, per-connection, and in-flight budgets explicitly,
-  oversized or stalled fragmented inputs are disconnected predictably, and
-  integration tests cover soft-pressure and hard-cap behaviour. Dependencies:
-  1.3.2, 1.6.1.
+  sets per-message, per-connection, and in-flight budgets explicitly, oversized
+  or stalled fragmented inputs are disconnected predictably, and integration
+  tests cover soft-pressure and hard-cap behaviour. Dependencies: 1.3.2, 1.6.1.
 - [ ] 1.7.2. Add regression coverage for the v0.3.0 budgeting and
   fragmentation controls using `wireframe::testkit`. Acceptance: low-level
   transport tests use partial-frame, fragment, and slow-I/O helpers instead of
@@ -253,23 +252,21 @@ and explicit dependencies. Timeframes are intentionally omitted.
   reused by file-transfer and large-payload regression suites. Dependencies:
   1.3.2, 1.6.1.
 - [ ] 1.7.4. Adopt `wireframe_testing` loopback and observability helpers for
-  selected protocol suites. Acceptance: `WireframePair`,
-  `ObservabilityHandle`, and codec-aware fixtures replace custom loopback
-  scaffolding in at least one routing or handshake suite and expose
-  codec/queue metrics for assertions. Dependencies: 1.7.2, 1.7.3.
+  selected protocol suites. Acceptance: `WireframePair`, `ObservabilityHandle`,
+  and codec-aware fixtures replace custom loopback scaffolding in at least one
+  routing or handshake suite and expose codec/queue metrics for assertions.
+  Dependencies: 1.7.2, 1.7.3.
 - [ ] 1.7.5. Add client request hooks, structured tracing, and, where
   justified, pooling to validation tooling. Acceptance: validation and
   load-oriented harnesses use `before_send`/`after_receive` hooks and
-  `TracingConfig` for frame diagnostics, and any `WireframeClientPool`
-  adoption demonstrates measurable throughput or fixture-simplification gains
-  without changing protocol semantics. Dependencies: 1.6.2, 1.7.3.
+  `TracingConfig` for frame diagnostics, and any `WireframeClientPool` adoption
+  demonstrates measurable throughput or fixture-simplification gains without
+  changing protocol semantics. Dependencies: 1.6.2, 1.7.3.
 
 \[^1\]:
-[docs/design.md §Transaction routing middleware (December
-2025)](docs/design.md#transaction-routing-middleware-december-2025)
-\[^2\]:
-[docs/design.md §Regression verification via the wireframe binary (February
-2026)](docs/design.md#regression-verification-via-the-wireframe-binary-february-2026)
+[docs/design.md §Transaction routing middleware (December 2025)](docs/design.md#transaction-routing-middleware-december-2025)
+ \[^2\]:
+[docs/design.md §Regression verification via the wireframe binary (February 2026)](docs/design.md#regression-verification-via-the-wireframe-binary-february-2026)
 
 ## 2. Session and presence parity
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -108,7 +108,7 @@ wireframe-only suites; the postgres jobs automatically reuse the staged
 binaries. Both server binaries honour the same `MXD_DATABASE` and `--database`
 values, allowing the helper to be re-run once and then switching between
 `cargo run --bin mxd` and `cargo run --bin mxd-wireframe-server` without
-additional setup. Refer to `docs/pg-embedded-setup-unpriv-users-guide.md` for
+additional setup. Refer to `docs/pg-embed-setup-unpriv-users-guide.md` for
 cluster path customization and privilege troubleshooting details.
 
 ## Behaviour coverage

--- a/docs/wireframe-users-guide.md
+++ b/docs/wireframe-users-guide.md
@@ -163,8 +163,8 @@ consecutive deserialization errors.[^6][^7]
 
 `WireframeServer::new` accepts an app factory rather than a pre-built
 `WireframeApp`. The server calls that factory for each accepted connection so
-handlers, middleware state, and connection-scoped resources can be assembled
-at connection start.
+handlers, middleware state, and connection-scoped resources can be assembled at
+connection start.
 
 Wireframe models this through two traits:
 
@@ -220,10 +220,10 @@ other per-connection prerequisites that can legitimately fail.
 #### Accessing handshake context inside a factory
 
 Adapters that negotiate connection metadata before app construction can fetch
-that state from the current task inside a fallible factory. In mxd, the
-Hotline handshake stores a `ConnectionContext` that the app factory retrieves
-with `take_current_context()`, failing closed when the handshake did not
-provide the expected metadata.
+that state from the current task inside a fallible factory. In mxd, the Hotline
+handshake stores a `ConnectionContext` that the app factory retrieves with
+`take_current_context()`, failing closed when the handshake did not provide the
+expected metadata.
 
 ```rust,no_run
 use wireframe::app::{Envelope, WireframeApp};

--- a/docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/wireframe-v0-2-0-to-v0-3-0-migration-guide.md
@@ -200,8 +200,9 @@ wireframe = { version = "0.3.0", features = ["testkit"] }
 
 ## Unified error surface
 
-`wireframe` now exposes one canonical error type: `wireframe::WireframeError<E>`,
-defined in `wireframe::error`. The two previous error types are gone.
+`wireframe` now exposes one canonical error type:
+`wireframe::WireframeError<E>`, defined in `wireframe::error`. The two previous
+error types are gone.
 
 - `wireframe::app::error::WireframeError` is removed.
 - `wireframe::response::WireframeError` is removed.
@@ -236,21 +237,21 @@ reference the module directly rather than the root shorthand.
 
 The most common moves:
 
-| Removed root path | New path |
-| --- | --- |
-| `wireframe::BincodeSerializer`, `wireframe::Serializer` | `wireframe::serializer::{BincodeSerializer, Serializer}` |
-| `wireframe::ConnectionActor` | `wireframe::connection::ConnectionActor` |
-| `wireframe::CorrelatableFrame` | `wireframe::correlation::CorrelatableFrame` |
+| Removed root path                                                                          | New path                                                                  |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `wireframe::BincodeSerializer`, `wireframe::Serializer`                                    | `wireframe::serializer::{BincodeSerializer, Serializer}`                  |
+| `wireframe::ConnectionActor`                                                               | `wireframe::connection::ConnectionActor`                                  |
+| `wireframe::CorrelatableFrame`                                                             | `wireframe::correlation::CorrelatableFrame`                               |
 | `wireframe::ConnectionContext`, `wireframe::ProtocolHooks`, `wireframe::WireframeProtocol` | `wireframe::hooks::{ConnectionContext, ProtocolHooks, WireframeProtocol}` |
-| `wireframe::ClientCodecConfig`, `wireframe::ClientError`, `wireframe::WireframeClient` | `wireframe::client::{...}` |
-| `wireframe::CodecError`, `wireframe::DefaultRecoveryPolicy`, `wireframe::RecoveryConfig` | `wireframe::codec::{...}` |
-| `wireframe::FrameStream`, `wireframe::Response` | `wireframe::response::{FrameStream, Response}` |
-| `wireframe::ConnectionId`, `wireframe::SessionRegistry` | `wireframe::session::{ConnectionId, SessionRegistry}` |
-| `wireframe::RequestParts`, `wireframe::RequestBodyStream` | `wireframe::request::{RequestParts, RequestBodyStream}` |
+| `wireframe::ClientCodecConfig`, `wireframe::ClientError`, `wireframe::WireframeClient`     | `wireframe::client::{...}`                                                |
+| `wireframe::CodecError`, `wireframe::DefaultRecoveryPolicy`, `wireframe::RecoveryConfig`   | `wireframe::codec::{...}`                                                 |
+| `wireframe::FrameStream`, `wireframe::Response`                                            | `wireframe::response::{FrameStream, Response}`                            |
+| `wireframe::ConnectionId`, `wireframe::SessionRegistry`                                    | `wireframe::session::{ConnectionId, SessionRegistry}`                     |
+| `wireframe::RequestParts`, `wireframe::RequestBodyStream`                                  | `wireframe::request::{RequestParts, RequestBodyStream}`                   |
 
 The full list of moved types is in the
-[v0.1.0 → v0.2.0 migration guide](v0-1-0-to-v0-2-0-migration-guide.md).
-That list now takes effect.
+[v0.1.0 → v0.2.0 migration guide](v0-1-0-to-v0-2-0-migration-guide.md). That
+list now takes effect.
 
 `wireframe::prelude::*` provides an optional convenience import for
 high-frequency types. It is intentionally small; prefer direct module imports
@@ -336,14 +337,14 @@ impl EncodeWith<MySerializer> for MyMessage {
 }
 ```
 
-A `SerdeSerializerBridge` trait (behind the `serializer-serde` feature) and
-the `SerdeMessage<T>` wrapper provide a path for Serde-derived types without
+A `SerdeSerializerBridge` trait (behind the `serializer-serde` feature) and the
+`SerdeMessage<T>` wrapper provide a path for Serde-derived types without
 implementing `bincode::Encode`.
 
 ## WireframeApp construction
 
-`WireframeApp::new()` now returns `Result<Self>` for forward compatibility.
-The call currently always succeeds, but the return type must be handled.
+`WireframeApp::new()` now returns `Result<Self>` for forward compatibility. The
+call currently always succeeds, but the return type must be handled.
 
 ```rust
 // Before
@@ -611,7 +612,8 @@ partial frames, fragments, and slow I/O, plus `TestSerializer`, `TestResult`,
 `TestError`, and assembly snapshot assertion helpers. The `wireframe_testing`
 companion crate provides `WireframePair` (real loopback server–client pair),
 `ObservabilityHandle` (log + metrics capture with atomic snapshot semantics),
-`Labels`, and `HotlineFixtures` (codec regression fixtures and `new_test_codec`).*
+`Labels`, and `HotlineFixtures` (codec regression fixtures and
+`new_test_codec`).*
 
 `wireframe::testkit` (behind the `testkit` Cargo feature) provides optional
 test utilities for downstream protocol crates. The module is not available in
@@ -627,8 +629,8 @@ Capabilities include:
   real network delay.
 - Assembly assertion helpers (`assert_message_assembly_completed`,
   `assert_fragment_reassembly_error`, and the full `MessageAssemblySnapshot` /
-  `FragmentReassemblySnapshot` families) for verifying assembly and
-  reassembly outcomes without panicking.
+  `FragmentReassemblySnapshot` families) for verifying assembly and reassembly
+  outcomes without panicking.
 - `TestSerializer` – a minimal serializer for use in tests.
 - `TestResult` and `TestError` – ergonomic result types for test functions.
 
@@ -700,8 +702,8 @@ assert_eq!(
 ```
 
 `obs_handle()` is an `rstest` fixture that constructs a handle directly.
-`Labels` provides a builder for label pairs used with `ObservabilityHandle::
-counter`.
+`Labels` provides a builder for label pairs used with
+`ObservabilityHandle:: counter`.
 
 The handle's `snapshot()` method drains counters atomically. Query after
 `snapshot()`; earlier values are not retained.
@@ -885,14 +887,14 @@ yielding a `SendStreamingOutcome`.*
   request, and returns a `ResponseStream` that yields typed frames until the
   server sends a stream terminator.
 - `receive_streaming(correlation_id)` – the lower-level variant for callers
-  that have already sent the request via `send` or `send_envelope` and hold
-  the correlation identifier. Returns a `ResponseStream` that validates every
+  that have already sent the request via `send` or `send_envelope` and hold the
+  correlation identifier. Returns a `ResponseStream` that validates every
   inbound frame against that identifier.
 
-`ResponseStream` implements `futures::Stream` with `Item = Result<P,
-ClientError>`. It holds an exclusive borrow of the client for the duration of
-the stream, preventing concurrent sends. The terminator frame is consumed
-internally and the stream returns `None` once it arrives.
+`ResponseStream` implements `futures::Stream` with
+`Item = Result<P, ClientError>`. It holds an exclusive borrow of the client for
+the duration of the stream, preventing concurrent sends. The terminator frame
+is consumed internally and the stream returns `None` once it arrives.
 
 ```rust
 use std::net::SocketAddr;
@@ -945,16 +947,16 @@ sequenceDiagram
 ```
 
 *Sequence diagram: `call_streaming` sends the request and returns a
-`ResponseStream` that holds an exclusive borrow of the client. Each `try_next()`
-call polls the client for the next server frame; the loop continues until the
-server sends a terminator, at which point the stream returns `None`. Dropping
-the `ResponseStream` releases the borrow, making the client available for
-further calls.*
+`ResponseStream` that holds an exclusive borrow of the client. Each
+`try_next()` call polls the client for the next server frame; the loop
+continues until the server sends a terminator, at which point the stream
+returns `None`. Dropping the `ResponseStream` releases the borrow, making the
+client available for further calls.*
 
 `StreamingResponseExt` is a trait on any `Stream` of response frames. It
-provides `typed_with(mapper)`, which produces a `TypedResponseStream<S, Mapper,
-P, Item>` that translates raw frames into domain values and skips control
-frames where the mapper returns `Ok(None)`.
+provides `typed_with(mapper)`, which produces a
+`TypedResponseStream<S, Mapper, P, Item>` that translates raw frames into
+domain values and skips control frames where the mapper returns `Ok(None)`.
 
 ```rust
 use wireframe::client::StreamingResponseExt;
@@ -973,8 +975,8 @@ let typed_stream = raw_stream.typed_with(|frame| {
 `WireframeClient::send_streaming` sends a large body as a sequence of
 protocol-framed chunks, reading from any `AsyncRead` source.
 
-`SendStreamingConfig` controls chunk sizing and timeout. When chunk size is
-not set, it is derived from `max_frame_length - frame_header.len()`.
+`SendStreamingConfig` controls chunk sizing and timeout. When chunk size is not
+set, it is derived from `max_frame_length - frame_header.len()`.
 
 ```rust
 use std::time::Duration;
@@ -1086,11 +1088,11 @@ classDiagram
     ClientPoolConfig --> PoolFairnessPolicy
 ```
 
-*Class diagram: `WireframeClientBuilder` creates a `WireframeClientPool` using a
-`ClientPoolConfig` (which selects a `PoolFairnessPolicy`). The pool vends
-`PoolHandle` instances; each handle yields a `PooledClientLease` on `acquire()`.
-`PooledClientLease` derefs to `WireframeClient`, exposing `call`, `send`, and
-`receive` for individual requests.*
+*Class diagram: `WireframeClientBuilder` creates a `WireframeClientPool` using
+a `ClientPoolConfig` (which selects a `PoolFairnessPolicy`). The pool vends
+`PoolHandle` instances; each handle yields a `PooledClientLease` on
+`acquire()`. `PooledClientLease` derefs to `WireframeClient`, exposing `call`,
+`send`, and `receive` for individual requests.*
 
 Sequence diagram showing the connection pool usage flow: building the pool,
 acquiring a PoolHandle, checking out a PooledClientLease, making a request, and
@@ -1173,9 +1175,9 @@ let client = WireframeClientBuilder::new()
 `TracingConfig` controls which client operations emit tracing spans, at what
 level, and whether per-operation elapsed-time events are recorded.
 
-The default configuration emits `INFO` spans for lifecycle operations (`connect`,
-`close`) and `DEBUG` spans for data operations (`send`, `receive`, `call`,
-`call_streaming`). Timing is disabled by default.
+The default configuration emits `INFO` spans for lifecycle operations
+(`connect`, `close`) and `DEBUG` spans for data operations (`send`, `receive`,
+`call`, `call_streaming`). Timing is disabled by default.
 
 ```rust
 use tracing::Level;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2025-11-08"
-components = ["rustfmt", "clippy", "llvm-tools-preview"]
+components = ["rustfmt", "clippy", "llvm-tools-preview", "rust-analyzer"]

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -199,7 +199,7 @@ install_file hx "$HX_BIN_DIR"
 
 wget -O "$source_archive" "$source_url"
 verify_archive_checksum "$source_archive" "$HX_SOURCE_SHA256"
-archive_listing="$(tar -tzf -- "$source_archive")"
+archive_listing="$(tar -tzf "$source_archive")"
 mapfile -t source_dirs < <(
     printf '%s\n' "$archive_listing" |
         awk -F/ 'NF > 0 && $1 != "" { print $1 }' |
@@ -214,7 +214,7 @@ source_dir="$(basename -- "${source_dirs[0]}")"
 validate_source_dir "$source_dir"
 
 rm -rf -- "./$source_dir"
-tar xzf -- "$source_archive"
+tar xzf "$source_archive"
 rm -f "$source_archive"
 
 if [[ ! -d "./$source_dir" ]]; then

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Install the SynHX `hx` binary and source tree for validator runs.
+# Requires Bash 4+.
 #
 # Usage:
 #   ./scripts/install-synhx.sh
@@ -26,6 +27,14 @@ HX_PLATFORM_ARCHIVE=""
 fail() {
     echo "Error: $*" >&2
     exit 1
+}
+
+require_bash_4() {
+    if (( BASH_VERSINFO[0] >= 4 )); then
+        return
+    fi
+
+    fail "scripts/install-synhx.sh requires Bash 4 or newer"
 }
 
 require_supported_platform() {
@@ -94,6 +103,7 @@ install_file() {
     fail "cannot write to $destination_dir and sudo is unavailable; set HX_BIN_DIR to a writable directory or provide sudo access"
 }
 
+require_bash_4
 require_supported_platform
 require_command tar
 require_command wget

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -19,6 +19,8 @@ HX_VERSION="${HX_VERSION:-0.1.48.1}"
 HX_WORK_ROOT="${HX_WORK_ROOT:-$HOME/git}"
 HX_BIN_DIR="${HX_BIN_DIR:-/usr/local/bin}"
 HX_SRC_LINK="${HX_SRC_LINK:-$HX_WORK_ROOT/synhx-client}"
+HX_BINARY_SHA256="${HX_BINARY_SHA256:-}"
+HX_SOURCE_SHA256="${HX_SOURCE_SHA256:-}"
 HX_PLATFORM_ARCHIVE=""
 
 fail() {
@@ -100,6 +102,60 @@ require_command ln
 require_command rm
 require_command mv
 
+set_expected_checksums() {
+    if [[ -n "$HX_BINARY_SHA256" && -n "$HX_SOURCE_SHA256" ]]; then
+        return
+    fi
+
+    case "$HX_VERSION" in
+        0.1.48.1)
+            : "${HX_BINARY_SHA256:=fcef7e2bff84bce4c42cab577e480a3bf788d4cca063f6ebda9df5b200c96b36}"
+            : "${HX_SOURCE_SHA256:=65964cac332146214ed945f290e26bce5fcefa21ac6fea6f9edd4fdff906d965}"
+            ;;
+        *)
+            fail "no built-in checksums for SynHX v$HX_VERSION; set HX_BINARY_SHA256 and HX_SOURCE_SHA256 explicitly"
+            ;;
+    esac
+}
+
+sha256_file() {
+    local path checksum
+    path="$1"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        read -r checksum _ < <(sha256sum "$path")
+        printf '%s\n' "$checksum"
+        return
+    fi
+
+    if command -v shasum >/dev/null 2>&1; then
+        read -r checksum _ < <(shasum -a 256 "$path")
+        printf '%s\n' "$checksum"
+        return
+    fi
+
+    fail "required command not found: sha256sum or shasum"
+}
+
+verify_archive_checksum() {
+    local archive expected actual
+    archive="$1"
+    expected="$2"
+
+    if [[ -z "$expected" ]]; then
+        fail "missing expected checksum for $archive"
+    fi
+
+    actual="$(sha256_file "$archive")"
+    if [[ "$actual" == "$expected" ]]; then
+        return
+    fi
+
+    rm -f "$archive"
+    fail "checksum verification failed for $archive (expected $expected, got $actual)"
+}
+
+set_expected_checksums
 ensure_dir "$HX_WORK_ROOT"
 ensure_dir "$HX_BIN_DIR"
 ensure_dir "$(dirname "$HX_SRC_LINK")"
@@ -114,6 +170,7 @@ pushd "$HX_WORK_ROOT" >/dev/null
 rm -f "$binary_archive" "$source_archive" hx
 
 wget -O "$binary_archive" "$binary_url"
+verify_archive_checksum "$binary_archive" "$HX_BINARY_SHA256"
 tar xvf "$binary_archive"
 rm -f "$binary_archive"
 
@@ -124,6 +181,7 @@ fi
 install_file hx "$HX_BIN_DIR"
 
 wget -O "$source_archive" "$source_url"
+verify_archive_checksum "$source_archive" "$HX_SOURCE_SHA256"
 archive_listing="$(tar -tzf "$source_archive")"
 source_dir="$(printf '%s\n' "$archive_listing" | sed -n '1s#/.*##p')"
 

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Install the SynHX `hx` binary and source tree for validator runs.
+#
+# Usage:
+#   ./scripts/install-synhx.sh
+#
+# Optional environment overrides:
+#   HX_VERSION      Version tag to install (default: 0.1.48.1)
+#   HX_WORK_ROOT    Working directory for downloads and source checkout
+#                   (default: $HOME/git)
+#   HX_BIN_DIR      Directory to install the `hx` binary into
+#                   (default: /usr/local/bin)
+#   HX_SRC_LINK     Symlink path for the extracted source tree
+#                   (default: $HX_WORK_ROOT/synhx-client)
+
+set -euo pipefail
+
+HX_VERSION="${HX_VERSION:-0.1.48.1}"
+HX_WORK_ROOT="${HX_WORK_ROOT:-$HOME/git}"
+HX_BIN_DIR="${HX_BIN_DIR:-/usr/local/bin}"
+HX_SRC_LINK="${HX_SRC_LINK:-$HX_WORK_ROOT/synhx-client}"
+
+require_command() {
+    local name
+    name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        echo "Error: required command not found: $name" >&2
+        exit 1
+    fi
+}
+
+ensure_dir() {
+    local directory
+    directory="$1"
+
+    if [[ -d "$directory" ]]; then
+        return
+    fi
+
+    if mkdir -p "$directory" 2>/dev/null; then
+        return
+    fi
+
+    if command -v sudo >/dev/null 2>&1; then
+        sudo mkdir -p "$directory"
+        return
+    fi
+
+    echo "Error: cannot create directory $directory and sudo is unavailable" >&2
+    exit 1
+}
+
+install_file() {
+    local source destination_dir destination
+    source="$1"
+    destination_dir="$2"
+    destination="$destination_dir/$(basename "$source")"
+
+    if [[ -w "$destination_dir" ]]; then
+        install -m 0755 "$source" "$destination"
+        return
+    fi
+
+    if command -v sudo >/dev/null 2>&1; then
+        sudo install -m 0755 "$source" "$destination"
+        return
+    fi
+
+    echo "Error: cannot write to $destination_dir and sudo is unavailable" >&2
+    echo "Set HX_BIN_DIR to a writable directory or provide sudo access." >&2
+    exit 1
+}
+
+require_command tar
+require_command wget
+require_command install
+require_command ln
+require_command rm
+require_command mv
+
+ensure_dir "$HX_WORK_ROOT"
+ensure_dir "$HX_BIN_DIR"
+ensure_dir "$(dirname "$HX_SRC_LINK")"
+
+binary_archive="hx-ubuntu-latest-v${HX_VERSION}.tar.gz"
+binary_url="https://github.com/leynos/synhx-client/releases/download/v${HX_VERSION}/${binary_archive}"
+source_archive="synhx-client-v${HX_VERSION}.tar.gz"
+source_url="https://github.com/leynos/synhx-client/archive/refs/tags/v${HX_VERSION}.tar.gz"
+
+pushd "$HX_WORK_ROOT" >/dev/null
+
+rm -f "$binary_archive" "$source_archive" hx
+
+wget -O "$binary_archive" "$binary_url"
+tar xvf "$binary_archive"
+rm -f "$binary_archive"
+
+if [[ ! -f hx ]]; then
+    echo "Error: expected extracted binary '$HX_WORK_ROOT/hx'" >&2
+    exit 1
+fi
+
+install_file hx "$HX_BIN_DIR"
+
+wget -O "$source_archive" "$source_url"
+archive_listing="$(tar -tzf "$source_archive")"
+source_dir="$(printf '%s\n' "$archive_listing" | sed -n '1s#/.*##p')"
+
+if [[ -z "$source_dir" ]]; then
+    echo "Error: unable to determine extracted source directory" >&2
+    exit 1
+fi
+
+rm -rf "$source_dir"
+tar xzf "$source_archive"
+rm -f "$source_archive"
+
+ln -sfn "$HX_WORK_ROOT/$source_dir" "$HX_SRC_LINK"
+
+echo "hx binary is available at $HX_BIN_DIR/hx"
+echo "source code is available at $(cd "$HX_SRC_LINK" && pwd)"
+
+popd >/dev/null

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -163,7 +163,7 @@ validate_source_dir() {
         fail "unable to determine extracted source directory"
     fi
 
-    if [[ "$directory" == .* || "$directory" == -* || "$directory" == */* ]]; then
+    if [[ "$directory" == "." || "$directory" == ".." || "$directory" == -* || "$directory" == */* ]]; then
         fail "refusing unsafe extracted source directory name: $directory"
     fi
 
@@ -200,8 +200,17 @@ install_file hx "$HX_BIN_DIR"
 wget -O "$source_archive" "$source_url"
 verify_archive_checksum "$source_archive" "$HX_SOURCE_SHA256"
 archive_listing="$(tar -tzf -- "$source_archive")"
-source_dir="$(printf '%s\n' "$archive_listing" | sed -n '1s#/.*##p')"
-source_dir="$(basename -- "$source_dir")"
+mapfile -t source_dirs < <(
+    printf '%s\n' "$archive_listing" |
+        awk -F/ 'NF > 0 && $1 != "" { print $1 }' |
+        sort -u
+)
+
+if [[ "${#source_dirs[@]}" -ne 1 ]]; then
+    fail "expected exactly one top-level source directory in $source_archive"
+fi
+
+source_dir="$(basename -- "${source_dirs[0]}")"
 validate_source_dir "$source_dir"
 
 rm -rf -- "./$source_dir"

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -155,6 +155,23 @@ verify_archive_checksum() {
     fail "checksum verification failed for $archive (expected $expected, got $actual)"
 }
 
+validate_source_dir() {
+    local directory
+    directory="$1"
+
+    if [[ -z "$directory" ]]; then
+        fail "unable to determine extracted source directory"
+    fi
+
+    if [[ "$directory" == .* || "$directory" == -* || "$directory" == */* ]]; then
+        fail "refusing unsafe extracted source directory name: $directory"
+    fi
+
+    if [[ ! "$directory" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        fail "refusing extracted source directory with unexpected characters: $directory"
+    fi
+}
+
 set_expected_checksums
 ensure_dir "$HX_WORK_ROOT"
 ensure_dir "$HX_BIN_DIR"
@@ -182,16 +199,18 @@ install_file hx "$HX_BIN_DIR"
 
 wget -O "$source_archive" "$source_url"
 verify_archive_checksum "$source_archive" "$HX_SOURCE_SHA256"
-archive_listing="$(tar -tzf "$source_archive")"
+archive_listing="$(tar -tzf -- "$source_archive")"
 source_dir="$(printf '%s\n' "$archive_listing" | sed -n '1s#/.*##p')"
+source_dir="$(basename -- "$source_dir")"
+validate_source_dir "$source_dir"
 
-if [[ -z "$source_dir" ]]; then
-    fail "unable to determine extracted source directory"
-fi
-
-rm -rf "$source_dir"
-tar xzf "$source_archive"
+rm -rf -- "./$source_dir"
+tar xzf -- "$source_archive"
 rm -f "$source_archive"
+
+if [[ ! -d "./$source_dir" ]]; then
+    fail "expected extracted source directory '$HX_WORK_ROOT/$source_dir'"
+fi
 
 ln -sfn "$HX_WORK_ROOT/$source_dir" "$HX_SRC_LINK"
 

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -221,6 +221,10 @@ if [[ ! -d "./$source_dir" ]]; then
     fail "expected extracted source directory '$HX_WORK_ROOT/$source_dir'"
 fi
 
+if [[ -e "$HX_SRC_LINK" || -L "$HX_SRC_LINK" ]]; then
+    rm -rf -- "$HX_SRC_LINK"
+fi
+
 ln -sfn "$HX_WORK_ROOT/$source_dir" "$HX_SRC_LINK"
 
 echo "hx binary is available at $HX_BIN_DIR/hx"

--- a/scripts/install-synhx.sh
+++ b/scripts/install-synhx.sh
@@ -19,13 +19,37 @@ HX_VERSION="${HX_VERSION:-0.1.48.1}"
 HX_WORK_ROOT="${HX_WORK_ROOT:-$HOME/git}"
 HX_BIN_DIR="${HX_BIN_DIR:-/usr/local/bin}"
 HX_SRC_LINK="${HX_SRC_LINK:-$HX_WORK_ROOT/synhx-client}"
+HX_PLATFORM_ARCHIVE=""
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+require_supported_platform() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    if [[ "$os" != "Linux" ]]; then
+        fail "SynHX auto-install currently supports Linux only; set HX_BIN_DIR and HX_SRC_LINK manually on $os."
+    fi
+
+    case "$arch" in
+        x86_64|amd64)
+            HX_PLATFORM_ARCHIVE="hx-ubuntu-latest-v${HX_VERSION}.tar.gz"
+            ;;
+        *)
+            fail "SynHX auto-install currently supports Linux x86_64 only; unsupported architecture: $arch."
+            ;;
+    esac
+}
 
 require_command() {
     local name
     name="$1"
     if ! command -v "$name" >/dev/null 2>&1; then
-        echo "Error: required command not found: $name" >&2
-        exit 1
+        fail "required command not found: $name"
     fi
 }
 
@@ -46,8 +70,7 @@ ensure_dir() {
         return
     fi
 
-    echo "Error: cannot create directory $directory and sudo is unavailable" >&2
-    exit 1
+    fail "cannot create directory $directory and sudo is unavailable; choose a writable path or install sudo"
 }
 
 install_file() {
@@ -66,11 +89,10 @@ install_file() {
         return
     fi
 
-    echo "Error: cannot write to $destination_dir and sudo is unavailable" >&2
-    echo "Set HX_BIN_DIR to a writable directory or provide sudo access." >&2
-    exit 1
+    fail "cannot write to $destination_dir and sudo is unavailable; set HX_BIN_DIR to a writable directory or provide sudo access"
 }
 
+require_supported_platform
 require_command tar
 require_command wget
 require_command install
@@ -82,7 +104,7 @@ ensure_dir "$HX_WORK_ROOT"
 ensure_dir "$HX_BIN_DIR"
 ensure_dir "$(dirname "$HX_SRC_LINK")"
 
-binary_archive="hx-ubuntu-latest-v${HX_VERSION}.tar.gz"
+binary_archive="$HX_PLATFORM_ARCHIVE"
 binary_url="https://github.com/leynos/synhx-client/releases/download/v${HX_VERSION}/${binary_archive}"
 source_archive="synhx-client-v${HX_VERSION}.tar.gz"
 source_url="https://github.com/leynos/synhx-client/archive/refs/tags/v${HX_VERSION}.tar.gz"
@@ -96,8 +118,7 @@ tar xvf "$binary_archive"
 rm -f "$binary_archive"
 
 if [[ ! -f hx ]]; then
-    echo "Error: expected extracted binary '$HX_WORK_ROOT/hx'" >&2
-    exit 1
+    fail "expected extracted binary '$HX_WORK_ROOT/hx'"
 fi
 
 install_file hx "$HX_BIN_DIR"
@@ -107,8 +128,7 @@ archive_listing="$(tar -tzf "$source_archive")"
 source_dir="$(printf '%s\n' "$archive_listing" | sed -n '1s#/.*##p')"
 
 if [[ -z "$source_dir" ]]; then
-    echo "Error: unable to determine extracted source directory" >&2
-    exit 1
+    fail "unable to determine extracted source directory"
 fi
 
 rm -rf "$source_dir"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -258,7 +258,7 @@ impl Command {
     /// Returns an error if required parameters are missing or cannot be parsed.
     pub fn from_transaction(tx: Transaction) -> Result<Self, TransactionError> {
         let ty = TransactionType::from(tx.header.ty);
-        if !ty.allows_payload() && !tx.payload.is_empty() {
+        if ty.rejects_payload(tx.payload.is_empty()) {
             return Ok(Self::InvalidPayload { header: tx.header });
         }
         match ty {

--- a/src/commands/tests.rs
+++ b/src/commands/tests.rs
@@ -99,3 +99,23 @@ fn parse_login_params_rejects_malformed_payload() {
     let result = parse_login_params(malformed);
     assert!(matches!(result, Err(TransactionError::SizeMismatch)));
 }
+
+#[test]
+fn get_file_name_list_accepts_client_directory_payload() {
+    let transaction = Transaction {
+        header: FrameHeader {
+            flags: 0,
+            is_reply: 0,
+            ty: TransactionType::GetFileNameList.into(),
+            id: 7,
+            error: 0,
+            total_size: 5,
+            data_size: 5,
+        },
+        payload: vec![0xca, 0x00, 0x02, 0x00, 0x01],
+    };
+
+    let command = Command::from_transaction(transaction).expect("command should parse");
+
+    assert!(matches!(command, Command::GetFileNameList { .. }));
+}

--- a/src/transaction/params.rs
+++ b/src/transaction/params.rs
@@ -7,7 +7,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::{FrameHeader, Transaction, errors::TransactionError, read_u16};
-use crate::field_id::FieldId;
+use crate::{field_id::FieldId, transaction_type::TransactionType};
 
 /// Determine whether duplicate instances of the given field id are permitted.
 const fn duplicate_allowed(fid: FieldId) -> bool {
@@ -150,6 +150,9 @@ pub fn validate_payload_parts(
         return Err(TransactionError::SizeMismatch);
     }
     if payload.is_empty() {
+        return Ok(());
+    }
+    if header.is_reply == 0 && TransactionType::from(header.ty).bypass_payload_decode() {
         return Ok(());
     }
     let mut iter = iter_params(payload)?;

--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -135,22 +135,48 @@ impl std::fmt::Display for TransactionType {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
-
     use super::TransactionType;
 
-    #[rstest]
-    #[case::file_list_empty(TransactionType::GetFileNameList, true, false)]
-    #[case::file_list_non_empty(TransactionType::GetFileNameList, false, false)]
-    #[case::banner_empty(TransactionType::DownloadBanner, true, false)]
-    #[case::banner_non_empty(TransactionType::DownloadBanner, false, true)]
-    #[case::news_article_empty(TransactionType::NewsArticleData, true, false)]
-    #[case::news_article_non_empty(TransactionType::NewsArticleData, false, false)]
-    fn rejects_payload_matches_expected_policy(
-        #[case] transaction_type: TransactionType,
-        #[case] payload_is_empty: bool,
-        #[case] expected: bool,
-    ) {
-        assert_eq!(transaction_type.rejects_payload(payload_is_empty), expected);
+    const ALL_TRANSACTION_TYPES: [TransactionType; 13] = [
+        TransactionType::Error,
+        TransactionType::Login,
+        TransactionType::Agreement,
+        TransactionType::Agreed,
+        TransactionType::GetFileNameList,
+        TransactionType::DownloadBanner,
+        TransactionType::GetUserNameList,
+        TransactionType::UserAccess,
+        TransactionType::NewsCategoryNameList,
+        TransactionType::NewsArticleNameList,
+        TransactionType::NewsArticleData,
+        TransactionType::PostNewsArticle,
+        TransactionType::Other(999),
+    ];
+
+    #[test]
+    fn rejects_payload_matches_expected_policy() {
+        assert!(!TransactionType::GetFileNameList.rejects_payload(true));
+        assert!(!TransactionType::GetFileNameList.rejects_payload(false));
+        assert!(!TransactionType::NewsArticleData.rejects_payload(true));
+        assert!(!TransactionType::NewsArticleData.rejects_payload(false));
+        assert!(!TransactionType::DownloadBanner.rejects_payload(true));
+        assert!(TransactionType::DownloadBanner.rejects_payload(false));
+        assert!(!TransactionType::GetUserNameList.rejects_payload(true));
+        assert!(TransactionType::GetUserNameList.rejects_payload(false));
+    }
+
+    #[test]
+    fn bypass_payload_decode_matches_transaction_policy() {
+        for transaction_type in ALL_TRANSACTION_TYPES {
+            let expected = matches!(transaction_type, TransactionType::GetFileNameList)
+                || !transaction_type.allows_payload();
+            assert_eq!(
+                transaction_type.bypass_payload_decode(),
+                expected,
+                "unexpected bypass policy for {transaction_type:?}"
+            );
+        }
+
+        assert!(TransactionType::GetUserNameList.bypass_payload_decode());
     }
 }

--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -49,6 +49,22 @@ impl TransactionType {
             Self::GetFileNameList | Self::DownloadBanner | Self::GetUserNameList
         )
     }
+
+    /// Return `true` when a non-empty payload should be rejected outright.
+    #[must_use]
+    pub const fn rejects_payload(self, payload_is_empty: bool) -> bool {
+        if payload_is_empty {
+            return false;
+        }
+        match self {
+            // SynHX sends a binary `DATA_DIR` block for `/ls`, even for the
+            // root listing flow that MXD currently treats as a single logical
+            // file-list command. Accept the payload and let the handler ignore
+            // it until directory-aware semantics land.
+            Self::GetFileNameList => false,
+            _ => !self.allows_payload(),
+        }
+    }
 }
 
 impl From<u16> for TransactionType {

--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -65,6 +65,12 @@ impl TransactionType {
             _ => !self.allows_payload(),
         }
     }
+
+    /// Return `true` when request payload bytes should bypass decode attempts.
+    #[must_use]
+    pub const fn bypass_payload_decode(self) -> bool {
+        matches!(self, Self::GetFileNameList) || !self.allows_payload()
+    }
 }
 
 impl From<u16> for TransactionType {
@@ -124,5 +130,27 @@ impl std::fmt::Display for TransactionType {
             Self::PostNewsArticle => f.write_str("PostNewsArticle"),
             Self::Other(v) => write!(f, "Other({v})"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::TransactionType;
+
+    #[rstest]
+    #[case::file_list_empty(TransactionType::GetFileNameList, true, false)]
+    #[case::file_list_non_empty(TransactionType::GetFileNameList, false, false)]
+    #[case::banner_empty(TransactionType::DownloadBanner, true, false)]
+    #[case::banner_non_empty(TransactionType::DownloadBanner, false, true)]
+    #[case::news_article_empty(TransactionType::NewsArticleData, true, false)]
+    #[case::news_article_non_empty(TransactionType::NewsArticleData, false, false)]
+    fn rejects_payload_matches_expected_policy(
+        #[case] transaction_type: TransactionType,
+        #[case] payload_is_empty: bool,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(transaction_type.rejects_payload(payload_is_empty), expected);
     }
 }

--- a/src/transaction_type.rs
+++ b/src/transaction_type.rs
@@ -135,6 +135,11 @@ impl std::fmt::Display for TransactionType {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for `TransactionType` payload-policy helpers across explicit and
+    //! table-driven cases.
+
+    use rstest::rstest;
+
     use super::TransactionType;
 
     const ALL_TRANSACTION_TYPES: [TransactionType; 13] = [
@@ -153,30 +158,52 @@ mod tests {
         TransactionType::Other(999),
     ];
 
-    #[test]
-    fn rejects_payload_matches_expected_policy() {
-        assert!(!TransactionType::GetFileNameList.rejects_payload(true));
-        assert!(!TransactionType::GetFileNameList.rejects_payload(false));
-        assert!(!TransactionType::NewsArticleData.rejects_payload(true));
-        assert!(!TransactionType::NewsArticleData.rejects_payload(false));
-        assert!(!TransactionType::DownloadBanner.rejects_payload(true));
-        assert!(TransactionType::DownloadBanner.rejects_payload(false));
-        assert!(!TransactionType::GetUserNameList.rejects_payload(true));
-        assert!(TransactionType::GetUserNameList.rejects_payload(false));
+    #[rstest]
+    #[case(TransactionType::GetFileNameList, false, false)]
+    #[case(TransactionType::NewsArticleData, false, false)]
+    #[case(TransactionType::DownloadBanner, false, true)]
+    #[case(TransactionType::GetUserNameList, false, true)]
+    fn rejects_payload_matches_expected_policy(
+        #[case] transaction_type: TransactionType,
+        #[case] expected_for_empty_payload: bool,
+        #[case] expected_for_non_empty_payload: bool,
+    ) {
+        assert_eq!(
+            transaction_type.rejects_payload(true),
+            expected_for_empty_payload
+        );
+        assert_eq!(
+            transaction_type.rejects_payload(false),
+            expected_for_non_empty_payload
+        );
     }
 
-    #[test]
-    fn bypass_payload_decode_matches_transaction_policy() {
-        for transaction_type in ALL_TRANSACTION_TYPES {
-            let expected = matches!(transaction_type, TransactionType::GetFileNameList)
-                || !transaction_type.allows_payload();
-            assert_eq!(
-                transaction_type.bypass_payload_decode(),
-                expected,
-                "unexpected bypass policy for {transaction_type:?}"
-            );
-        }
-
-        assert!(TransactionType::GetUserNameList.bypass_payload_decode());
+    #[rstest]
+    #[case(TransactionType::Error, false)]
+    #[case(TransactionType::Login, false)]
+    #[case(TransactionType::Agreement, false)]
+    #[case(TransactionType::Agreed, false)]
+    #[case(TransactionType::GetFileNameList, true)]
+    #[case(TransactionType::DownloadBanner, true)]
+    #[case(TransactionType::GetUserNameList, true)]
+    #[case(TransactionType::UserAccess, false)]
+    #[case(TransactionType::NewsCategoryNameList, false)]
+    #[case(TransactionType::NewsArticleNameList, false)]
+    #[case(TransactionType::NewsArticleData, false)]
+    #[case(TransactionType::PostNewsArticle, false)]
+    #[case(TransactionType::Other(999), false)]
+    fn bypass_payload_decode_matches_transaction_policy(
+        #[case] transaction_type: TransactionType,
+        #[case] expected: bool,
+    ) {
+        assert!(
+            ALL_TRANSACTION_TYPES.contains(&transaction_type),
+            "missing coverage entry for {transaction_type:?}"
+        );
+        assert_eq!(
+            transaction_type.bypass_payload_decode(),
+            expected,
+            "unexpected bypass policy for {transaction_type:?}"
+        );
     }
 }

--- a/src/wireframe/codec/tests.rs
+++ b/src/wireframe/codec/tests.rs
@@ -16,6 +16,18 @@ fn hotline_config() -> impl bincode::config::Config {
         .with_fixed_int_encoding()
 }
 
+fn file_list_header(is_reply: u8, payload_len: u32) -> FrameHeader {
+    FrameHeader {
+        flags: 0,
+        is_reply,
+        ty: 200,
+        id: 99,
+        error: 0,
+        total_size: payload_len,
+        data_size: payload_len,
+    }
+}
+
 /// Assert that encoding the given transaction fails with an error message
 /// containing the expected substring.
 fn assert_encode_error(tx: &HotlineTransaction, expected_msg: &str) {
@@ -69,30 +81,34 @@ async fn decodes_valid_single_frame(#[case] total: u32, #[case] data: u32) {
     assert_eq!(tx.payload().len(), total as usize);
 }
 
+#[rstest]
+#[case(0)]
+#[case(1)]
 #[tokio::test]
-async fn decodes_opaque_file_list_request_payload() {
+async fn decodes_opaque_file_list_payload(#[case] is_reply: u8) {
     let payload = b"\x00\xffnot-a-param-block".to_vec();
     let payload_len = u32::try_from(payload.len()).expect("payload length fits in u32");
-    let header = FrameHeader {
-        flags: 0,
-        is_reply: 0,
-        ty: 200,
-        id: 99,
-        error: 0,
-        total_size: payload_len,
-        data_size: payload_len,
-    };
-    let bytes = transaction_bytes(&header, &payload);
-    let mut reader = BufReader::new(Cursor::new(bytes));
+    let header = file_list_header(is_reply, payload_len);
+    if is_reply == 0 {
+        let bytes = transaction_bytes(&header, &payload);
+        let mut reader = BufReader::new(Cursor::new(bytes));
 
-    let (tx, leftover) = read_preamble::<_, HotlineTransaction>(&mut reader)
-        .await
-        .expect("file-list request should decode");
+        let (tx, leftover) = read_preamble::<_, HotlineTransaction>(&mut reader)
+            .await
+            .expect("file-list request should decode");
 
-    assert!(leftover.is_empty());
-    assert_eq!(tx.header().ty, header.ty);
-    assert_eq!(tx.header().id, header.id);
-    assert_eq!(tx.payload(), payload.as_slice());
+        assert!(leftover.is_empty());
+        assert_eq!(tx.header().ty, header.ty);
+        assert_eq!(tx.header().is_reply, is_reply);
+        assert_eq!(tx.header().id, header.id);
+        assert_eq!(tx.payload(), payload.as_slice());
+        return;
+    }
+
+    let tx = Transaction { header, payload };
+    let err = HotlineTransaction::try_from(tx)
+        .expect_err("invalid file-list reply payload must be rejected");
+    assert!(err.to_string().contains("size mismatch"));
 }
 
 #[rstest]
@@ -309,25 +325,4 @@ fn encoding_rejects_invalid_transactions(
 ) {
     let tx = HotlineTransaction { header, payload };
     assert_encode_error(&tx, expected_msg);
-}
-
-#[test]
-fn try_from_rejects_invalid_file_list_reply_payload() {
-    let payload = b"\x00\xffnot-a-param-block".to_vec();
-    let payload_len = u32::try_from(payload.len()).expect("payload length fits in u32");
-    let tx = Transaction {
-        header: FrameHeader {
-            flags: 0,
-            is_reply: 1,
-            ty: 200,
-            id: 99,
-            error: 0,
-            total_size: payload_len,
-            data_size: payload_len,
-        },
-        payload,
-    };
-
-    let err = HotlineTransaction::try_from(tx).expect_err("invalid reply payload must be rejected");
-    assert!(err.to_string().contains("size mismatch"));
 }

--- a/src/wireframe/codec/tests.rs
+++ b/src/wireframe/codec/tests.rs
@@ -69,6 +69,32 @@ async fn decodes_valid_single_frame(#[case] total: u32, #[case] data: u32) {
     assert_eq!(tx.payload().len(), total as usize);
 }
 
+#[tokio::test]
+async fn decodes_opaque_file_list_request_payload() {
+    let payload = b"\x00\xffnot-a-param-block".to_vec();
+    let payload_len = u32::try_from(payload.len()).expect("payload length fits in u32");
+    let header = FrameHeader {
+        flags: 0,
+        is_reply: 0,
+        ty: 200,
+        id: 99,
+        error: 0,
+        total_size: payload_len,
+        data_size: payload_len,
+    };
+    let bytes = transaction_bytes(&header, &payload);
+    let mut reader = BufReader::new(Cursor::new(bytes));
+
+    let (tx, leftover) = read_preamble::<_, HotlineTransaction>(&mut reader)
+        .await
+        .expect("file-list request should decode");
+
+    assert!(leftover.is_empty());
+    assert_eq!(tx.header().ty, header.ty);
+    assert_eq!(tx.header().id, header.id);
+    assert_eq!(tx.payload(), payload.as_slice());
+}
+
 #[rstest]
 #[case(10, 20, "data size exceeds total")]
 #[case(100, 0, "data size is zero but total size is non-zero")]
@@ -283,4 +309,25 @@ fn encoding_rejects_invalid_transactions(
 ) {
     let tx = HotlineTransaction { header, payload };
     assert_encode_error(&tx, expected_msg);
+}
+
+#[test]
+fn try_from_rejects_invalid_file_list_reply_payload() {
+    let payload = b"\x00\xffnot-a-param-block".to_vec();
+    let payload_len = u32::try_from(payload.len()).expect("payload length fits in u32");
+    let tx = Transaction {
+        header: FrameHeader {
+            flags: 0,
+            is_reply: 1,
+            ty: 200,
+            id: 99,
+            error: 0,
+            total_size: payload_len,
+            data_size: payload_len,
+        },
+        payload,
+    };
+
+    let err = HotlineTransaction::try_from(tx).expect_err("invalid reply payload must be rejected");
+    assert!(err.to_string().contains("size mismatch"));
 }

--- a/src/wireframe/compat_layer.rs
+++ b/src/wireframe/compat_layer.rs
@@ -108,7 +108,7 @@ fn decode_payload_for_request(
     tx_type: TransactionType,
     transaction: Transaction,
 ) -> Result<Transaction, Vec<u8>> {
-    if !tx_type.allows_payload() {
+    if !tx_type.allows_payload() || tx_type == TransactionType::GetFileNameList {
         return Ok(transaction);
     }
     let decoded_payload = match xor.decode_payload(&transaction.payload) {
@@ -164,11 +164,14 @@ pub(crate) fn finalize_reply(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::{
+        net::SocketAddr,
+        sync::atomic::{AtomicU32, Ordering},
+    };
 
     use tokio::runtime::Builder;
 
-    use super::CompatibilityLayer;
+    use super::{CompatibilityLayer, decode_payload_for_request};
     use crate::{
         commands::{Command, CommandContext},
         handler::Session,
@@ -177,6 +180,7 @@ mod tests {
         transaction_type::TransactionType,
         wireframe::{
             auth_strategy::{AuthStrategy, AuthStrategyFuture},
+            compat::XorCompatibility,
             login_reply_augmenter::LoginReplyAugmenter,
             test_helpers::dummy_pool,
         },
@@ -272,6 +276,26 @@ mod tests {
     #[test]
     fn non_login_commands_bypass_auth_strategy() {
         run_auth_strategy_test(TransactionType::GetFileNameList, 0);
+    }
+
+    #[test]
+    fn file_list_payload_bypasses_param_decode() {
+        let peer: SocketAddr = "127.0.0.1:12345".parse().expect("valid loopback socket");
+        let xor = XorCompatibility::disabled();
+        let transaction = Transaction {
+            header: header(TransactionType::GetFileNameList),
+            payload: vec![0xca, 0x00, 0x02, 0x00, 0x01],
+        };
+
+        let decoded = decode_payload_for_request(
+            &xor,
+            peer,
+            TransactionType::GetFileNameList,
+            transaction.clone(),
+        )
+        .expect("file-list payload should bypass parameter decode");
+
+        assert_eq!(decoded.payload, transaction.payload);
     }
 
     #[test]

--- a/src/wireframe/compat_layer.rs
+++ b/src/wireframe/compat_layer.rs
@@ -108,7 +108,7 @@ fn decode_payload_for_request(
     tx_type: TransactionType,
     transaction: Transaction,
 ) -> Result<Transaction, Vec<u8>> {
-    if !tx_type.allows_payload() || tx_type == TransactionType::GetFileNameList {
+    if tx_type.bypass_payload_decode() {
         return Ok(transaction);
     }
     let decoded_payload = match xor.decode_payload(&transaction.payload) {

--- a/src/wireframe/compat_layer.rs
+++ b/src/wireframe/compat_layer.rs
@@ -294,10 +294,23 @@ mod tests {
             transaction.clone(),
         )
         .expect("file-list payload should bypass parameter decode");
+        let non_bypassed = decode_payload_for_request(
+            &xor,
+            peer,
+            TransactionType::NewsArticleData,
+            transaction.clone(),
+        );
 
         assert!(
             xor.is_enabled(),
             "xor state should remain non-trivial for the bypass check"
+        );
+        assert!(
+            match non_bypassed.as_ref() {
+                Err(_) => true,
+                Ok(non_bypassed_decoded) => non_bypassed_decoded.payload != transaction.payload,
+            },
+            "non-bypassed transaction should not preserve the opaque payload"
         );
         assert_eq!(decoded.payload, transaction.payload);
     }

--- a/src/wireframe/compat_layer.rs
+++ b/src/wireframe/compat_layer.rs
@@ -281,10 +281,10 @@ mod tests {
     #[test]
     fn file_list_payload_bypasses_param_decode() {
         let peer: SocketAddr = "127.0.0.1:12345".parse().expect("valid loopback socket");
-        let xor = XorCompatibility::disabled();
+        let xor = XorCompatibility::enabled();
         let transaction = Transaction {
             header: header(TransactionType::GetFileNameList),
-            payload: vec![0xca, 0x00, 0x02, 0x00, 0x01],
+            payload: vec![0xff, 0x00, 0x01, 0x02, 0x03],
         };
 
         let decoded = decode_payload_for_request(
@@ -295,6 +295,10 @@ mod tests {
         )
         .expect("file-list payload should bypass parameter decode");
 
+        assert!(
+            xor.is_enabled(),
+            "xor state should remain non-trivial for the bypass check"
+        );
         assert_eq!(decoded.payload, transaction.payload);
     }
 

--- a/test-util/src/postgres.rs
+++ b/test-util/src/postgres.rs
@@ -25,6 +25,8 @@ use rstest::fixture;
 use url::Url;
 use uuid::Uuid;
 
+const DEFAULT_POSTGRES_PORT: u16 = 5432;
+
 /// A validated `PostgreSQL` database connection URL.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatabaseUrl(String);
@@ -170,7 +172,7 @@ impl PostgresTestDbError {
 
 #[expect(clippy::shadow_reuse, reason = "clearer flow with shadowing")]
 fn postgres_available(url: &Url) -> bool {
-    if let (Some(host), Some(port)) = (url.host_str(), url.port_or_known_default()) {
+    if let (Some(host), Some(port)) = (url.host_str(), probe_port(url)) {
         let addr = (host, port)
             .to_socket_addrs()
             .ok()
@@ -180,6 +182,13 @@ fn postgres_available(url: &Url) -> bool {
         }
     }
     false
+}
+
+fn probe_port(url: &Url) -> Option<u16> {
+    url.port().or_else(|| match url.scheme() {
+        "postgres" | "postgresql" => Some(DEFAULT_POSTGRES_PORT),
+        _ => url.port_or_known_default(),
+    })
 }
 
 fn generate_db_name(prefix: &str) -> Result<DatabaseName, DatabaseNameError> {
@@ -652,4 +661,23 @@ pub fn postgres_db_fast() -> PostgresTestDb {
         };
         panic!("{msg}");
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for external `PostgreSQL` URL probing.
+
+    use rstest::rstest;
+    use url::Url;
+
+    use super::probe_port;
+
+    #[rstest]
+    #[case("postgres://postgres:password@127.0.0.1/test", Some(5432))]
+    #[case("postgresql://postgres:password@127.0.0.1/test", Some(5432))]
+    #[case("postgres://postgres:password@127.0.0.1:6543/test", Some(6543))]
+    fn probe_port_matches_postgres_url_policy(#[case] url: &str, #[case] expected: Option<u16>) {
+        let parsed = Url::parse(url).expect("test URL should parse");
+        assert_eq!(probe_port(&parsed), expected);
+    }
 }

--- a/test-util/src/server/mod.rs
+++ b/test-util/src/server/mod.rs
@@ -33,7 +33,7 @@ use crate::postgres::PostgresTestDb;
 /// The wireframe server (`mxd-wireframe-server`) is the default, as it provides
 /// the production-ready transport layer implementation.
 const SERVER_BINARY_NAME: &str = "mxd-wireframe-server";
-const DEFAULT_BIND_HOST: &str = "localhost";
+const DEFAULT_BIND_HOST: &str = "127.0.0.1";
 const TEST_BIND_HOST_ENV: &str = "MXD_TEST_BIND_HOST";
 const MAX_SERVER_LAUNCH_ATTEMPTS: u8 = 3;
 

--- a/test-util/src/server/readiness.rs
+++ b/test-util/src/server/readiness.rs
@@ -104,12 +104,12 @@ mod tests {
 
     use rstest::{fixture, rstest};
 
-    use super::{wait_for_listening, wait_for_server};
+    use super::{super::DEFAULT_BIND_HOST, wait_for_listening, wait_for_server};
     use crate::AnyError;
 
     #[fixture]
     fn listening_socket() -> TcpListener {
-        TcpListener::bind("localhost:0").expect("listen socket should bind")
+        TcpListener::bind(format!("{DEFAULT_BIND_HOST}:0")).expect("listen socket should bind")
     }
 
     #[rstest]

--- a/tests/file_list.rs
+++ b/tests/file_list.rs
@@ -82,28 +82,35 @@ fn perform_login(stream: &mut TcpStream, username: &[u8], password: &[u8]) -> Re
 /// # }
 /// ```
 fn get_file_list(stream: &mut TcpStream) -> Result<Vec<String>, AnyError> {
+    request_file_list(stream, Vec::new(), 2)
+}
+
+fn request_file_list(
+    stream: &mut TcpStream,
+    payload: Vec<u8>,
+    transaction_id: u32,
+) -> Result<Vec<String>, AnyError> {
+    let payload_len =
+        u32::try_from(payload.len()).expect("payload length fits within the 32-bit header field");
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
         ty: TransactionType::GetFileNameList.into(),
-        id: 2,
+        id: transaction_id,
         error: 0,
-        total_size: 0,
-        data_size: 0,
+        total_size: payload_len,
+        data_size: payload_len,
     };
-    let tx = Transaction {
-        header,
-        payload: Vec::new(),
-    };
+    let tx = Transaction { header, payload };
     stream.write_all(&tx.to_bytes())?;
     let mut buf = [0u8; 20];
     stream.read_exact(&mut buf)?;
     let hdr = FrameHeader::from_bytes(&buf);
-    let mut payload = vec![0u8; hdr.data_size as usize];
-    stream.read_exact(&mut payload)?;
+    let mut reply_payload = vec![0u8; hdr.data_size as usize];
+    stream.read_exact(&mut reply_payload)?;
     let resp = Transaction {
         header: hdr,
-        payload,
+        payload: reply_payload,
     };
     if resp.header.error != 0 {
         return Err(anyhow::anyhow!(
@@ -143,13 +150,6 @@ fn test_stream(
     Ok(Some((server, stream)))
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Keep signature consistent with `SetupFn` so tests can swap in fallible setup \
-              routines."
-)]
-fn noop_setup(_: DatabaseUrl) -> TestResult<()> { Ok(()) }
-
 #[rstest]
 fn list_files_acl(test_stream: TestResult<Option<(TestServer, TcpStream)>>) -> TestResult<()> {
     let Some((server, mut stream)) = test_stream? else {
@@ -166,37 +166,18 @@ fn list_files_acl(test_stream: TestResult<Option<(TestServer, TcpStream)>>) -> T
 }
 
 #[rstest]
-fn list_files_reject_payload(
-    #[with(noop_setup)] test_stream: TestResult<Option<(TestServer, TcpStream)>>,
+fn list_files_ignores_request_payload(
+    test_stream: TestResult<Option<(TestServer, TcpStream)>>,
 ) -> TestResult<()> {
     let Some((server, mut stream)) = test_stream? else {
         return Ok(());
     };
     let _server = server;
-    debug!("sending invalid file list payload");
+    perform_login(&mut stream, b"alice", b"secret")?;
+    debug!("sending decorated file list payload");
     let params = encode_params(&[(FieldId::Other(999), b"bogus".as_ref())])?;
-    let params_len =
-        u32::try_from(params.len()).expect("parameter block length fits within the header field");
-    let header = FrameHeader {
-        flags: 0,
-        is_reply: 0,
-        ty: TransactionType::GetFileNameList.into(),
-        id: 99,
-        error: 0,
-        total_size: params_len,
-        data_size: params_len,
-    };
-    let tx = Transaction {
-        header,
-        payload: params,
-    };
-    stream.write_all(&tx.to_bytes())?;
-    debug!("awaiting file list error reply");
-    let mut buf = [0u8; 20];
-    stream.read_exact(&mut buf)?;
-    let hdr = FrameHeader::from_bytes(&buf);
-    info!(error = hdr.error, "file list reply received");
-    assert_eq!(hdr.error, mxd::commands::ERR_INVALID_PAYLOAD);
-    assert_eq!(hdr.data_size, 0);
+    let names = request_file_list(&mut stream, params, 99)?;
+    info!(files = ?names, "file list reply received");
+    assert_eq!(names, vec!["fileA.txt", "fileC.txt"]);
     Ok(())
 }

--- a/tests/file_list.rs
+++ b/tests/file_list.rs
@@ -2,7 +2,6 @@
 //!
 //! Exercises the `GetFileNameList` transaction with ACL filtering and error
 //! handling scenarios.
-#![expect(clippy::expect_used, reason = "test assertions")]
 #![expect(clippy::panic_in_result_fn, reason = "test assertions")]
 
 use std::{
@@ -39,8 +38,7 @@ type SetupFn = fn(DatabaseUrl) -> TestResult<()>;
 fn perform_login(stream: &mut TcpStream, username: &[u8], password: &[u8]) -> Result<(), AnyError> {
     let params = vec![(FieldId::Login, username), (FieldId::Password, password)];
     let payload = encode_params(&params)?;
-    let payload_len =
-        u32::try_from(payload.len()).expect("payload length fits within the 32-bit header field");
+    let payload_len = u32::try_from(payload.len())?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,
@@ -90,8 +88,7 @@ fn request_file_list(
     payload: Vec<u8>,
     transaction_id: u32,
 ) -> Result<Vec<String>, AnyError> {
-    let payload_len =
-        u32::try_from(payload.len()).expect("payload length fits within the 32-bit header field");
+    let payload_len = u32::try_from(payload.len())?;
     let header = FrameHeader {
         flags: 0,
         is_reply: 0,

--- a/tests/file_list.rs
+++ b/tests/file_list.rs
@@ -175,8 +175,7 @@ fn list_files_ignores_request_payload(
     let _server = server;
     perform_login(&mut stream, b"alice", b"secret")?;
     debug!("sending decorated file list payload");
-    let params = encode_params(&[(FieldId::Other(999), b"bogus".as_ref())])?;
-    let names = request_file_list(&mut stream, params, 99)?;
+    let names = request_file_list(&mut stream, b"\x00\xffnot-a-param-block".to_vec(), 99)?;
     info!(files = ?names, "file list reply received");
     assert_eq!(names, vec!["fileA.txt", "fileC.txt"]);
     Ok(())

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -2,6 +2,38 @@
 #[cfg(feature = "postgres")]
 use test_util::{AnyError, PostgresTestDb, postgres::PostgresTestDbError, with_env_var};
 
+/// Validates that an opened database is an external (non-embedded) instance
+/// and that its URL has been assigned a unique suffix by the test harness.
+#[cfg(feature = "postgres")]
+fn validate_external_db(db: &PostgresTestDb, base: &str, prefix: &str) -> Result<(), AnyError> {
+    if db.uses_embedded() {
+        return Err(anyhow::anyhow!("expected external PostgreSQL instance"));
+    }
+    if !db.url.starts_with(prefix) {
+        return Err(anyhow::anyhow!("expected URL with prefix {prefix}"));
+    }
+    if db.url.as_ref() == base {
+        return Err(anyhow::anyhow!("expected database URL to be updated"));
+    }
+    Ok(())
+}
+
+/// Handles the case where `PostgreSQL` is reported as unreachable.
+///
+/// If the caller had an explicit `POSTGRES_TEST_URL` configured, the
+/// unreachable state is a hard failure. Otherwise the test is skipped with a
+/// warning.
+#[cfg(feature = "postgres")]
+fn handle_unavailable_postgres(configured_external_url: Option<&str>) -> Result<(), AnyError> {
+    if configured_external_url.is_some() {
+        return Err(anyhow::anyhow!(
+            "expected configured external PostgreSQL instance to be reachable"
+        ));
+    }
+    tracing::warn!("skipping test: PostgreSQL unavailable");
+    Ok(())
+}
+
 #[cfg(feature = "postgres")]
 #[test]
 fn external_postgres_is_used() -> Result<(), AnyError> {
@@ -19,26 +51,9 @@ fn external_postgres_is_used() -> Result<(), AnyError> {
         "POSTGRES_TEST_URL",
         Some(&base),
         || match PostgresTestDb::new() {
-            Ok(db) => {
-                if db.uses_embedded() {
-                    return Err(anyhow::anyhow!("expected external PostgreSQL instance"));
-                }
-                if !db.url.starts_with(prefix) {
-                    return Err(anyhow::anyhow!("expected URL with prefix {prefix}"));
-                }
-                if db.url.as_ref() == base {
-                    return Err(anyhow::anyhow!("expected database URL to be updated"));
-                }
-                Ok::<_, AnyError>(())
-            }
+            Ok(db) => validate_external_db(&db, &base, prefix),
             Err(PostgresTestDbError::Unavailable(_)) => {
-                if configured_external_url.is_some() {
-                    return Err(anyhow::anyhow!(
-                        "expected configured external PostgreSQL instance to be reachable"
-                    ));
-                }
-                tracing::warn!("skipping test: PostgreSQL unavailable");
-                Ok(())
+                handle_unavailable_postgres(configured_external_url.as_deref())
             }
             Err(e) => Err(e.into()),
         },

--- a/tests/postgres_env.rs
+++ b/tests/postgres_env.rs
@@ -5,8 +5,10 @@ use test_util::{AnyError, PostgresTestDb, postgres::PostgresTestDbError, with_en
 #[cfg(feature = "postgres")]
 #[test]
 fn external_postgres_is_used() -> Result<(), AnyError> {
-    let base = std::env::var("POSTGRES_TEST_URL")
-        .unwrap_or_else(|_| "postgres://postgres:password@localhost/test".to_owned());
+    let configured_external_url = std::env::var("POSTGRES_TEST_URL").ok();
+    let base = configured_external_url
+        .clone()
+        .unwrap_or_else(|| "postgres://postgres:password@localhost/test".to_owned());
     let idx = base
         .rfind('/')
         .ok_or_else(|| anyhow::anyhow!("POSTGRES_TEST_URL missing path"))?;
@@ -30,6 +32,11 @@ fn external_postgres_is_used() -> Result<(), AnyError> {
                 Ok::<_, AnyError>(())
             }
             Err(PostgresTestDbError::Unavailable(_)) => {
+                if configured_external_url.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "expected configured external PostgreSQL instance to be reachable"
+                    ));
+                }
                 tracing::warn!("skipping test: PostgreSQL unavailable");
                 Ok(())
             }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -8,6 +8,9 @@ expectrl = "0.7"
 tempfile = "3"
 which = "4"
 nix = { version = "0.27", optional = false, features = ["signal"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+thiserror = "2"
 
 [lints]
 workspace = true
@@ -24,3 +27,4 @@ argon2 = { version = "0.5", features = ["std"] }
 diesel = { version = "2.3", default-features = false, features = ["sqlite", "postgres"] }
 diesel-async = { version = "0.7", default-features = false, features = ["sqlite", "postgres", "sync-connection-wrapper"] }
 wait-timeout = "0.2"
+rstest = { workspace = true }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -11,6 +11,8 @@ nix = { version = "0.27", optional = false, features = ["signal"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "2"
+test-util = { path = "../test-util", default-features = false }
+wait-timeout = "0.2"
 
 [lints]
 workspace = true
@@ -21,10 +23,8 @@ sqlite = ["test-util/sqlite", "mxd/sqlite"]
 postgres = ["test-util/postgres", "mxd/postgres"]
 
 [dev-dependencies]
-test-util = { path = "../test-util", default-features = false }
 mxd = { path = "..", default-features = false }
 argon2 = { version = "0.5", features = ["std"] }
 diesel = { version = "2.3", default-features = false, features = ["sqlite", "postgres"] }
 diesel-async = { version = "0.7", default-features = false, features = ["sqlite", "postgres", "sync-connection-wrapper"] }
-wait-timeout = "0.2"
 rstest = { workspace = true }

--- a/validator/src/config.rs
+++ b/validator/src/config.rs
@@ -141,6 +141,7 @@ impl ValidatorConfig {
 
 /// An error raised while loading validator configuration.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ValidatorConfigError {
     /// The explicitly requested config file does not exist.
     #[error("validator config file does not exist: {0}")]

--- a/validator/src/config.rs
+++ b/validator/src/config.rs
@@ -227,14 +227,22 @@ fn parse_bool_env(env_var: &'static str, value: &str) -> Result<bool, ValidatorC
 mod tests {
     use std::collections::BTreeMap;
 
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
     use tempfile::TempDir;
 
     use super::*;
 
-    #[derive(Default)]
+    #[derive(Debug, Default, Clone)]
     struct FakeEnv {
         values: BTreeMap<String, String>,
+    }
+
+    #[derive(Debug)]
+    struct EnablementCase {
+        config_contents: Option<&'static str>,
+        env: FakeEnv,
+        validator: PendingValidator,
+        expected_enabled: bool,
     }
 
     impl FakeEnv {
@@ -256,46 +264,63 @@ mod tests {
         path
     }
 
-    #[test]
-    fn defaults_disable_pending_validators() {
-        let config =
-            ValidatorConfig::load_from_sources(None, &FakeEnv::default()).expect("load config");
-        assert!(!config.is_enabled(PendingValidator::Chat));
-        assert!(!config.is_enabled(PendingValidator::FileDownload));
-    }
-
-    #[test]
-    fn file_config_enables_pending_validator() {
-        let temp_dir = TempDir::new().expect("create temp dir");
-        let path = write_config(
-            &temp_dir,
-            "[validators]\nchat = true\nfile_download = false\n",
-        );
-
-        let config = ValidatorConfig::load_from_sources(Some(&path), &FakeEnv::default())
-            .expect("load config");
-
-        assert!(config.is_enabled(PendingValidator::Chat));
-        assert!(!config.is_enabled(PendingValidator::FileDownload));
+    #[fixture]
+    fn temp_config_dir() -> TempDir {
+        match TempDir::new() {
+            Ok(temp_dir) => temp_dir,
+            Err(error) => panic!("create temp dir: {error}"),
+        }
     }
 
     #[rstest]
-    #[case::chat(VALIDATOR_ENABLE_CHAT_ENV_VAR, PendingValidator::Chat)]
-    #[case::file_download(VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR, PendingValidator::FileDownload)]
-    fn env_override_enables_pending_validator(
-        #[case] env_var: &'static str,
-        #[case] validator: PendingValidator,
+    #[case::defaults_chat(EnablementCase {
+        config_contents: None,
+        env: FakeEnv::default(),
+        validator: PendingValidator::Chat,
+        expected_enabled: false,
+    })]
+    #[case::defaults_file_download(EnablementCase {
+        config_contents: None,
+        env: FakeEnv::default(),
+        validator: PendingValidator::FileDownload,
+        expected_enabled: false,
+    })]
+    #[case::file_config_chat(EnablementCase {
+        config_contents: Some("[validators]\nchat = true\nfile_download = false\n"),
+        env: FakeEnv::default(),
+        validator: PendingValidator::Chat,
+        expected_enabled: true,
+    })]
+    #[case::file_config_file_download(EnablementCase {
+        config_contents: Some("[validators]\nchat = true\nfile_download = false\n"),
+        env: FakeEnv::default(),
+        validator: PendingValidator::FileDownload,
+        expected_enabled: false,
+    })]
+    #[case::env_override_chat(EnablementCase {
+        config_contents: Some("[validators]\nchat = false\nfile_download = false\n"),
+        env: FakeEnv::default().with(VALIDATOR_ENABLE_CHAT_ENV_VAR, "true"),
+        validator: PendingValidator::Chat,
+        expected_enabled: true,
+    })]
+    #[case::env_override_file_download(EnablementCase {
+        config_contents: Some("[validators]\nchat = false\nfile_download = false\n"),
+        env: FakeEnv::default().with(VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR, "true"),
+        validator: PendingValidator::FileDownload,
+        expected_enabled: true,
+    })]
+    fn validator_enablement_follows_sources(
+        temp_config_dir: TempDir,
+        #[case] case: EnablementCase,
     ) {
-        let temp_dir = TempDir::new().expect("create temp dir");
-        let path = write_config(
-            &temp_dir,
-            "[validators]\nchat = false\nfile_download = false\n",
-        );
-        let env = FakeEnv::default().with(env_var, "true");
+        let path = case
+            .config_contents
+            .map(|contents| write_config(&temp_config_dir, contents));
 
-        let config = ValidatorConfig::load_from_sources(Some(&path), &env).expect("load config");
+        let config =
+            ValidatorConfig::load_from_sources(path.as_deref(), &case.env).expect("load config");
 
-        assert!(config.is_enabled(validator));
+        assert_eq!(config.is_enabled(case.validator), case.expected_enabled);
     }
 
     #[test]

--- a/validator/src/config.rs
+++ b/validator/src/config.rs
@@ -1,0 +1,328 @@
+//! Configuration for validator feature selection.
+//!
+//! Implemented validator flows such as login and XOR/news validation always
+//! run. Pending flows can be enabled selectively from a configuration file or
+//! environment variables so parallel feature branches can opt into the checks
+//! before the main branch can satisfy them.
+
+use std::{
+    env,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Environment variable that points at an alternate validator config file.
+pub const VALIDATOR_CONFIG_ENV_VAR: &str = "MXD_VALIDATOR_CONFIG";
+/// Environment variable that enables the pending chat validator.
+pub const VALIDATOR_ENABLE_CHAT_ENV_VAR: &str = "MXD_VALIDATOR_ENABLE_CHAT";
+/// Environment variable that enables the pending file-download validator.
+pub const VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR: &str = "MXD_VALIDATOR_ENABLE_FILE_DOWNLOAD";
+
+/// A pending validator that can be enabled selectively while the underlying
+/// server functionality is still landing on a parallel branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingValidator {
+    /// Validator for the chat flow.
+    Chat,
+    /// Validator for the file-download flow.
+    FileDownload,
+}
+
+impl PendingValidator {
+    const fn config_key(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::FileDownload => "file_download",
+        }
+    }
+
+    const fn env_var(self) -> &'static str {
+        match self {
+            Self::Chat => VALIDATOR_ENABLE_CHAT_ENV_VAR,
+            Self::FileDownload => VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR,
+        }
+    }
+}
+
+impl std::fmt::Display for PendingValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.config_key())
+    }
+}
+
+/// Effective validator configuration after merging file and environment inputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ValidatorConfig {
+    chat: bool,
+    file_download: bool,
+}
+
+impl ValidatorConfig {
+    /// Load validator configuration from the default file and environment.
+    ///
+    /// The default file is `validator/validator.toml` relative to this crate's
+    /// manifest directory. `MXD_VALIDATOR_CONFIG` can point at an alternate
+    /// file, and environment toggles override file values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an explicitly requested config file does not
+    /// exist, when a config file cannot be read or parsed, or when an
+    /// environment override is not a valid boolean.
+    pub fn load() -> Result<Self, ValidatorConfigError> { Self::load_with_env(&RealEnv) }
+
+    /// Return `true` when the given pending validator is enabled.
+    #[must_use]
+    pub const fn is_enabled(self, validator: PendingValidator) -> bool {
+        match validator {
+            PendingValidator::Chat => self.chat,
+            PendingValidator::FileDownload => self.file_download,
+        }
+    }
+
+    fn load_with_env(env_source: &impl EnvSource) -> Result<Self, ValidatorConfigError> {
+        let override_path = env_source.var(VALIDATOR_CONFIG_ENV_VAR).map(PathBuf::from);
+        Self::load_from_sources(override_path.as_deref(), env_source)
+    }
+
+    fn load_from_sources(
+        override_path: Option<&Path>,
+        env_source: &impl EnvSource,
+    ) -> Result<Self, ValidatorConfigError> {
+        let default_path = Self::default_config_path();
+        let config_path = override_path.unwrap_or(default_path.as_path());
+        let mut config = if config_path.exists() {
+            Self::from_file(config_path)?
+        } else if override_path.is_some() {
+            return Err(ValidatorConfigError::MissingConfigFile(
+                config_path.to_path_buf(),
+            ));
+        } else {
+            Self::default()
+        };
+        config.apply_env(env_source)?;
+        Ok(config)
+    }
+
+    fn default_config_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("validator.toml")
+    }
+
+    fn from_file(path: &Path) -> Result<Self, ValidatorConfigError> {
+        let contents =
+            fs::read_to_string(path).map_err(|source| ValidatorConfigError::ReadConfig {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let parsed: FileConfig =
+            toml::from_str(&contents).map_err(|source| ValidatorConfigError::ParseConfig {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        Ok(Self {
+            chat: parsed.validators.chat.unwrap_or(false),
+            file_download: parsed.validators.file_download.unwrap_or(false),
+        })
+    }
+
+    fn apply_env(&mut self, env_source: &impl EnvSource) -> Result<(), ValidatorConfigError> {
+        if let Some(value) = env_source.var(VALIDATOR_ENABLE_CHAT_ENV_VAR) {
+            self.chat = parse_bool_env(VALIDATOR_ENABLE_CHAT_ENV_VAR, &value)?;
+        }
+        if let Some(value) = env_source.var(VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR) {
+            self.file_download = parse_bool_env(VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR, &value)?;
+        }
+        Ok(())
+    }
+}
+
+/// An error raised while loading validator configuration.
+#[derive(Debug, Error)]
+pub enum ValidatorConfigError {
+    /// The explicitly requested config file does not exist.
+    #[error("validator config file does not exist: {0}")]
+    MissingConfigFile(PathBuf),
+    /// The config file could not be read.
+    #[error("failed to read validator config {path}: {source}")]
+    ReadConfig {
+        /// Path that was being read.
+        path: PathBuf,
+        /// Underlying read error.
+        source: std::io::Error,
+    },
+    /// The config file could not be parsed as TOML.
+    #[error("failed to parse validator config {path}: {source}")]
+    ParseConfig {
+        /// Path that was being parsed.
+        path: PathBuf,
+        /// Underlying TOML parse error.
+        source: toml::de::Error,
+    },
+    /// An environment override was not a valid boolean string.
+    #[error("environment variable {env_var} must be 'true' or 'false', got '{value}'")]
+    InvalidBool {
+        /// Environment variable name.
+        env_var: &'static str,
+        /// Invalid provided value.
+        value: String,
+    },
+}
+
+/// Return the skip message emitted when a pending validator is disabled.
+#[must_use]
+pub fn pending_validator_disabled_message(validator: PendingValidator) -> String {
+    format!(
+        "pending validator '{validator}' is disabled; enable it with {} or {}",
+        validator.env_var(),
+        VALIDATOR_CONFIG_ENV_VAR
+    )
+}
+
+/// Return the failure message emitted when an enabled pending validator has not
+/// yet been implemented.
+#[must_use]
+pub fn pending_validator_unimplemented_message(validator: PendingValidator) -> String {
+    format!(
+        "pending validator '{validator}' is enabled, but the wireframe server flow is not \
+         implemented yet"
+    )
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct FileConfig {
+    #[serde(default)]
+    validators: FileValidators,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct FileValidators {
+    chat: Option<bool>,
+    file_download: Option<bool>,
+}
+
+trait EnvSource {
+    fn var(&self, key: &str) -> Option<String>;
+}
+
+struct RealEnv;
+
+impl EnvSource for RealEnv {
+    fn var(&self, key: &str) -> Option<String> { env::var(key).ok() }
+}
+
+fn parse_bool_env(env_var: &'static str, value: &str) -> Result<bool, ValidatorConfigError> {
+    value
+        .parse::<bool>()
+        .map_err(|_| ValidatorConfigError::InvalidBool {
+            env_var,
+            value: value.to_owned(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use rstest::rstest;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeEnv {
+        values: BTreeMap<String, String>,
+    }
+
+    impl FakeEnv {
+        fn with(mut self, key: &str, value: &str) -> Self {
+            self.values.insert(key.to_owned(), value.to_owned());
+            self
+        }
+    }
+
+    impl EnvSource for FakeEnv {
+        fn var(&self, key: &str) -> Option<String> { self.values.get(key).cloned() }
+    }
+
+    fn config_path(temp_dir: &TempDir) -> PathBuf { temp_dir.path().join("validator.toml") }
+
+    fn write_config(temp_dir: &TempDir, contents: &str) -> PathBuf {
+        let path = config_path(temp_dir);
+        fs::write(&path, contents).expect("write validator config");
+        path
+    }
+
+    #[test]
+    fn defaults_disable_pending_validators() {
+        let config =
+            ValidatorConfig::load_from_sources(None, &FakeEnv::default()).expect("load config");
+        assert!(!config.is_enabled(PendingValidator::Chat));
+        assert!(!config.is_enabled(PendingValidator::FileDownload));
+    }
+
+    #[test]
+    fn file_config_enables_pending_validator() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let path = write_config(
+            &temp_dir,
+            "[validators]\nchat = true\nfile_download = false\n",
+        );
+
+        let config = ValidatorConfig::load_from_sources(Some(&path), &FakeEnv::default())
+            .expect("load config");
+
+        assert!(config.is_enabled(PendingValidator::Chat));
+        assert!(!config.is_enabled(PendingValidator::FileDownload));
+    }
+
+    #[rstest]
+    #[case::chat(VALIDATOR_ENABLE_CHAT_ENV_VAR, PendingValidator::Chat)]
+    #[case::file_download(VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR, PendingValidator::FileDownload)]
+    fn env_override_enables_pending_validator(
+        #[case] env_var: &'static str,
+        #[case] validator: PendingValidator,
+    ) {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let path = write_config(
+            &temp_dir,
+            "[validators]\nchat = false\nfile_download = false\n",
+        );
+        let env = FakeEnv::default().with(env_var, "true");
+
+        let config = ValidatorConfig::load_from_sources(Some(&path), &env).expect("load config");
+
+        assert!(config.is_enabled(validator));
+    }
+
+    #[test]
+    fn invalid_env_bool_is_reported() {
+        let env = FakeEnv::default().with(VALIDATOR_ENABLE_CHAT_ENV_VAR, "enabled");
+
+        let err =
+            ValidatorConfig::load_from_sources(None, &env).expect_err("invalid bool should fail");
+
+        assert!(matches!(
+            err,
+            ValidatorConfigError::InvalidBool {
+                env_var: VALIDATOR_ENABLE_CHAT_ENV_VAR,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn explicit_missing_config_file_fails() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let env = FakeEnv::default().with(
+            VALIDATOR_CONFIG_ENV_VAR,
+            &config_path(&temp_dir).display().to_string(),
+        );
+
+        let err = ValidatorConfig::load_with_env(&env).expect_err("missing file should fail");
+
+        assert!(matches!(err, ValidatorConfigError::MissingConfigFile(_)));
+    }
+}

--- a/validator/src/harness.rs
+++ b/validator/src/harness.rs
@@ -164,12 +164,9 @@ pub fn expect_no_match(
     context: &'static str,
 ) -> Result<(), AnyError> {
     session.set_expect_timeout(Some(Duration::from_millis(250)));
-    let result = session.expect(Regex(pattern));
+    let result = session.expect(Regex(pattern)).map(|_| ());
     session.set_expect_timeout(Some(DEFAULT_EXPECT_TIMEOUT));
-    if result.is_ok() {
-        return Err(AnyError::msg(context));
-    }
-    Ok(())
+    interpret_no_match_result(result, context, pending_output(session))
 }
 
 /// Close a `SynHX` session, reporting cleanup failures as skipped diagnostics.
@@ -206,6 +203,20 @@ fn format_expect_error(
         "{context}: {error}; pending output: {}",
         pending_transcript.escape_default()
     )
+}
+
+fn interpret_no_match_result(
+    result: Result<(), expectrl::Error>,
+    context: &str,
+    transcript: Option<String>,
+) -> Result<(), AnyError> {
+    match result {
+        Ok(()) => Err(AnyError::msg(context.to_owned())),
+        Err(expectrl::Error::ExpectTimeout) => Ok(()),
+        Err(error) => Err(AnyError::msg(format_expect_error(
+            context, &error, transcript,
+        ))),
+    }
 }
 
 fn handle_prerequisite(
@@ -246,7 +257,7 @@ impl From<ServerBinaryError> for PrerequisiteError {
 
 #[cfg(test)]
 mod tests {
-    use super::format_expect_error;
+    use super::{format_expect_error, interpret_no_match_result};
 
     #[test]
     fn format_expect_error_omits_empty_transcript() {
@@ -276,6 +287,33 @@ mod tests {
                 "context: Reached a timeout for expect type of command; pending output: ",
                 "connected to host\\nHX"
             )
+        );
+    }
+
+    #[test]
+    fn no_match_timeout_is_treated_as_success() {
+        let result = interpret_no_match_result(
+            Err(expectrl::Error::ExpectTimeout),
+            "context",
+            Some("HX".to_owned()),
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn no_match_eof_is_reported_as_failure() {
+        let error = interpret_no_match_result(
+            Err(expectrl::Error::Eof),
+            "context",
+            Some("pending output".to_owned()),
+        )
+        .expect_err("EOF must fail the no-match assertion");
+
+        assert_eq!(
+            error.to_string(),
+            "context: EOF was reached; the read may successed later; pending output: pending \
+             output"
         );
     }
 }

--- a/validator/src/harness.rs
+++ b/validator/src/harness.rs
@@ -1,0 +1,196 @@
+//! High-level validator harness helpers.
+//!
+//! This module centralizes prerequisite checks, explicit wireframe server
+//! targeting, and `SynHX` PTY setup so end-to-end validator tests can stay
+//! focused on protocol flows rather than process orchestration.
+
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use expectrl::{Regex, Session};
+use test_util::{AnyError, TestServer, with_env_var};
+
+use crate::{
+    hx_client::{HxClientError, expect_hotline_prompt, spawn_hx_session, terminate_hx},
+    policy::{PrerequisiteResolution, ValidatorRunPolicy},
+    server_binary::{ServerBinaryError, resolve_wireframe_server_binary},
+};
+
+const SERVER_BINARY_ENV: &str = "CARGO_BIN_EXE_mxd-wireframe-server";
+const DEFAULT_EXPECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_MANIFEST_PATH: &str = "../Cargo.toml";
+
+/// Prepared validator harness with explicit `hx` and server binary targeting.
+#[derive(Debug, Clone)]
+pub struct ValidatorHarness {
+    server_binary: PathBuf,
+}
+
+impl ValidatorHarness {
+    /// Prepare the validator harness or skip locally when prerequisites are
+    /// unavailable.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when fail-closed policy is active and a prerequisite is
+    /// missing or invalid.
+    pub fn prepare() -> Result<Option<Self>, AnyError> {
+        let policy = ValidatorRunPolicy::load()?;
+        let server_binary = match resolve_wireframe_server_binary() {
+            Ok(path) => path,
+            Err(error) => return handle_prerequisite(policy, error),
+        };
+        if let Err(error) = crate::hx_client::resolve_hx_binary() {
+            return handle_prerequisite(policy, error);
+        }
+
+        Ok(Some(Self { server_binary }))
+    }
+
+    /// Return the explicit wireframe server binary used by the harness.
+    #[must_use]
+    pub fn server_binary(&self) -> &Path { self.server_binary.as_path() }
+
+    /// Start a test server with the shared wireframe binary environment set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if database setup, server launch, or environment
+    /// mutation fails.
+    pub fn start_server_with_setup<F>(&self, setup: F) -> Result<TestServer, AnyError>
+    where
+        F: FnOnce(&str) -> Result<(), AnyError>,
+    {
+        let binary = self.server_binary.display().to_string();
+        with_env_var(SERVER_BINARY_ENV, Some(&binary), || {
+            TestServer::start_with_setup(DEFAULT_MANIFEST_PATH, |db| setup(db.as_str()))
+        })
+    }
+
+    /// Spawn a `SynHX` session and wait for the standard prompt.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the client cannot be launched or if the prompt does
+    /// not appear.
+    pub fn spawn_hx(&self) -> Result<Session, AnyError> {
+        let mut session = spawn_hx_session(DEFAULT_EXPECT_TIMEOUT)?;
+        expect_hotline_prompt(&mut session)?;
+        Ok(session)
+    }
+}
+
+/// Report a skipped validator test to stderr.
+pub fn report_skip(message: &str) {
+    #[expect(
+        clippy::print_stderr,
+        reason = "skip message: inform user why test is being skipped"
+    )]
+    {
+        eprintln!("{message}");
+    }
+}
+
+/// Send a command and assert that the session output matches the provided
+/// regular expression.
+///
+/// # Errors
+///
+/// Returns an error if the write fails or if the expected output is not
+/// observed before the PTY timeout expires.
+pub fn send_line_and_expect(
+    session: &mut Session,
+    command: impl AsRef<str>,
+    pattern: &'static str,
+    context: &'static str,
+) -> Result<(), AnyError> {
+    session.send_line(command.as_ref())?;
+    expect_output(session, pattern, context)
+}
+
+/// Assert that the current session output matches the provided regular
+/// expression.
+///
+/// # Errors
+///
+/// Returns an error if the expected output is not observed before the PTY
+/// timeout expires.
+pub fn expect_output(
+    session: &mut Session,
+    pattern: &'static str,
+    context: &'static str,
+) -> Result<(), AnyError> {
+    session
+        .expect(Regex(pattern))
+        .map(|_| ())
+        .map_err(|error| AnyError::msg(format!("{context}: {error}")))
+}
+
+/// Assert that the provided pattern does not appear in the current session
+/// output window.
+///
+/// # Errors
+///
+/// Returns an error if the pattern unexpectedly appears or if expect timeout
+/// configuration fails.
+pub fn expect_no_match(
+    session: &mut Session,
+    pattern: &'static str,
+    context: &'static str,
+) -> Result<(), AnyError> {
+    session.set_expect_timeout(Some(Duration::from_millis(250)));
+    let result = session.expect(Regex(pattern));
+    session.set_expect_timeout(Some(DEFAULT_EXPECT_TIMEOUT));
+    if result.is_ok() {
+        return Err(AnyError::msg(context));
+    }
+    Ok(())
+}
+
+/// Close a `SynHX` session, reporting cleanup failures as skipped diagnostics.
+pub fn close_hx(session: &mut Session) {
+    if let Err(error) = session.send_line("/quit") {
+        report_skip(&format!("hx quit command failed ({error})"));
+    }
+    if let Err(error) = terminate_hx(session) {
+        report_skip(&error.to_string());
+    }
+}
+
+fn handle_prerequisite(
+    policy: ValidatorRunPolicy,
+    error: impl Into<PrerequisiteError>,
+) -> Result<Option<ValidatorHarness>, AnyError> {
+    match policy.prerequisite_resolution(error.into().to_string()) {
+        PrerequisiteResolution::Skip(message) => {
+            report_skip(&message);
+            Ok(None)
+        }
+        PrerequisiteResolution::Fail(message) => Err(AnyError::msg(message)),
+    }
+}
+
+#[derive(Debug)]
+enum PrerequisiteError {
+    Hx(HxClientError),
+    ServerBinary(ServerBinaryError),
+}
+
+impl std::fmt::Display for PrerequisiteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hx(error) => error.fmt(f),
+            Self::ServerBinary(error) => error.fmt(f),
+        }
+    }
+}
+
+impl From<HxClientError> for PrerequisiteError {
+    fn from(value: HxClientError) -> Self { Self::Hx(value) }
+}
+
+impl From<ServerBinaryError> for PrerequisiteError {
+    fn from(value: ServerBinaryError) -> Self { Self::ServerBinary(value) }
+}

--- a/validator/src/harness.rs
+++ b/validator/src/harness.rs
@@ -20,6 +20,7 @@ use crate::{
 
 const SERVER_BINARY_ENV: &str = "CARGO_BIN_EXE_mxd-wireframe-server";
 const DEFAULT_EXPECT_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECT_EXPECT_TIMEOUT: Duration = Duration::from_secs(20);
 const DEFAULT_MANIFEST_PATH: &str = "../Cargo.toml";
 
 /// Prepared validator harness with explicit `hx` and server binary targeting.
@@ -122,10 +123,32 @@ pub fn expect_output(
     pattern: &'static str,
     context: &'static str,
 ) -> Result<(), AnyError> {
-    session
-        .expect(Regex(pattern))
-        .map(|_| ())
-        .map_err(|error| AnyError::msg(format!("{context}: {error}")))
+    expect_output_with_timeout(session, pattern, context, DEFAULT_EXPECT_TIMEOUT)
+}
+
+/// Assert that the current session output matches the provided regular
+/// expression, using a temporary expect timeout.
+///
+/// # Errors
+///
+/// Returns an error if the expected output is not observed before the PTY
+/// timeout expires.
+pub fn expect_output_with_timeout(
+    session: &mut Session,
+    pattern: &'static str,
+    context: &'static str,
+    timeout: Duration,
+) -> Result<(), AnyError> {
+    session.set_expect_timeout(Some(timeout));
+    let result = session.expect(Regex(pattern)).map(|_| ()).map_err(|error| {
+        AnyError::msg(format_expect_error(
+            context,
+            &error,
+            pending_output(session),
+        ))
+    });
+    session.set_expect_timeout(Some(DEFAULT_EXPECT_TIMEOUT));
+    result
 }
 
 /// Assert that the provided pattern does not appear in the current session
@@ -157,6 +180,32 @@ pub fn close_hx(session: &mut Session) {
     if let Err(error) = terminate_hx(session) {
         report_skip(&error.to_string());
     }
+}
+
+/// Timeout used when waiting for `hx` to authenticate against a test server.
+#[must_use]
+pub const fn connect_expect_timeout() -> Duration { CONNECT_EXPECT_TIMEOUT }
+
+fn pending_output(session: &mut Session) -> Option<String> {
+    session
+        .check(Regex("(?s).+"))
+        .ok()
+        .filter(|captures| !captures.is_empty())
+        .map(|captures| String::from_utf8_lossy(captures.as_bytes()).into_owned())
+}
+
+fn format_expect_error(
+    context: &str,
+    error: &expectrl::Error,
+    transcript: Option<String>,
+) -> String {
+    let Some(pending_transcript) = transcript.filter(|output| !output.trim().is_empty()) else {
+        return format!("{context}: {error}");
+    };
+    format!(
+        "{context}: {error}; pending output: {}",
+        pending_transcript.escape_default()
+    )
 }
 
 fn handle_prerequisite(
@@ -193,4 +242,40 @@ impl From<HxClientError> for PrerequisiteError {
 
 impl From<ServerBinaryError> for PrerequisiteError {
     fn from(value: ServerBinaryError) -> Self { Self::ServerBinary(value) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_expect_error;
+
+    #[test]
+    fn format_expect_error_omits_empty_transcript() {
+        let message = format_expect_error(
+            "context",
+            &expectrl::Error::ExpectTimeout,
+            Some(" \n\t".to_owned()),
+        );
+
+        assert_eq!(
+            message,
+            "context: Reached a timeout for expect type of command"
+        );
+    }
+
+    #[test]
+    fn format_expect_error_includes_transcript() {
+        let message = format_expect_error(
+            "context",
+            &expectrl::Error::ExpectTimeout,
+            Some("connected to host\nHX".to_owned()),
+        );
+
+        assert_eq!(
+            message,
+            concat!(
+                "context: Reached a timeout for expect type of command; pending output: ",
+                "connected to host\\nHX"
+            )
+        );
+    }
 }

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -173,13 +173,7 @@ fn hx_is_helix(path: &PathBuf) -> Result<bool, HxClientError> {
         }
         Ok(None) => {
             terminate_child(&mut child);
-            Err(HxClientError::Probe {
-                path: path.clone(),
-                source: std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "hx --version probe timed out",
-                ),
-            })
+            Ok(false)
         }
         Err(source) => {
             terminate_child(&mut child);
@@ -212,6 +206,9 @@ mod tests {
     //!
     //! These tests cover the lightweight output classifier plus resolver behaviour
     //! around missing overrides and accepted executable paths.
+
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
 
     use rstest::rstest;
     use tempfile::TempDir;
@@ -257,5 +254,22 @@ mod tests {
 
         assert_ne!(explicit, discovered);
         assert_eq!(resolved, explicit);
+    }
+
+    #[test]
+    fn timeout_probe_is_treated_as_non_helix() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let hx_script = temp_dir.path().join("hx");
+        fs::write(&hx_script, "#!/usr/bin/env sh\nsleep 2\n").expect("write timeout script");
+        let mut permissions = fs::metadata(&hx_script)
+            .expect("read timeout script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hx_script, permissions).expect("make timeout script executable");
+
+        let resolved = resolve_hx_binary_with_env(None, Some(hx_script.clone()))
+            .expect("timeout probe should still accept non-Helix hx");
+
+        assert_eq!(resolved, hx_script);
     }
 }

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -210,7 +210,7 @@ fn read_stream<T: Read>(maybe_stream: Option<T>) -> Result<String, std::io::Erro
 mod tests {
     //! Unit tests for Helix probe heuristics and binary-resolution edge cases.
     //!
-    //! These tests cover the lightweight output classifier plus resolver behavior
+    //! These tests cover the lightweight output classifier plus resolver behaviour
     //! around missing overrides and accepted executable paths.
 
     use rstest::rstest;
@@ -247,12 +247,15 @@ mod tests {
     #[test]
     fn explicit_override_wins_when_present() {
         let explicit = std::env::current_exe().expect("resolve current test binary");
-        let discovered = std::env::current_exe().expect("resolve current test binary");
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let discovered = temp_dir.path().join("discovered-hx");
+        std::os::unix::fs::symlink(&explicit, &discovered).expect("create discovered hx symlink");
 
         let resolved =
             resolve_hx_binary_with_env(Some(explicit.as_os_str()), Some(discovered.clone()))
                 .expect("resolve explicit hx binary");
 
+        assert_ne!(explicit, discovered);
         assert_eq!(resolved, explicit);
     }
 }

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -7,7 +7,7 @@
 use std::{
     ffi::OsStr,
     io::Read,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     time::Duration,
 };
@@ -146,14 +146,14 @@ pub fn terminate_hx(session: &mut Session) -> Result<(), HxClientError> {
         .map_err(|error| HxClientError::Cleanup(error.to_string()))
 }
 
-fn hx_is_helix(path: &PathBuf) -> Result<bool, HxClientError> {
+fn hx_is_helix(path: &Path) -> Result<bool, HxClientError> {
     let mut child = Command::new(path)
         .arg("--version")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|source| HxClientError::Probe {
-            path: path.clone(),
+            path: path.to_path_buf(),
             source,
         })?;
 
@@ -161,12 +161,12 @@ fn hx_is_helix(path: &PathBuf) -> Result<bool, HxClientError> {
         Ok(Some(_)) => {
             let stdout =
                 read_stream(child.stdout.take()).map_err(|source| HxClientError::Probe {
-                    path: path.clone(),
+                    path: path.to_path_buf(),
                     source,
                 })?;
             let stderr =
                 read_stream(child.stderr.take()).map_err(|source| HxClientError::Probe {
-                    path: path.clone(),
+                    path: path.to_path_buf(),
                     source,
                 })?;
             let combined = format!("{stdout}{stderr}");
@@ -179,7 +179,7 @@ fn hx_is_helix(path: &PathBuf) -> Result<bool, HxClientError> {
         Err(source) => {
             terminate_child(&mut child);
             Err(HxClientError::Probe {
-                path: path.clone(),
+                path: path.to_path_buf(),
                 source,
             })
         }

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -1,0 +1,162 @@
+//! `SynHX` discovery and PTY helpers for validator runs.
+//!
+//! The validator harness must reject the unrelated Helix editor binary when it
+//! is installed as `hx`, while still allowing local developer runs to skip
+//! cleanly when `SynHX` is absent.
+
+use std::{
+    io::Read,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    time::Duration,
+};
+
+use expectrl::{Regex, Session, spawn};
+use thiserror::Error;
+use wait_timeout::ChildExt;
+use which::which;
+
+/// Environment variable that overrides the `hx` binary used by the validator.
+pub const VALIDATOR_HX_BINARY_ENV_VAR: &str = "MXD_VALIDATOR_HX_BINARY";
+
+const HELIX_DETECTION_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Error raised while resolving or launching the `hx` client.
+#[derive(Debug, Error)]
+pub enum HxClientError {
+    /// The `hx` binary could not be found.
+    #[error("hx binary not found; install SynHX or set MXD_VALIDATOR_HX_BINARY")]
+    MissingBinary,
+    /// The discovered `hx` binary appears to be the Helix editor.
+    #[error("hx appears to be the Helix editor, not SynHX")]
+    HelixBinary,
+    /// Spawning the `hx` client failed.
+    #[error("failed to spawn hx from {path}: {source}")]
+    Spawn {
+        /// Binary path used for spawning.
+        path: PathBuf,
+        /// Underlying spawn error.
+        source: expectrl::Error,
+    },
+    /// The expected `SynHX` prompt did not appear.
+    #[error("hx did not present the Hotline prompt: {0}")]
+    Prompt(expectrl::Error),
+    /// Best-effort cleanup failed.
+    #[error("hx cleanup failed: {0}")]
+    Cleanup(String),
+}
+
+/// Resolve the `SynHX` `hx` binary path and reject Helix if it is installed
+/// under the same name.
+///
+/// # Errors
+///
+/// Returns an error if no `hx` binary can be found or if the resolved binary
+/// is the Helix editor.
+pub fn resolve_hx_binary() -> Result<PathBuf, HxClientError> {
+    let path = std::env::var_os(VALIDATOR_HX_BINARY_ENV_VAR)
+        .map(PathBuf::from)
+        .or_else(|| which("hx").ok())
+        .ok_or(HxClientError::MissingBinary)?;
+
+    if hx_is_helix(&path) {
+        return Err(HxClientError::HelixBinary);
+    }
+
+    Ok(path)
+}
+
+/// Spawn a `SynHX` session with the provided expect timeout.
+///
+/// # Errors
+///
+/// Returns an error if the `hx` binary cannot be resolved or if the PTY
+/// session cannot be started.
+pub fn spawn_hx_session(expect_timeout: Duration) -> Result<Session, HxClientError> {
+    let path = resolve_hx_binary()?;
+    let mut session = spawn(path.to_string_lossy().as_ref())
+        .map_err(|source| HxClientError::Spawn { path, source })?;
+    session.set_expect_timeout(Some(expect_timeout));
+    Ok(session)
+}
+
+/// Wait for the standard `SynHX` prompt.
+///
+/// # Errors
+///
+/// Returns an error if the prompt does not appear before the configured expect
+/// timeout elapses.
+pub fn expect_hotline_prompt(session: &mut Session) -> Result<(), HxClientError> {
+    session
+        .expect(Regex("HX"))
+        .map(|_| ())
+        .map_err(HxClientError::Prompt)
+}
+
+/// Close a `SynHX` session, ignoring whether the process already exited.
+///
+/// # Errors
+///
+/// Returns an error if the PTY process could not be terminated cleanly.
+pub fn terminate_hx(session: &mut Session) -> Result<(), HxClientError> {
+    session
+        .get_process_mut()
+        .exit(true)
+        .map(|_| ())
+        .map_err(|error| HxClientError::Cleanup(error.to_string()))
+}
+
+fn hx_is_helix(path: &PathBuf) -> bool {
+    let Ok(mut child) = Command::new(path)
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    else {
+        return false;
+    };
+
+    if let Ok(Some(_)) = child.wait_timeout(HELIX_DETECTION_TIMEOUT) {
+        let stdout = read_stream(child.stdout.take());
+        let stderr = read_stream(child.stderr.take());
+        let combined = format!("{stdout}{stderr}");
+        output_looks_like_helix(&combined)
+    } else {
+        terminate_child(&mut child);
+        false
+    }
+}
+
+fn output_looks_like_helix(output: &str) -> bool { output.to_lowercase().contains("helix") }
+
+fn terminate_child(child: &mut Child) {
+    let _kill_result = child.kill();
+    let _wait_result = child.wait();
+}
+
+fn read_stream<T: Read>(maybe_stream: Option<T>) -> String {
+    let mut buffer = Vec::new();
+    if let Some(mut stream) = maybe_stream {
+        let _read_result = stream.read_to_end(&mut buffer);
+    }
+    String::from_utf8_lossy(&buffer).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helix_output_is_detected_case_insensitively() {
+        assert!(output_looks_like_helix("Helix 24.03"));
+        assert!(output_looks_like_helix("helix terminal editor"));
+    }
+
+    #[test]
+    fn non_helix_output_is_not_rejected() {
+        assert!(!output_looks_like_helix("hx version 0.1.48.1"));
+        assert!(!output_looks_like_helix(
+            "load: p: No such file or directory"
+        ));
+    }
+}

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -40,6 +40,14 @@ pub enum HxClientError {
     /// The discovered `hx` binary appears to be the Helix editor.
     #[error("hx appears to be the Helix editor, not SynHX")]
     HelixBinary,
+    /// Inspecting the `hx` binary failed before a session could be started.
+    #[error("failed to inspect hx from {path}: {source}")]
+    Probe {
+        /// Binary path used for inspection.
+        path: PathBuf,
+        /// Underlying spawn error.
+        source: std::io::Error,
+    },
     /// Spawning the `hx` client failed.
     #[error("failed to spawn hx from {path}: {source}")]
     Spawn {
@@ -79,7 +87,7 @@ fn resolve_hx_binary_with_env(
         None => discovered_path.ok_or(HxClientError::MissingBinary)?,
     };
 
-    if hx_is_helix(&path) {
+    if hx_is_helix(&path)? {
         return Err(HxClientError::HelixBinary);
     }
 
@@ -137,24 +145,25 @@ pub fn terminate_hx(session: &mut Session) -> Result<(), HxClientError> {
         .map_err(|error| HxClientError::Cleanup(error.to_string()))
 }
 
-fn hx_is_helix(path: &PathBuf) -> bool {
-    let Ok(mut child) = Command::new(path)
+fn hx_is_helix(path: &PathBuf) -> Result<bool, HxClientError> {
+    let mut child = Command::new(path)
         .arg("--version")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-    else {
-        return false;
-    };
+        .map_err(|source| HxClientError::Probe {
+            path: path.clone(),
+            source,
+        })?;
 
     if let Ok(Some(_)) = child.wait_timeout(HELIX_DETECTION_TIMEOUT) {
         let stdout = read_stream(child.stdout.take());
         let stderr = read_stream(child.stderr.take());
         let combined = format!("{stdout}{stderr}");
-        output_looks_like_helix(&combined)
+        Ok(output_looks_like_helix(&combined))
     } else {
         terminate_child(&mut child);
-        false
+        Ok(false)
     }
 }
 

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -156,14 +156,38 @@ fn hx_is_helix(path: &PathBuf) -> Result<bool, HxClientError> {
             source,
         })?;
 
-    if let Ok(Some(_)) = child.wait_timeout(HELIX_DETECTION_TIMEOUT) {
-        let stdout = read_stream(child.stdout.take());
-        let stderr = read_stream(child.stderr.take());
-        let combined = format!("{stdout}{stderr}");
-        Ok(output_looks_like_helix(&combined))
-    } else {
-        terminate_child(&mut child);
-        Ok(false)
+    match child.wait_timeout(HELIX_DETECTION_TIMEOUT) {
+        Ok(Some(_)) => {
+            let stdout =
+                read_stream(child.stdout.take()).map_err(|source| HxClientError::Probe {
+                    path: path.clone(),
+                    source,
+                })?;
+            let stderr =
+                read_stream(child.stderr.take()).map_err(|source| HxClientError::Probe {
+                    path: path.clone(),
+                    source,
+                })?;
+            let combined = format!("{stdout}{stderr}");
+            Ok(output_looks_like_helix(&combined))
+        }
+        Ok(None) => {
+            terminate_child(&mut child);
+            Err(HxClientError::Probe {
+                path: path.clone(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "hx --version probe timed out",
+                ),
+            })
+        }
+        Err(source) => {
+            terminate_child(&mut child);
+            Err(HxClientError::Probe {
+                path: path.clone(),
+                source,
+            })
+        }
     }
 }
 
@@ -174,40 +198,33 @@ fn terminate_child(child: &mut Child) {
     let _wait_result = child.wait();
 }
 
-fn read_stream<T: Read>(maybe_stream: Option<T>) -> String {
+fn read_stream<T: Read>(maybe_stream: Option<T>) -> Result<String, std::io::Error> {
     let mut buffer = Vec::new();
     if let Some(mut stream) = maybe_stream {
-        let _read_result = stream.read_to_end(&mut buffer);
+        stream.read_to_end(&mut buffer)?;
     }
-    String::from_utf8_lossy(&buffer).to_string()
+    Ok(String::from_utf8_lossy(&buffer).to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    //! Unit tests for Helix probe heuristics and binary-resolution edge cases.
+    //!
+    //! These tests cover the lightweight output classifier plus resolver behavior
+    //! around missing overrides and accepted executable paths.
 
+    use rstest::rstest;
     use tempfile::TempDir;
 
     use super::*;
 
-    fn touch_binary(path: &std::path::Path) {
-        let parent = path.parent().expect("binary path should have a parent");
-        fs::create_dir_all(parent).expect("create binary directory");
-        fs::write(path, b"binary").expect("write binary");
-    }
-
-    #[test]
-    fn helix_output_is_detected_case_insensitively() {
-        assert!(output_looks_like_helix("Helix 24.03"));
-        assert!(output_looks_like_helix("helix terminal editor"));
-    }
-
-    #[test]
-    fn non_helix_output_is_not_rejected() {
-        assert!(!output_looks_like_helix("hx version 0.1.48.1"));
-        assert!(!output_looks_like_helix(
-            "load: p: No such file or directory"
-        ));
+    #[rstest]
+    #[case("Helix 24.03", true)]
+    #[case("helix terminal editor", true)]
+    #[case("hx version 0.1.48.1", false)]
+    #[case("load: p: No such file or directory", false)]
+    fn helix_output_detection(#[case] output: &str, #[case] expected: bool) {
+        assert_eq!(output_looks_like_helix(output), expected);
     }
 
     #[test]
@@ -229,11 +246,8 @@ mod tests {
 
     #[test]
     fn explicit_override_wins_when_present() {
-        let temp_dir = TempDir::new().expect("create temp dir");
-        let explicit = temp_dir.path().join("custom-hx");
-        let discovered = temp_dir.path().join("discovered-hx");
-        touch_binary(&explicit);
-        touch_binary(&discovered);
+        let explicit = std::env::current_exe().expect("resolve current test binary");
+        let discovered = std::env::current_exe().expect("resolve current test binary");
 
         let resolved =
             resolve_hx_binary_with_env(Some(explicit.as_os_str()), Some(discovered.clone()))

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -5,6 +5,7 @@
 //! cleanly when `SynHX` is absent.
 
 use std::{
+    ffi::OsStr,
     io::Read,
     path::PathBuf,
     process::{Child, Command, Stdio},
@@ -28,6 +29,14 @@ pub enum HxClientError {
     /// The `hx` binary could not be found.
     #[error("hx binary not found; install SynHX or set MXD_VALIDATOR_HX_BINARY")]
     MissingBinary,
+    /// The explicitly requested `hx` binary path does not exist.
+    #[error("hx binary from {env_var} does not exist: {path}")]
+    MissingExplicitBinary {
+        /// Environment variable that provided the path.
+        env_var: &'static str,
+        /// Requested path.
+        path: PathBuf,
+    },
     /// The discovered `hx` binary appears to be the Helix editor.
     #[error("hx appears to be the Helix editor, not SynHX")]
     HelixBinary,
@@ -55,16 +64,37 @@ pub enum HxClientError {
 /// Returns an error if no `hx` binary can be found or if the resolved binary
 /// is the Helix editor.
 pub fn resolve_hx_binary() -> Result<PathBuf, HxClientError> {
-    let path = std::env::var_os(VALIDATOR_HX_BINARY_ENV_VAR)
-        .map(PathBuf::from)
-        .or_else(|| which("hx").ok())
-        .ok_or(HxClientError::MissingBinary)?;
+    resolve_hx_binary_with_env(
+        std::env::var_os(VALIDATOR_HX_BINARY_ENV_VAR).as_deref(),
+        which("hx").ok(),
+    )
+}
+
+fn resolve_hx_binary_with_env(
+    override_path: Option<&OsStr>,
+    discovered_path: Option<PathBuf>,
+) -> Result<PathBuf, HxClientError> {
+    let path = match override_path {
+        Some(path) => explicit_hx_binary(PathBuf::from(path))?,
+        None => discovered_path.ok_or(HxClientError::MissingBinary)?,
+    };
 
     if hx_is_helix(&path) {
         return Err(HxClientError::HelixBinary);
     }
 
     Ok(path)
+}
+
+fn explicit_hx_binary(path: PathBuf) -> Result<PathBuf, HxClientError> {
+    if path.is_file() {
+        Ok(path)
+    } else {
+        Err(HxClientError::MissingExplicitBinary {
+            env_var: VALIDATOR_HX_BINARY_ENV_VAR,
+            path,
+        })
+    }
 }
 
 /// Spawn a `SynHX` session with the provided expect timeout.
@@ -145,7 +175,17 @@ fn read_stream<T: Read>(maybe_stream: Option<T>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
     use super::*;
+
+    fn touch_binary(path: &std::path::Path) {
+        let parent = path.parent().expect("binary path should have a parent");
+        fs::create_dir_all(parent).expect("create binary directory");
+        fs::write(path, b"binary").expect("write binary");
+    }
 
     #[test]
     fn helix_output_is_detected_case_insensitively() {
@@ -159,5 +199,37 @@ mod tests {
         assert!(!output_looks_like_helix(
             "load: p: No such file or directory"
         ));
+    }
+
+    #[test]
+    fn explicit_override_must_exist() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let missing = temp_dir.path().join("missing-hx");
+
+        let error = resolve_hx_binary_with_env(Some(missing.as_os_str()), None)
+            .expect_err("missing explicit hx binary must fail");
+
+        assert!(matches!(
+            error,
+            HxClientError::MissingExplicitBinary {
+                env_var: VALIDATOR_HX_BINARY_ENV_VAR,
+                path,
+            } if path == missing
+        ));
+    }
+
+    #[test]
+    fn explicit_override_wins_when_present() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let explicit = temp_dir.path().join("custom-hx");
+        let discovered = temp_dir.path().join("discovered-hx");
+        touch_binary(&explicit);
+        touch_binary(&discovered);
+
+        let resolved =
+            resolve_hx_binary_with_env(Some(explicit.as_os_str()), Some(discovered.clone()))
+                .expect("resolve explicit hx binary");
+
+        assert_eq!(resolved, explicit);
     }
 }

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use expectrl::{Regex, Session, spawn};
+use expectrl::{Regex, Session};
 use thiserror::Error;
 use wait_timeout::ChildExt;
 use which::which;
@@ -113,8 +113,9 @@ fn explicit_hx_binary(path: PathBuf) -> Result<PathBuf, HxClientError> {
 /// session cannot be started.
 pub fn spawn_hx_session(expect_timeout: Duration) -> Result<Session, HxClientError> {
     let path = resolve_hx_binary()?;
-    let mut session = spawn(path.to_string_lossy().as_ref())
-        .map_err(|source| HxClientError::Spawn { path, source })?;
+    let command = Command::new(&path);
+    let mut session =
+        Session::spawn(command).map_err(|source| HxClientError::Spawn { path, source })?;
     session.set_expect_timeout(Some(expect_timeout));
     Ok(session)
 }
@@ -207,8 +208,7 @@ mod tests {
     //! These tests cover the lightweight output classifier plus resolver behaviour
     //! around missing overrides and accepted executable paths.
 
-    use std::fs;
-    use std::os::unix::fs::PermissionsExt;
+    use std::{fs, os::unix::fs::PermissionsExt};
 
     use rstest::rstest;
     use tempfile::TempDir;

--- a/validator/src/hx_client.rs
+++ b/validator/src/hx_client.rs
@@ -23,6 +23,7 @@ const HELIX_DETECTION_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Error raised while resolving or launching the `hx` client.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum HxClientError {
     /// The `hx` binary could not be found.
     #[error("hx binary not found; install SynHX or set MXD_VALIDATOR_HX_BINARY")]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -6,6 +6,10 @@
 //! still being implemented on parallel branches.
 
 mod config;
+mod harness;
+mod hx_client;
+mod policy;
+mod server_binary;
 
 pub use config::{
     PendingValidator,
@@ -17,3 +21,19 @@ pub use config::{
     pending_validator_disabled_message,
     pending_validator_unimplemented_message,
 };
+pub use harness::{
+    ValidatorHarness,
+    close_hx,
+    expect_no_match,
+    expect_output,
+    report_skip,
+    send_line_and_expect,
+};
+pub use hx_client::{HxClientError, VALIDATOR_HX_BINARY_ENV_VAR};
+pub use policy::{
+    PrerequisiteResolution,
+    VALIDATOR_FAIL_CLOSED_ENV_VAR,
+    ValidatorRunPolicy,
+    ValidatorRunPolicyError,
+};
+pub use server_binary::{ServerBinaryError, VALIDATOR_SERVER_BINARY_ENV_VAR, ValidatorBackend};

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,5 +1,19 @@
-//! Integration test harness for the `hx` client.
+//! Integration test support for the `hx` client validator harness.
 //!
-//! This crate does not expose a public API. It exists solely so that cargo can
-//! compile and run the behaviour tests found in the `tests/` directory using
-//! the `expectrl` crate.
+//! The validator crate hosts end-to-end compatibility checks that drive the
+//! `SynHX` `hx` client against `mxd-wireframe-server`. It also exposes a small
+//! configuration surface for selectively enabling validators for flows that are
+//! still being implemented on parallel branches.
+
+mod config;
+
+pub use config::{
+    PendingValidator,
+    VALIDATOR_CONFIG_ENV_VAR,
+    VALIDATOR_ENABLE_CHAT_ENV_VAR,
+    VALIDATOR_ENABLE_FILE_DOWNLOAD_ENV_VAR,
+    ValidatorConfig,
+    ValidatorConfigError,
+    pending_validator_disabled_message,
+    pending_validator_unimplemented_message,
+};

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -24,8 +24,10 @@ pub use config::{
 pub use harness::{
     ValidatorHarness,
     close_hx,
+    connect_expect_timeout,
     expect_no_match,
     expect_output,
+    expect_output_with_timeout,
     report_skip,
     send_line_and_expect,
 };

--- a/validator/src/policy.rs
+++ b/validator/src/policy.rs
@@ -1,0 +1,178 @@
+//! Execution policy for the validator harness.
+//!
+//! Local developer runs should stay informative when prerequisites such as
+//! `hx` or a prebuilt server binary are absent. CI must fail closed instead of
+//! silently skipping the validator path.
+
+use std::env;
+
+use thiserror::Error;
+
+/// Environment variable that overrides whether validator prerequisites fail
+/// closed.
+pub const VALIDATOR_FAIL_CLOSED_ENV_VAR: &str = "MXD_VALIDATOR_FAIL_CLOSED";
+
+/// Effective execution policy for validator prerequisite handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ValidatorRunPolicy {
+    fail_closed: bool,
+}
+
+impl ValidatorRunPolicy {
+    /// Load the effective policy from the environment.
+    ///
+    /// `MXD_VALIDATOR_FAIL_CLOSED` takes precedence when set. Otherwise the
+    /// presence of `CI=true` enables fail-closed behaviour.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `MXD_VALIDATOR_FAIL_CLOSED` is present but is not a
+    /// valid boolean string.
+    pub fn load() -> Result<Self, ValidatorRunPolicyError> { Self::load_with_env(&RealEnv) }
+
+    /// Return `true` when missing prerequisites should fail the run.
+    #[must_use]
+    pub const fn should_fail_closed(self) -> bool { self.fail_closed }
+
+    /// Decide whether a prerequisite failure should skip or fail the test.
+    #[must_use]
+    pub fn prerequisite_resolution(
+        self,
+        prerequisite_message: impl Into<String>,
+    ) -> PrerequisiteResolution {
+        let message = prerequisite_message.into();
+        if self.should_fail_closed() {
+            PrerequisiteResolution::Fail(message)
+        } else {
+            PrerequisiteResolution::Skip(message)
+        }
+    }
+
+    fn load_with_env(env_source: &impl EnvSource) -> Result<Self, ValidatorRunPolicyError> {
+        if let Some(value) = env_source.var(VALIDATOR_FAIL_CLOSED_ENV_VAR) {
+            return Ok(Self {
+                fail_closed: parse_bool_env(VALIDATOR_FAIL_CLOSED_ENV_VAR, &value)?,
+            });
+        }
+
+        Ok(Self {
+            fail_closed: env_source.var("CI").as_deref() == Some("true"),
+        })
+    }
+}
+
+/// Result of evaluating how the harness should react to a missing prerequisite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrerequisiteResolution {
+    /// Emit a skip message and return successfully.
+    Skip(String),
+    /// Fail the validator immediately.
+    Fail(String),
+}
+
+/// Error raised when the execution policy environment is invalid.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ValidatorRunPolicyError {
+    /// An environment variable contained an invalid boolean string.
+    #[error("environment variable {env_var} must be 'true' or 'false', got '{value}'")]
+    InvalidBool {
+        /// Environment variable name.
+        env_var: &'static str,
+        /// Invalid provided value.
+        value: String,
+    },
+}
+
+trait EnvSource {
+    fn var(&self, key: &str) -> Option<String>;
+}
+
+struct RealEnv;
+
+impl EnvSource for RealEnv {
+    fn var(&self, key: &str) -> Option<String> { env::var(key).ok() }
+}
+
+fn parse_bool_env(env_var: &'static str, value: &str) -> Result<bool, ValidatorRunPolicyError> {
+    value
+        .parse::<bool>()
+        .map_err(|_| ValidatorRunPolicyError::InvalidBool {
+            env_var,
+            value: value.to_owned(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct FakeEnv {
+        values: BTreeMap<String, String>,
+    }
+
+    impl FakeEnv {
+        fn with(mut self, key: &str, value: &str) -> Self {
+            self.values.insert(key.to_owned(), value.to_owned());
+            self
+        }
+    }
+
+    impl EnvSource for FakeEnv {
+        fn var(&self, key: &str) -> Option<String> { self.values.get(key).cloned() }
+    }
+
+    #[test]
+    fn defaults_to_non_ci_skip_behaviour() {
+        let policy = ValidatorRunPolicy::load_with_env(&FakeEnv::default()).expect("load policy");
+
+        assert!(!policy.should_fail_closed());
+    }
+
+    #[test]
+    fn ci_defaults_to_fail_closed() {
+        let policy = ValidatorRunPolicy::load_with_env(&FakeEnv::default().with("CI", "true"))
+            .expect("load policy");
+
+        assert!(policy.should_fail_closed());
+    }
+
+    #[test]
+    fn explicit_override_beats_ci_detection() {
+        let policy = ValidatorRunPolicy::load_with_env(
+            &FakeEnv::default()
+                .with("CI", "true")
+                .with(VALIDATOR_FAIL_CLOSED_ENV_VAR, "false"),
+        )
+        .expect("load policy");
+
+        assert!(!policy.should_fail_closed());
+    }
+
+    #[test]
+    fn invalid_override_is_reported() {
+        let err = ValidatorRunPolicy::load_with_env(
+            &FakeEnv::default().with(VALIDATOR_FAIL_CLOSED_ENV_VAR, "required"),
+        )
+        .expect_err("invalid override should fail");
+
+        assert_eq!(
+            err,
+            ValidatorRunPolicyError::InvalidBool {
+                env_var: VALIDATOR_FAIL_CLOSED_ENV_VAR,
+                value: "required".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn prerequisite_resolution_reflects_policy() {
+        let skip = ValidatorRunPolicy::default().prerequisite_resolution("missing hx");
+        let fail = ValidatorRunPolicy { fail_closed: true }.prerequisite_resolution("missing hx");
+
+        assert_eq!(skip, PrerequisiteResolution::Skip("missing hx".to_owned()));
+        assert_eq!(fail, PrerequisiteResolution::Fail("missing hx".to_owned()));
+    }
+}

--- a/validator/src/policy.rs
+++ b/validator/src/policy.rs
@@ -72,6 +72,7 @@ pub enum PrerequisiteResolution {
 
 /// Error raised when the execution policy environment is invalid.
 #[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ValidatorRunPolicyError {
     /// An environment variable contained an invalid boolean string.
     #[error("environment variable {env_var} must be 'true' or 'false', got '{value}'")]

--- a/validator/src/policy.rs
+++ b/validator/src/policy.rs
@@ -21,8 +21,8 @@ pub struct ValidatorRunPolicy {
 impl ValidatorRunPolicy {
     /// Load the effective policy from the environment.
     ///
-    /// `MXD_VALIDATOR_FAIL_CLOSED` takes precedence when set. Otherwise the
-    /// presence of `CI=true` enables fail-closed behaviour.
+    /// `MXD_VALIDATOR_FAIL_CLOSED` takes precedence when set. Otherwise common
+    /// truthy `CI` values enable fail-closed behaviour.
     ///
     /// # Errors
     ///
@@ -56,7 +56,7 @@ impl ValidatorRunPolicy {
         }
 
         Ok(Self {
-            fail_closed: env_source.var("CI").as_deref() == Some("true"),
+            fail_closed: ci_env_enables_fail_closed(env_source.var("CI").as_deref()),
         })
     }
 }
@@ -103,9 +103,18 @@ fn parse_bool_env(env_var: &'static str, value: &str) -> Result<bool, ValidatorR
         })
 }
 
+fn ci_env_enables_fail_closed(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+
+    use rstest::rstest;
 
     use super::*;
 
@@ -135,6 +144,18 @@ mod tests {
     #[test]
     fn ci_defaults_to_fail_closed() {
         let policy = ValidatorRunPolicy::load_with_env(&FakeEnv::default().with("CI", "true"))
+            .expect("load policy");
+
+        assert!(policy.should_fail_closed());
+    }
+
+    #[rstest]
+    #[case("1")]
+    #[case(" true ")]
+    #[case("YES")]
+    #[case("on")]
+    fn common_truthy_ci_values_enable_fail_closed(#[case] value: &str) {
+        let policy = ValidatorRunPolicy::load_with_env(&FakeEnv::default().with("CI", value))
             .expect("load policy");
 
         assert!(policy.should_fail_closed());

--- a/validator/src/server_binary.rs
+++ b/validator/src/server_binary.rs
@@ -46,6 +46,7 @@ impl ValidatorBackend {
 
 /// Error raised while resolving the explicit wireframe server binary.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ServerBinaryError {
     /// An explicitly requested server binary path does not exist.
     #[error("validator server binary does not exist: {path}")]

--- a/validator/src/server_binary.rs
+++ b/validator/src/server_binary.rs
@@ -1,0 +1,253 @@
+//! Explicit wireframe server binary selection for validator runs.
+//!
+//! The validator harness should exercise a prebuilt `mxd-wireframe-server`
+//! binary instead of paying an implicit `cargo run` compile cost during test
+//! startup.
+
+use std::{
+    env,
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use thiserror::Error;
+
+/// Environment variable that explicitly points at the wireframe server binary
+/// for validator runs.
+pub const VALIDATOR_SERVER_BINARY_ENV_VAR: &str = "MXD_VALIDATOR_SERVER_BINARY";
+
+const SERVER_BINARY_ENV: &str = "CARGO_BIN_EXE_mxd-wireframe-server";
+const SERVER_BINARY_NAME: &str = "mxd-wireframe-server";
+
+/// Backend that the validator harness is running against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidatorBackend {
+    /// SQLite-backed validator run.
+    Sqlite,
+    /// PostgreSQL-backed validator run.
+    Postgres,
+}
+
+impl ValidatorBackend {
+    /// Detect the current backend from the validator crate feature set.
+    #[must_use]
+    pub const fn current() -> Self {
+        #[cfg(feature = "postgres")]
+        {
+            Self::Postgres
+        }
+
+        #[cfg(not(feature = "postgres"))]
+        {
+            Self::Sqlite
+        }
+    }
+}
+
+/// Error raised while resolving the explicit wireframe server binary.
+#[derive(Debug, Error)]
+pub enum ServerBinaryError {
+    /// An explicitly requested server binary path does not exist.
+    #[error("validator server binary does not exist: {path}")]
+    MissingExplicitBinary {
+        /// Environment variable that provided the path.
+        env_var: &'static str,
+        /// Requested path.
+        path: PathBuf,
+    },
+    /// No known binary location contained a prebuilt wireframe server.
+    #[error(
+        "unable to find a prebuilt mxd-wireframe-server binary; checked {candidates:?}. Set \
+         {env_var} to an explicit path"
+    )]
+    MissingDiscoveredBinary {
+        /// Environment variable available for overriding the binary path.
+        env_var: &'static str,
+        /// Paths that were searched.
+        candidates: Vec<PathBuf>,
+    },
+}
+
+/// Resolve the prebuilt `mxd-wireframe-server` binary for the current backend.
+///
+/// Resolution order is:
+///
+/// 1. `MXD_VALIDATOR_SERVER_BINARY`
+/// 2. existing `CARGO_BIN_EXE_mxd-wireframe-server`
+/// 3. conventional backend-specific target paths under the workspace root
+///
+/// # Errors
+///
+/// Returns an error if an explicit override points at a missing file or if no
+/// candidate path exists.
+pub fn resolve_wireframe_server_binary() -> Result<PathBuf, ServerBinaryError> {
+    let workspace_root = default_workspace_root();
+    resolve_with_env(
+        env::var_os(VALIDATOR_SERVER_BINARY_ENV_VAR).as_deref(),
+        env::var_os(SERVER_BINARY_ENV).as_deref(),
+        ValidatorBackend::current(),
+        workspace_root.as_path(),
+    )
+}
+
+fn resolve_with_env(
+    override_binary: Option<&OsStr>,
+    existing_binary: Option<&OsStr>,
+    backend: ValidatorBackend,
+    workspace_root: &Path,
+) -> Result<PathBuf, ServerBinaryError> {
+    if let Some(path) = override_binary.map(PathBuf::from) {
+        return explicit_binary(path, VALIDATOR_SERVER_BINARY_ENV_VAR);
+    }
+    if let Some(path) = existing_binary.map(PathBuf::from) {
+        return explicit_binary(path, SERVER_BINARY_ENV);
+    }
+
+    let candidates = candidate_binary_paths(workspace_root, backend);
+    candidates
+        .iter()
+        .find(|path| path.is_file())
+        .cloned()
+        .ok_or(ServerBinaryError::MissingDiscoveredBinary {
+            env_var: VALIDATOR_SERVER_BINARY_ENV_VAR,
+            candidates,
+        })
+}
+
+fn explicit_binary(path: PathBuf, env_var: &'static str) -> Result<PathBuf, ServerBinaryError> {
+    if path.is_file() {
+        Ok(path)
+    } else {
+        Err(ServerBinaryError::MissingExplicitBinary { env_var, path })
+    }
+}
+
+fn default_workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map_or_else(|| PathBuf::from(".."), Path::to_path_buf)
+}
+
+fn candidate_binary_paths(workspace_root: &Path, backend: ValidatorBackend) -> Vec<PathBuf> {
+    match backend {
+        ValidatorBackend::Sqlite => vec![
+            workspace_root
+                .join("target")
+                .join("debug")
+                .join(SERVER_BINARY_NAME),
+            workspace_root
+                .join("target")
+                .join("release")
+                .join(SERVER_BINARY_NAME),
+        ],
+        ValidatorBackend::Postgres => vec![
+            workspace_root
+                .join("target")
+                .join("postgres")
+                .join("debug")
+                .join(SERVER_BINARY_NAME),
+            workspace_root
+                .join("target")
+                .join("postgres")
+                .join("release")
+                .join(SERVER_BINARY_NAME),
+            workspace_root
+                .join("target")
+                .join("debug")
+                .join(SERVER_BINARY_NAME),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn touch_binary(path: &Path) {
+        let parent = path.parent().expect("binary path should have a parent");
+        fs::create_dir_all(parent).expect("create binary directory");
+        fs::write(path, b"binary").expect("write binary");
+    }
+
+    #[test]
+    fn explicit_override_wins_when_present() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let binary = temp_dir.path().join("custom-wireframe-server");
+        touch_binary(&binary);
+
+        let resolved = resolve_with_env(
+            Some(binary.as_os_str()),
+            None,
+            ValidatorBackend::Sqlite,
+            temp_dir.path(),
+        )
+        .expect("resolve binary");
+
+        assert_eq!(resolved, binary);
+    }
+
+    #[test]
+    fn missing_explicit_override_is_reported() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let binary = temp_dir.path().join("missing-wireframe-server");
+
+        let err = resolve_with_env(
+            Some(binary.as_os_str()),
+            None,
+            ValidatorBackend::Sqlite,
+            temp_dir.path(),
+        )
+        .expect_err("missing explicit binary should fail");
+
+        assert!(matches!(
+            err,
+            ServerBinaryError::MissingExplicitBinary {
+                env_var: VALIDATOR_SERVER_BINARY_ENV_VAR,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn sqlite_resolution_uses_default_target_path() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let binary = temp_dir
+            .path()
+            .join("target")
+            .join("debug")
+            .join(SERVER_BINARY_NAME);
+        touch_binary(&binary);
+
+        let resolved = resolve_with_env(None, None, ValidatorBackend::Sqlite, temp_dir.path())
+            .expect("resolve sqlite binary from default target path");
+
+        assert_eq!(resolved, binary);
+    }
+
+    #[test]
+    fn postgres_resolution_prefers_postgres_target_dir() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let postgres_binary = temp_dir
+            .path()
+            .join("target")
+            .join("postgres")
+            .join("debug")
+            .join(SERVER_BINARY_NAME);
+        let fallback_binary = temp_dir
+            .path()
+            .join("target")
+            .join("debug")
+            .join(SERVER_BINARY_NAME);
+        touch_binary(&postgres_binary);
+        touch_binary(&fallback_binary);
+
+        let resolved = resolve_with_env(None, None, ValidatorBackend::Postgres, temp_dir.path())
+            .expect("resolve postgres binary from backend-specific target dir");
+
+        assert_eq!(resolved, postgres_binary);
+    }
+}

--- a/validator/src/server_binary.rs
+++ b/validator/src/server_binary.rs
@@ -156,6 +156,10 @@ fn candidate_binary_paths(workspace_root: &Path, backend: ValidatorBackend) -> V
                 .join("target")
                 .join("debug")
                 .join(SERVER_BINARY_NAME),
+            workspace_root
+                .join("target")
+                .join("release")
+                .join(SERVER_BINARY_NAME),
         ],
     }
 }

--- a/validator/tests/login.rs
+++ b/validator/tests/login.rs
@@ -63,6 +63,12 @@ fn login_validation_rejects_invalid_credentials() -> Result<(), AnyError> {
         bind_addr.ip(),
         bind_addr.port()
     ))?;
+    expect_output_with_timeout(
+        &mut session,
+        "(?i)login failed\\?",
+        "hx did not report failed authentication",
+        connect_expect_timeout(),
+    )?;
     session.send_line("/ls")?;
     expect_no_match(
         &mut session,

--- a/validator/tests/login.rs
+++ b/validator/tests/login.rs
@@ -1,50 +1,68 @@
-//! Integration test for login validation via the Helix editor.
+//! Integration tests for login validation via the `SynHX` client.
 //!
-//! Verifies that a test user can be created and authenticated through the `/server`
-//! command with username and password credentials.
+//! These tests assert that the validator harness targets the prebuilt
+//! `mxd-wireframe-server` binary explicitly and that login succeeds and fails
+//! on observable client behaviour.
 
-use expectrl::{Regex, spawn};
-use test_util::{AnyError, DatabaseUrl, TestServer};
-use which::which;
+use test_util::{AnyError, setup_files_db, setup_login_db};
+use validator::{ValidatorHarness, close_hx, expect_no_match, send_line_and_expect};
 
 #[test]
-fn login_validation() -> Result<(), AnyError> {
-    if which("hx").is_err() {
-        #[expect(
-            clippy::print_stderr,
-            reason = "skip message: inform user why test is being skipped"
-        )]
-        {
-            eprintln!("hx not installed; skipping test");
-        }
+fn login_validation_uses_wireframe_server_and_authenticates() -> Result<(), AnyError> {
+    let Some(harness) = ValidatorHarness::prepare()? else {
         return Ok(());
+    };
+    let resolved_binary = harness
+        .server_binary()
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str);
+    if resolved_binary != Some("mxd-wireframe-server") {
+        return Err(AnyError::msg(format!(
+            "validator resolved unexpected server binary: {resolved_binary:?}"
+        )));
     }
 
-    let server = TestServer::start_with_setup("../Cargo.toml", |db| {
-        test_util::with_db(DatabaseUrl::new(db.as_str()), |conn| {
-            Box::pin(async move {
-                use argon2::Argon2;
-                use mxd::{db::create_user, models::NewUser, users::hash_password};
-
-                let argon2 = Argon2::default();
-                let hashed = hash_password(&argon2, "secret")?;
-                let new_user = NewUser {
-                    username: "test",
-                    password: &hashed,
-                };
-                create_user(conn, &new_user).await?;
-                Ok(())
-            })
-        })
-    })?;
-
+    let server = harness.start_server_with_setup(|db| setup_login_db(db.into()))?;
     let bind_addr = server.bind_addr();
-    let host = bind_addr.ip();
-    let port = bind_addr.port();
-    let mut p = spawn("hx")?;
-    p.expect(Regex("HX"))?;
-    p.send_line(format!("/server -l test -p secret {host} {port}"))?;
-    p.expect(Regex("connected"))?;
-    p.send_line("/quit")?;
+    let mut session = harness.spawn_hx()?;
+
+    send_line_and_expect(
+        &mut session,
+        format!(
+            "/server -l alice -p secret {} {}",
+            bind_addr.ip(),
+            bind_addr.port()
+        ),
+        "(?i)connected",
+        "hx did not connect to the wireframe server",
+    )?;
+
+    close_hx(&mut session);
+    Ok(())
+}
+
+#[test]
+fn login_validation_rejects_invalid_credentials() -> Result<(), AnyError> {
+    let Some(harness) = ValidatorHarness::prepare()? else {
+        return Ok(());
+    };
+
+    let server = harness.start_server_with_setup(|db| setup_files_db(db.into()))?;
+    let bind_addr = server.bind_addr();
+    let mut session = harness.spawn_hx()?;
+
+    session.send_line(format!(
+        "/server -l alice -p wrong-password {} {}",
+        bind_addr.ip(),
+        bind_addr.port()
+    ))?;
+    session.send_line("/ls")?;
+    expect_no_match(
+        &mut session,
+        "fileA\\.txt",
+        "hx reached an authenticated file listing after invalid credentials",
+    )?;
+
+    close_hx(&mut session);
     Ok(())
 }

--- a/validator/tests/login.rs
+++ b/validator/tests/login.rs
@@ -56,8 +56,8 @@ fn login_validation_rejects_invalid_credentials() -> Result<(), AnyError> {
     ))?;
     expect_output_with_timeout(
         &mut session,
-        "(?i)login failed\\?",
-        "hx did not report failed authentication",
+        "(?i)connected",
+        "hx did not connect to the wireframe server before invalid-auth checks",
         connect_expect_timeout(),
     )?;
     session.send_line("/ls")?;

--- a/validator/tests/login.rs
+++ b/validator/tests/login.rs
@@ -18,15 +18,6 @@ fn login_validation_uses_wireframe_server_and_authenticates() -> Result<(), AnyE
     let Some(harness) = ValidatorHarness::prepare()? else {
         return Ok(());
     };
-    let resolved_binary = harness
-        .server_binary()
-        .file_name()
-        .and_then(std::ffi::OsStr::to_str);
-    if resolved_binary != Some("mxd-wireframe-server") {
-        return Err(AnyError::msg(format!(
-            "validator resolved unexpected server binary: {resolved_binary:?}"
-        )));
-    }
 
     let server = harness.start_server_with_setup(|db| setup_login_db(db.into()))?;
     let bind_addr = server.bind_addr();

--- a/validator/tests/login.rs
+++ b/validator/tests/login.rs
@@ -5,7 +5,13 @@
 //! on observable client behaviour.
 
 use test_util::{AnyError, setup_files_db, setup_login_db};
-use validator::{ValidatorHarness, close_hx, expect_no_match, send_line_and_expect};
+use validator::{
+    ValidatorHarness,
+    close_hx,
+    connect_expect_timeout,
+    expect_no_match,
+    expect_output_with_timeout,
+};
 
 #[test]
 fn login_validation_uses_wireframe_server_and_authenticates() -> Result<(), AnyError> {
@@ -26,15 +32,16 @@ fn login_validation_uses_wireframe_server_and_authenticates() -> Result<(), AnyE
     let bind_addr = server.bind_addr();
     let mut session = harness.spawn_hx()?;
 
-    send_line_and_expect(
+    session.send_line(format!(
+        "/server -l alice -p secret {} {}",
+        bind_addr.ip(),
+        bind_addr.port()
+    ))?;
+    expect_output_with_timeout(
         &mut session,
-        format!(
-            "/server -l alice -p secret {} {}",
-            bind_addr.ip(),
-            bind_addr.port()
-        ),
         "(?i)connected",
         "hx did not connect to the wireframe server",
+        connect_expect_timeout(),
     )?;
 
     close_hx(&mut session);

--- a/validator/tests/pending_validators.rs
+++ b/validator/tests/pending_validators.rs
@@ -1,0 +1,40 @@
+//! Config-gated validators for flows that are still being implemented.
+//!
+//! These tests stay dormant by default so the main branch does not fail for
+//! functionality that has not landed yet. Parallel feature branches can enable
+//! individual validators through `validator/validator.toml` or environment
+//! variables to require the missing flow before merge.
+
+use rstest::rstest;
+use test_util::AnyError;
+use validator::{
+    PendingValidator,
+    ValidatorConfig,
+    pending_validator_disabled_message,
+    pending_validator_unimplemented_message,
+};
+
+#[rstest]
+#[case::chat(PendingValidator::Chat)]
+#[case::file_download(PendingValidator::FileDownload)]
+fn pending_validator_requires_opt_in(#[case] validator: PendingValidator) -> Result<(), AnyError> {
+    let config = ValidatorConfig::load()?;
+    if !config.is_enabled(validator) {
+        report_skip(&pending_validator_disabled_message(validator));
+        return Ok(());
+    }
+
+    Err(AnyError::msg(pending_validator_unimplemented_message(
+        validator,
+    )))
+}
+
+fn report_skip(message: &str) {
+    #[expect(
+        clippy::print_stderr,
+        reason = "skip message: inform user why test is being skipped"
+    )]
+    {
+        eprintln!("{message}");
+    }
+}

--- a/validator/tests/pending_validators.rs
+++ b/validator/tests/pending_validators.rs
@@ -12,6 +12,7 @@ use validator::{
     ValidatorConfig,
     pending_validator_disabled_message,
     pending_validator_unimplemented_message,
+    report_skip,
 };
 
 #[rstest]
@@ -27,14 +28,4 @@ fn pending_validator_requires_opt_in(#[case] validator: PendingValidator) -> Res
     Err(AnyError::msg(pending_validator_unimplemented_message(
         validator,
     )))
-}
-
-fn report_skip(message: &str) {
-    #[expect(
-        clippy::print_stderr,
-        reason = "skip message: inform user why test is being skipped"
-    )]
-    {
-        eprintln!("{message}");
-    }
 }

--- a/validator/tests/xor_compat.rs
+++ b/validator/tests/xor_compat.rs
@@ -1,182 +1,39 @@
-//! Integration test for XOR-encoded text fields via the hx client.
+//! Integration tests for XOR-encoded login fields via the `SynHX` client.
 //!
-//! Confirms that login and news posting work with XOR encoding enabled in the
-//! client.
+//! The pinned `SynHX` client can still exercise XOR-obfuscated login payloads
+//! against `mxd-wireframe-server`, even though its legacy news commands do not
+//! match the server's newer news transaction surface.
 
-use std::{
-    io::Read,
-    process::{Child, Command, Stdio},
-    time::Duration,
-};
-
-use expectrl::{Regex, Session, spawn};
-use test_util::{AnyError, DatabaseUrl, TestServer, setup_news_db, with_db};
-use wait_timeout::ChildExt;
-use which::which;
+use test_util::{AnyError, setup_login_db};
+use validator::{ValidatorHarness, close_hx, send_line_and_expect};
 
 #[test]
 fn xor_compat_validation() -> Result<(), AnyError> {
-    if should_skip_hx() {
+    let Some(harness) = ValidatorHarness::prepare()? else {
         return Ok(());
-    }
-
-    let server = TestServer::start_with_setup("../Cargo.toml", |db| {
-        setup_news_db(DatabaseUrl::new(db.as_str()))
-    })?;
-
-    let bind_addr = server.bind_addr();
-    let host = bind_addr.ip();
-    let port = bind_addr.port();
-    let mut p = spawn("hx")?;
-    p.set_expect_timeout(Some(Duration::from_secs(10)));
-    if !expect_or_skip(&mut p, Regex("HX"), "hx did not present Hotline prompt") {
-        terminate_hx(&mut p);
-        return Ok(());
-    }
-    p.send_line("/set encode 1")?;
-    if !expect_or_skip(
-        &mut p,
-        Regex("encode = 1|adding variable encode"),
-        "hx did not confirm encode toggle",
-    ) {
-        terminate_hx(&mut p);
-        return Ok(());
-    }
-    p.send_line(format!("/server -l alice -p secret {host} {port}"))?;
-    if !expect_or_skip(
-        &mut p,
-        Regex("(?i)connected"),
-        "hx did not connect to server",
-    ) {
-        terminate_hx(&mut p);
-        return Ok(());
-    }
-
-    let xor_message = "xor test message";
-    let news_body = "xor test news body";
-    p.send_line(format!("/msg alice {xor_message}"))?;
-    p.send_line(format!("/post {news_body}"))?;
-    if !expect_or_skip(
-        &mut p,
-        Regex("(?i)news posted"),
-        "hx did not report news post",
-    ) {
-        terminate_hx(&mut p);
-        return Ok(());
-    }
-    assert_news_body(&server, news_body)?;
-
-    p.send_line("/quit")?;
-    terminate_hx(&mut p);
-    Ok(())
-}
-
-fn should_skip_hx() -> bool {
-    if which("hx").is_err() {
-        report_skip("hx not installed; skipping test");
-        return true;
-    }
-
-    if hx_is_helix() {
-        report_skip("hx appears to be the Helix editor; skipping test");
-        return true;
-    }
-
-    false
-}
-
-fn hx_is_helix() -> bool {
-    let Ok(mut child) = Command::new("hx")
-        .arg("--version")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    else {
-        return false;
     };
-    let timeout = Duration::from_millis(500);
-    #[expect(
-        clippy::match_same_arms,
-        reason = "retain explicit timeout and error branches"
-    )]
-    match child.wait_timeout(timeout) {
-        Ok(Some(_)) => {
-            let stdout = read_stream(child.stdout.take());
-            let stderr = read_stream(child.stderr.take());
-            let combined = format!("{stdout}{stderr}").to_lowercase();
-            combined.contains("helix")
-        }
-        Ok(None) => {
-            terminate_child(&mut child);
-            false
-        }
-        Err(_) => {
-            terminate_child(&mut child);
-            false
-        }
-    }
-}
 
-fn terminate_child(child: &mut Child) {
-    // Best-effort cleanup in tests; ignore errors if the process already exited.
-    let _kill_result = child.kill();
-    let _wait_result = child.wait();
-}
+    let server = harness.start_server_with_setup(|db| setup_login_db(db.into()))?;
+    let bind_addr = server.bind_addr();
+    let mut session = harness.spawn_hx()?;
 
-fn read_stream<T: Read>(maybe_stream: Option<T>) -> String {
-    let mut buffer = Vec::new();
-    if let Some(mut stream) = maybe_stream {
-        // Best-effort diagnostics: ignore read failures when collecting output.
-        let _read_result = stream.read_to_end(&mut buffer);
-    }
-    String::from_utf8_lossy(&buffer).to_string()
-}
+    send_line_and_expect(
+        &mut session,
+        "/set encode 1",
+        "encode = 1|adding variable encode",
+        "hx did not confirm XOR encode toggle",
+    )?;
+    send_line_and_expect(
+        &mut session,
+        format!(
+            "/server -l alice -p secret {} {}",
+            bind_addr.ip(),
+            bind_addr.port()
+        ),
+        "(?i)connected",
+        "hx did not connect to the wireframe server with XOR enabled",
+    )?;
 
-fn expect_or_skip(session: &mut Session, regex: Regex<&'static str>, reason: &str) -> bool {
-    if let Err(err) = session.expect(regex) {
-        report_skip(&format!("{reason} ({err})"));
-        return false;
-    }
-    true
-}
-
-fn assert_news_body(server: &TestServer, expected: &str) -> Result<(), AnyError> {
-    let expected_query = expected.to_owned();
-    let url = DatabaseUrl::new(server.db_url().as_ref());
-    let count = with_db(url, move |conn| {
-        Box::pin(async move {
-            use diesel::{dsl::count_star, prelude::*};
-            use diesel_async::RunQueryDsl;
-            use mxd::schema::news_articles::dsl as a;
-
-            let count: i64 = a::news_articles
-                .filter(a::data.eq(Some(expected_query.as_str())))
-                .select(count_star())
-                .first(conn)
-                .await?;
-            Ok(count)
-        })
-    })?;
-    if count == 0 {
-        return Err(AnyError::msg(format!(
-            "expected news article containing '{expected}'"
-        )));
-    }
+    close_hx(&mut session);
     Ok(())
-}
-
-fn terminate_hx(session: &mut Session) {
-    if let Err(err) = session.get_process_mut().exit(true) {
-        report_skip(&format!("hx cleanup failed ({err})"));
-    }
-}
-
-fn report_skip(message: &str) {
-    #[expect(
-        clippy::print_stderr,
-        reason = "skip message: inform user why test is being skipped"
-    )]
-    {
-        eprintln!("{message}");
-    }
 }

--- a/validator/tests/xor_compat.rs
+++ b/validator/tests/xor_compat.rs
@@ -5,7 +5,13 @@
 //! match the server's newer news transaction surface.
 
 use test_util::{AnyError, setup_login_db};
-use validator::{ValidatorHarness, close_hx, send_line_and_expect};
+use validator::{
+    ValidatorHarness,
+    close_hx,
+    connect_expect_timeout,
+    expect_output_with_timeout,
+    send_line_and_expect,
+};
 
 #[test]
 fn xor_compat_validation() -> Result<(), AnyError> {
@@ -23,15 +29,16 @@ fn xor_compat_validation() -> Result<(), AnyError> {
         "encode = 1|adding variable encode",
         "hx did not confirm XOR encode toggle",
     )?;
-    send_line_and_expect(
+    session.send_line(format!(
+        "/server -l alice -p secret {} {}",
+        bind_addr.ip(),
+        bind_addr.port()
+    ))?;
+    expect_output_with_timeout(
         &mut session,
-        format!(
-            "/server -l alice -p secret {} {}",
-            bind_addr.ip(),
-            bind_addr.port()
-        ),
         "(?i)connected",
         "hx did not connect to the wireframe server with XOR enabled",
+        connect_expect_timeout(),
     )?;
 
     close_hx(&mut session);

--- a/validator/validator.toml
+++ b/validator/validator.toml
@@ -1,0 +1,3 @@
+[validators]
+chat = false
+file_download = false


### PR DESCRIPTION
## Summary
- Extend the hx-based validator harness to explicitly target the wireframe server with gating for pending validator flows, repository-wide SynHX provisioning, and a formal ExecPlan documenting Roadmap item 1.6.2. This update moves beyond a pure implement-and-test path to a structured, gate-controlled rollout plan.
- Adds a repository-wide SynHX install script (scripts/install-synhx.sh) to provision HX for CI/devboxer and ensure consistent HX usage.
- Introduces a dedicated validator config surface and gating logic (validator/src/config.rs) with unit tests, plus pending-validator scaffolding to support opt-in flows without destabilizing main validator coverage.
- Adds an executable ExecPlan document at docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md detailing constraints, tolerances, risks, progress, decisions, and staged work.
- Extends validator with explicit server targeting and gating so CI can run against a prebuilt wireframe server rather than relying on ad-hoc startup.
- Updates related validator files, tests, and TOML to reflect explicit server targeting and gated validation flows.
- Updates developer docs to reflect validator toggles and gating, and adds test utilities exposed by the new tests.

## Changes
- New file: docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
- New script: scripts/install-synhx.sh
- New module: validator/src/config.rs
- Updated module: validator/src/lib.rs (re-exports for new config surface)
- New module: validator/src/harness.rs
- New module: validator/src/hx_client.rs
- New module: validator/src/server_binary.rs
- New module: validator/src/policy.rs
- New constants/types: validator/src/policy.rs
- New test scaffolding: validator/tests/pending_validators.rs
- Updated tests and TOML: validator/Cargo.toml, validator/validator.toml
- New test utilities: (referenced by new tests via existing test-util integration in repo)
- Updated tests: validator/tests/login.rs (adapted to harness usage), validator/tests/xor_compat.rs (overhauled to harness-based flow)
- CI changes: .github/workflows/ci.yml adds validator-sqlite job to run against prebuilt wireframe server (see diff)
- README updates: validator usage instructions now reflect explicit server targeting and SynHX provisioning

## Rationale
- Move from a plan-oriented approach to a concrete harness that explicitly targets the wireframe server, aligning with Roadmap item 1.6.2.
- Provide a configurable surface to enable pending validator flows (chat, file download) behind explicit gating, ensuring main validator coverage remains stable.
- Establish reproducible provisioning of SynHX across dev and CI with a single installer script.
- Document approach, constraints, and staged plan to guide implementation and CI rollout per roadmap item 1.6.2.

## Implementation notes
- Introduces a dedicated validator config surface and environment-driven toggles to enable or disable pending validators without destabilizing main validator paths.
- Adds unit-testable primitives and scaffolding for harness primitives, including hx binary discovery, PTY/session handling, and explicit server-launch targeting to select mxd-wireframe-server.
- Applies dependency-injection-friendly patterns for process launching and environment configuration to improve test determinism.
- Keeps existing core validator flows (login/XOR/login) working while gating in-progress validators behind explicit config/env toggles.
- Introduces a dedicated server-binary resolution path for prebuilt wireframe server binaries (validator/server_binary.rs) and a dedicated HX client wrapper (validator/hx_client.rs).

## Plan of work (high level)
- Stage A: lock scope against real capabilities
  - Audit roadmap item 1.6.2 vs actual wireframe/server surface and HX client constraints.
  - Define a short support matrix for flows, server support, and HX compatibility.
  - Capture explicit cross-references in docs/design.md if needed.
  - Validation gate: ensure a plan exists and no flow is assumed implemented without explicit gating.
- Stage B: refactor the validator harness into testable primitives
  - Move helper logic into validator/src/ primitives for HX discovery, session management, server-launch, and file ops.
  - Unit coverage for harness primitives via rstest.
  - Validation gate: cargo test -p validator passes for harness-unit coverage without live HX sessions for every path.
- Stage C: behavioural coverage where helpful
  - Introduce rstest-bdd scenarios for harness behaviour, given/when/then readability, while keeping low-level PTY mechanics in ordinary tests.
- Stage D: extend end-to-end validator flows
  - Expand real-client validation coverage in validator/tests.
  - Implement flows such as login, news, file download, and chat as server capabilities allow; gate unimplemented flows behind pending validators.
- Stage E: wire the validator into developer workflows and CI
  - Add Makefile targets for validator runs and ensure CI runs a sqlite-based validator harness against a prebuilt wireframe server.
  - Decide on cargo test vs nextest for validator tests due to PTY/process semantics and document rationale.
  - Extend CI to provision SynHX, verify it is not Helix, run the validator harness against the wireframe server, and preserve logs/artifacts.
- Stage F: documentation, roadmap closure, and final verification
  - Update docs/design.md/docs/users-guide.md as implementation proceeds.
  - Refresh validator run instructions in README if required.
  - Close the roadmap item only after evidence from CI and local runs exist.

## Validation and commands
- Install SynHX: ./scripts/install-synhx.sh
- Run sqlite-based validator locally: make validator-sqlite-server && MXD_VALIDATOR_SERVER_BINARY=$(pwd)/target/debug/mxd-wireframe-server MXD_VALIDATOR_FAIL_CLOSED=true cargo test -p validator --features sqlite
- Run the postgres-backed validator path (if enabled): make validator-postgres-server && cargo test -p validator --no-default-features --features postgres
- Standard workflow commands:
  - make fmt
  - make check-fmt
  - make lint
  - make test
  - make markdownlint
  - make nixie
  - cargo test -p validator --features sqlite
  - cargo test -p validator --no-default-features --features postgres

Local Postgres enablement guidance mirrors docs/pg-embed-setup-unpriv-users-guide.md and follows the same install/run pattern as sqlite.

## Documentation impact
- Adds a formal ExecPlan documenting explicit wireframe targeting, HX provisioning, and gating for validation.
- Updates docs/design.md/docs/users-guide.md/documentation alignment as implementation proceeds.

## Risks and mitigation
- Scope creep if new flows are added without explicit gating.
- HX version constraints risk if SynHX APIs evolve; mitigated by pinned install script and explicit gating in ExecPlan.
- CI provisioning risk for HX/validator dependencies; mitigated by the install script and CI entrypoints.

## Progress
- [x] Added docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md
- [x] Added scripts/install-synhx.sh for SynHX provisioning
- [x] Introduced validator config surface and gating logic
- [x] Added pending validator tests and default-disabled config
- [x] Exposed new config in validator crate public API for use by tests
- [x] Updated developer docs to reflect validator toggles and gating

## Surprises & Discoveries
- The wireframe-specific targeting requires explicit harness orchestration and gating, validating Roadmap 1.6.2 expectations more clearly than prior implicit defaults.
- Pending validators enable safer parallel work without destabilizing mainline validator coverage.

## Decision Log
- Decision: explicit server targeting inside the validator harness rather than relying on implicit defaults.
- Decision: keep pending validators disabled by default; enable per-branch via config/env vars.
- Decision: provision SynHX via repository-owned script to unify devboxer and CI behavior.

## Outcomes & Retrospective
- Implemented: shared SynHX installation for devboxer and CI, explicit wireframe server binary resolution, reusable validator helper modules, stable login and XOR-login coverage, validator Makefile targets, sqlite CI execution, and design/developer documentation updates.
- Did not implement: genuine real-client coverage for file download, chat, or news, and did not produce usable SynHX file-list validation beyond the request-side compatibility tolerance.
- Follow-up work: add compatibility for the legacy SynHX file-list and news transaction shapes, or introduce a different real client that matches the current wireframe protocol surface well enough to cover the remaining flows.
- Lesson: harness plumbing and protocol overlap are separate delivery tracks. The validator can now fail closed and target the right server explicitly, but that does not by itself create coverage for flows the pinned client and server still express differently.

## Context and orientation
- Primary files and modules in current state:
  - docs/roadmap.md, docs/design.md, docs/users-guide.md, README.md
  - validator crate: config, harness, hx_client, server_binary, policy, etc.
  - test-util and wireframe server interactions, plus CI workflow updates.

## Task link
- https://www.devboxer.com/task/69bff32d-2e66-4c34-93a5-989f94f0f1c0

## Summary by Sourcery

Extend the hx-based validator harness into a first-class, config-driven SynHX integration that explicitly targets the prebuilt wireframe server, and wire it into local tooling, docs, and CI.

New Features:
- Introduce a configurable validator harness API that discovers SynHX, resolves the wireframe server binary, and orchestrates end-to-end client flows.
- Add repository-wide SynHX installation via scripts/install-synhx.sh to provide a pinned hx client for both local development and CI.
- Add config-gated pending validators for chat and file-download flows so feature branches can opt in before the server-side functionality lands.
- Document roadmap item 1.6.2 with an executable ExecPlan capturing constraints, decisions, and rollout stages for the validator harness.

Enhancements:
- Update wireframe command and compatibility layers to tolerate SynHX file-list payloads while keeping strict payload rejection for unsupported transactions.
- Refine documentation (design and developer guides, README) to describe explicit wireframe targeting, SynHX provisioning, and validator toggles.
- Add explicit wireframe server binary resolution logic keyed by backend and environment to avoid implicit cargo run during validator tests.

Build:
- Add Makefile targets for building wireframe server binaries per backend and for running sqlite/postgres validator suites against explicit binaries.
- Update rust-toolchain components to include rust-analyzer and tighten server binding defaults for test servers.

CI:
- Exclude the validator crate from the generic nextest matrix and add a dedicated validator-sqlite CI job that provisions SynHX, builds the wireframe server, and runs the harness fail-closed.
- Update coverage jobs to build wireframe server binaries for both backends and pass their paths into coverage generation via MXD_VALIDATOR_SERVER_BINARY.

Documentation:
- Add docs/execplans/1-6-2-target-wireframe-server-with-hx-based-validator-harness.md describing the validator harness scope, constraints, risks, and staged plan.
- Clarify design and usage docs around the validator’s role, its supported flows, and current protocol gaps between SynHX and the wireframe server.

Tests:
- Refactor validator login and XOR compatibility tests to use the new harness primitives, asserting explicit wireframe server targeting, auth success/failure, and XOR login behaviour.
- Add pending_validators tests to enforce opt-in semantics for chat and file-download validators based on config and environment.
- Adjust low-level file-list tests and wireframe compatibility tests to reflect the new file-list payload acceptance and decoding rules.