### PR TITLE
Clear Dependabot alerts for diesel-async, rstest, rand, tar and openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.8"
+version = "2.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78df0e4e8c596662edb07fbfbb7f23769cca35049827df5f909084d956b6aeaf"
+checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -924,24 +924,23 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.7.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13096fb8dae53f2d411c4b523bec85f45552ed3044a2ab4d85fb2092d9cb4f34"
+checksum = "dd39af30158d444884f166fe4c58f35dc40ad71ad017bb59408a3448526ff4bd"
 dependencies = [
  "bb8",
  "diesel",
  "futures-core",
  "futures-util",
- "scoped-futures",
+ "pin-project-lite",
  "tokio",
  "tokio-postgres",
 ]
 
 [[package]]
 name = "diesel-cte-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a78d8c2cc46fd81ca5fb189d24aafb6be58890dcd7511d14dce6b3adb5b738"
+version = "0.1.0"
+source = "git+https://github.com/leynos/diesel-cte-ext?rev=1457bb199adefd0ed368dfa9458fd4f07ae81679#1457bb199adefd0ed368dfa9458fd4f07ae81679"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -1051,7 +1050,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1125,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2554,7 +2553,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2961,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3803,7 +3802,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3927,15 +3926,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "scoped-futures"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b24aae2d0636530f359e9d5ef0c04669d11c5e756699b27a6a6d845d8329091"
-dependencies = [
- "pin-project-lite",
 ]
 
 [[package]]
@@ -4512,7 +4502,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5459,7 +5449,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
  "figment",
  "figment-json5",
  "ortho_config 0.3.0",
- "rstest 0.26.1",
+ "rstest",
  "serde",
  "serde_yaml",
  "toml 0.9.8",
@@ -2439,7 +2439,7 @@ dependencies = [
  "postgresql_embedded",
  "proptest",
  "rand 0.8.6",
- "rstest 0.26.1",
+ "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
  "serde",
@@ -2464,7 +2464,7 @@ dependencies = [
 name = "mxd-verification"
 version = "0.1.0"
 dependencies = [
- "rstest 0.26.1",
+ "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
  "stateright",
@@ -2924,7 +2924,7 @@ dependencies = [
  "postgres",
  "postgresql_embedded",
  "pq-sys",
- "rstest 0.26.1",
+ "rstest",
  "secrecy",
  "serde",
  "serde_json",
@@ -3603,25 +3603,13 @@ checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rstest"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros 0.18.2",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros 0.26.1",
+ "rstest_macros",
 ]
 
 [[package]]
@@ -3688,23 +3676,6 @@ name = "rstest-bdd-policy"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f2ca584f7d9d359a09f616900be015302c959d58c2c2da6c075573352dfa0d"
-
-[[package]]
-name = "rstest_macros"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.110",
- "unicode-ident",
-]
 
 [[package]]
 name = "rstest_macros"
@@ -4521,7 +4492,7 @@ dependencies = [
  "nix 0.28.0",
  "pg-embed-setup-unpriv",
  "postgres",
- "rstest 0.18.2",
+ "rstest",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -5197,7 +5168,7 @@ dependencies = [
  "expectrl",
  "mxd",
  "nix 0.27.1",
- "rstest 0.26.1",
+ "rstest",
  "serde",
  "tempfile",
  "test-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2438,7 +2438,7 @@ dependencies = [
  "pg-embed-setup-unpriv",
  "postgresql_embedded",
  "proptest",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
@@ -3079,7 +3079,7 @@ dependencies = [
  "anyhow",
  "postgresql_archive",
  "postgresql_commands",
- "rand 0.9.2",
+ "rand 0.9.4",
  "semver",
  "sqlx",
  "target-triple",
@@ -3207,7 +3207,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.10.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3280,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,12 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6a120d2e16b3e1b4a24bd70f23b12d3e16b81f113364a26935f8db7245452d"
-
-[[package]]
 name = "bincode_derive"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,7 +407,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -1057,7 +1051,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1131,7 +1125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2422,7 +2416,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "async-trait",
- "bincode 3.0.0",
+ "bincode",
  "bitflags 2.10.0",
  "bytes",
  "camino",
@@ -2560,7 +2554,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2611,15 +2605,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2652,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3810,7 +3803,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4494,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4519,7 +4512,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5466,7 +5459,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5906,7 +5899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae7ba1b82771f0428551e3d19c8578521cc77c73dda66746e1e4ae5986d8a7c6"
 dependencies = [
  "async-trait",
- "bincode 2.0.1",
+ "bincode",
  "bytes",
  "dashmap 6.1.0",
  "derive_more 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ default-members = ["."]
 resolver = "2"
 
 [workspace.dependencies]
-diesel-cte-ext = { version = "0.2.0", default-features = false, features = ["async"] }
+# Pinned to a git revision because the published 0.2.0 release requires
+# diesel-async ^0.7; the upstream default branch has migrated to
+# diesel-async 0.9 but is not yet released on crates.io.
+diesel-cte-ext = { git = "https://github.com/leynos/diesel-cte-ext", rev = "1457bb199adefd0ed368dfa9458fd4f07ae81679", default-features = false, features = ["async"] }
 rstest = "0.26.1"
 rstest-bdd = "0.5.0"
 rstest-bdd-macros = { version = "0.5.0", features = ["compile-time-validation"] }
@@ -68,7 +71,7 @@ tokio = { version = "1", features = ["full"] }
 cap-std = { version = "4.0.0", features = ["fs_utf8"] }
 camino = "1.2.1"
 diesel = { version = "2.3", default-features = false, features = ["chrono"] }
-diesel-async = { version = "0.7", default-features = false, features = ["bb8", "sync-connection-wrapper"] }
+diesel-async = { version = "0.9", default-features = false, features = ["bb8", "sync-connection-wrapper"] }
 diesel_migrations = { version = "2.3", default-features = false }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ resolver = "2"
 # Pinned to a git revision because the published 0.2.0 release requires
 # diesel-async ^0.7; the upstream default branch has migrated to
 # diesel-async 0.9 but is not yet released on crates.io.
+# TODO(https://github.com/leynos/mxd/issues/361): replace this git pin
+# with a caret requirement once a diesel-cte-ext release supporting
+# diesel-async 0.9 is published.
 diesel-cte-ext = { git = "https://github.com/leynos/diesel-cte-ext", rev = "1457bb199adefd0ed368dfa9458fd4f07ae81679", default-features = false, features = ["async"] }
 rstest = "0.26.1"
 rstest-bdd = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ clap = { version = "4", features = ["derive"] }
 cfg-if = "1"
 ortho_config = { git = "https://github.com/leynos/ortho-config", tag = "v0.3.0" }
 argon2 = { version = "0.5", features = ["std"] }
-rand = "0.8"
+rand = "0.9.3"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 diesel-cte-ext = { workspace = true }
 futures-util = "0.3"

--- a/src/db/articles.rs
+++ b/src/db/articles.rs
@@ -67,26 +67,20 @@ pub struct CreateRootArticleParams<'a> {
 ///
 /// # Errors
 /// Returns an error if the path is invalid or the insertion fails.
-#[expect(
-    clippy::shadow_reuse,
-    reason = "intentional shadowing in transaction closure"
-)]
 #[must_use = "handle the result"]
 pub async fn create_root_article(
     conn: &mut DbConnection,
     path: &str,
     params: CreateRootArticleParams<'_>,
 ) -> Result<i32, PathLookupError> {
-    conn.transaction::<_, PathLookupError, _>(|conn| {
-        Box::pin(async move {
-            let cat_id = category_id_from_path(conn, path).await?;
-            let last = get_last_root_article_id(conn, cat_id).await?;
-            let inserted = insert_new_article(conn, cat_id, last, &params).await?;
-            if let Some(prev) = last {
-                link_prev_to_new(conn, prev, inserted).await?;
-            }
-            Ok(inserted)
-        })
+    conn.transaction::<_, PathLookupError, _>(async |tx_conn| {
+        let cat_id = category_id_from_path(tx_conn, path).await?;
+        let last = get_last_root_article_id(tx_conn, cat_id).await?;
+        let inserted = insert_new_article(tx_conn, cat_id, last, &params).await?;
+        if let Some(prev) = last {
+            link_prev_to_new(tx_conn, prev, inserted).await?;
+        }
+        Ok(inserted)
     })
     .await
 }

--- a/src/db/tests/mod.rs
+++ b/src/db/tests/mod.rs
@@ -178,6 +178,49 @@ async fn test_create_root_article_round_trip(
 #[cfg(feature = "sqlite")]
 #[rstest]
 #[tokio::test]
+async fn test_create_root_article_links_previous_sibling(
+    #[future] migrated_conn: Result<DbConnection, AnyError>,
+) {
+    let mut conn = migrated_conn
+        .await
+        .expect("failed to create migrated test database");
+    seed_root_category(&mut conn, "General")
+        .await
+        .expect("failed to seed category");
+    let first_params = CreateRootArticleParams {
+        title: "First",
+        flags: 0,
+        data_flavor: "text/plain",
+        data: "first body",
+    };
+    let first_id = create_root_article(&mut conn, "/General", first_params)
+        .await
+        .expect("failed to create first article");
+    let second_params = CreateRootArticleParams {
+        title: "Second",
+        flags: 0,
+        data_flavor: "text/plain",
+        data: "second body",
+    };
+    let second_id = create_root_article(&mut conn, "/General", second_params)
+        .await
+        .expect("failed to create second article");
+    let first = get_article(&mut conn, "/General", first_id)
+        .await
+        .expect("lookup failed")
+        .expect("first article missing");
+    let second = get_article(&mut conn, "/General", second_id)
+        .await
+        .expect("lookup failed")
+        .expect("second article missing");
+    assert_eq!(first.next_article_id, Some(second_id));
+    assert_eq!(second.prev_article_id, Some(first_id));
+    assert_eq!(second.next_article_id, None);
+}
+
+#[cfg(feature = "sqlite")]
+#[rstest]
+#[tokio::test]
 async fn test_create_root_article_invalid_path(
     #[future] migrated_conn: Result<DbConnection, AnyError>,
 ) {

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -15,7 +15,7 @@ pg-embedded-setup-unpriv = { package = "pg-embed-setup-unpriv", version = "0.5.0
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
-rstest = "0.18"
+rstest = { workspace = true }
 tracing = "0.1"
 anyhow = "1"
 wait-timeout = "0.2.1"

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -9,7 +9,7 @@ nix = { version = "0.28", default-features = false, features = ["signal", "user"
 mxd = { path = "..", default-features = false, features = ["test-support"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 diesel = { version = "2.3", default-features = false, features = ["chrono"] }
-diesel-async = { version = "0.7", default-features = false, features = ["sync-connection-wrapper"] }
+diesel-async = { version = "0.9", default-features = false, features = ["sync-connection-wrapper"] }
 diesel_migrations = { version = "2.3", default-features = false }
 pg-embedded-setup-unpriv = { package = "pg-embed-setup-unpriv", version = "0.5.0", optional = true, features = ["async-api"] }
 argon2 = { version = "0.5", features = ["std"] }

--- a/test-util/src/postgres/mod.rs
+++ b/test-util/src/postgres/mod.rs
@@ -204,10 +204,6 @@ mod fixture_glue {
     //! `rstest` fixture glue for `PostgreSQL` test databases.
 
     #![expect(
-        missing_docs,
-        reason = "rstest #[fixture] macro generates undocumented helper items"
-    )]
-    #![expect(
         unused_braces,
         reason = "rstest #[fixture] macro expands from normal function bodies"
     )]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -26,5 +26,5 @@ postgres = ["test-util/postgres", "mxd/postgres"]
 mxd = { path = "..", default-features = false }
 argon2 = { version = "0.5", features = ["std"] }
 diesel = { version = "2.3", default-features = false, features = ["sqlite", "postgres"] }
-diesel-async = { version = "0.7", default-features = false, features = ["sqlite", "postgres", "sync-connection-wrapper"] }
+diesel-async = { version = "0.9", default-features = false, features = ["sqlite", "postgres", "sync-connection-wrapper"] }
 rstest = { workspace = true }


### PR DESCRIPTION
## Summary

This pull request clears all thirteen open Dependabot alerts and supersedes the failing Dependabot PRs #344 and #354.

- **diesel-async 0.7 → 0.9** (GHSA-ff9q-rm55-q7qr; alerts 36, 37 and 44). Dependabot's PR #344 bumped only the `test-util` and `validator` manifests, leaving the workspace root on 0.7 and mixing incompatible connection types across the workspace. This branch migrates the whole workspace coherently, including the one code change required: diesel-async 0.9 changed `AsyncConnection::transaction` to accept an `AsyncFnOnce` closure, so `create_root_article` now uses a native async closure rather than a `Box::pin` future.
- **diesel-cte-ext** is pinned to a git revision because the published 0.2.0 release requires diesel-async ^0.7; the upstream default branch has migrated to 0.9 but has not yet been released to crates.io. The pin should return to a caret requirement once a compatible release is published.
- **rstest 0.18 → 0.26.1** in `test-util` (superseding PR #354), adopting the existing workspace dependency. The 0.26 `#[fixture]` macro documents its generated items, so the now-unfulfilled `missing_docs` lint expectation in the PostgreSQL fixture glue is removed.
- **rand 0.8 → 0.9.3** (GHSA-cq8v-f236-94qc; alert 22). The only direct use, `rand::random::<u64>()`, is unchanged between releases. A transitive rand 0.8.6 remains in the lockfile (via retry-policies and sqlx) but sits outside the vulnerable range (≥ 0.9.0, < 0.9.3).
- **tar 0.4.45 → 0.4.46** (GHSA-3pv8-6f4r-ffg2; alert 45) and **openssl 0.10.75 → 0.10.81** (alerts 25–29, 34, 38 and 43): lockfile-only updates of transitive dependencies pulled in through the embedded PostgreSQL tooling.
- **crossbeam-epoch 0.9.18 → 0.9.20** (RUSTSEC-2026-0204): a lockfile-only update that returns the scheduled cargo-audit workflow to green.

A characterisation test was added ahead of the migration to pin the previously untested sibling-linking branch of `create_root_article`, whose transaction closure the migration rewrites; the test was verified against the pre-migration dependencies before the bump.

## Review walkthrough

- [Cargo.toml](https://github.com/leynos/mxd/blob/fix-dependabot-failures/Cargo.toml) — diesel-async 0.9, rand 0.9.3 and the annotated diesel-cte-ext git pin.
- [src/db/articles.rs](https://github.com/leynos/mxd/blob/fix-dependabot-failures/src/db/articles.rs) — the transaction closure migrated to an `AsyncFnOnce` async closure; the closure parameter is renamed to `tx_conn`, which also retires the `shadow_reuse` expectation.
- [src/db/tests/mod.rs](https://github.com/leynos/mxd/blob/fix-dependabot-failures/src/db/tests/mod.rs) — the new `test_create_root_article_links_previous_sibling` characterisation test.
- [test-util/Cargo.toml](https://github.com/leynos/mxd/blob/fix-dependabot-failures/test-util/Cargo.toml) — rstest moved to the workspace dependency; diesel-async 0.9.
- [test-util/src/postgres/mod.rs](https://github.com/leynos/mxd/blob/fix-dependabot-failures/test-util/src/postgres/mod.rs) — removal of the unfulfilled `missing_docs` expectation.
- [validator/Cargo.toml](https://github.com/leynos/mxd/blob/fix-dependabot-failures/validator/Cargo.toml) — diesel-async 0.9.
- [Cargo.lock](https://github.com/leynos/mxd/blob/fix-dependabot-failures/Cargo.lock) — resolved versions for all of the above plus the tar, openssl and crossbeam-epoch updates.

## Validation

Run locally (sequentially, matching the Makefile gates):

- `make check-fmt` — clean.
- `make typecheck` — postgres, sqlite and wireframe-only legs all clean.
- `make lint` — Clippy and whitaker clean on all three feature legs with `-D warnings`.
- `make test-sqlite` — 484 passed; `make test-postgres` (embedded PostgreSQL) — 480 passed; `make test-wireframe-only` — 482 passed; `make test-verification` — 69 passed.
- `make test-validator-sqlite` — validator harness green (37 tests across the suite binaries).
- `cargo audit` — no vulnerabilities; only the four allowed unmaintained-crate warnings remain.

Deferred to CI: the coverage job (cargo-llvm-cov across both backends) and the CI postgres leg that uses the external PostgreSQL service container; local runs used the embedded server instead.
