### PR TITLE
Standardize the Whitaker CI install on the pinned 0.2.5 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_REV: 9c154ead8d72dc4b26b5c67f2575fd891bc99962
+      WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@v7.0.0
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
@@ -80,30 +80,22 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-whitaker-${{ env.WHITAKER_INSTALLER_REV }}-${{ hashFiles('**/Cargo.lock') }}
-      - name: Lint with Whitaker
+            ~/.cargo/bin/whitaker-installer
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+      - name: Install Whitaker
         run: |
           if ! command -v whitaker-installer >/dev/null 2>&1; then
-            cargo install --locked \
-              --git https://github.com/leynos/whitaker \
-              --rev "${WHITAKER_INSTALLER_REV}" \
-              whitaker-installer
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
           fi
-          if ! command -v whitaker >/dev/null 2>&1; then
-            whitaker-installer
-          fi
-          if [[ -d "${HOME}/.local/share/whitaker/lints" ]]; then
-            find "${HOME}/.local/share/whitaker/lints" \
-              -type f \
-              \( -name 'lib*@*.so' -o -name 'lib*@*.dylib' -o -name '*@*.dll' \) \
-              ! -name 'libwhitaker_suite@*' \
-              ! -name 'whitaker_suite@*' \
-              -delete
-          fi
-          RUSTFLAGS="-D warnings" whitaker --all -- ${{ matrix.cargo_flags }} --all-targets
+          whitaker-installer
+      - name: Lint with Whitaker
+        run: RUSTFLAGS="-D warnings" whitaker --all -- ${{ matrix.cargo_flags }} --all-targets
       - name: Test
         run: |
           if [[ "${{ matrix.rstest_timeout }}" == "true" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,19 @@ jobs:
           key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
       - name: Install Whitaker
         run: |
-          if ! command -v whitaker-installer >/dev/null 2>&1; then
+          # The rust-cache step restores ~/.cargo/bin, which can resurrect a
+          # stale whitaker-installer; verify the version rather than merely
+          # checking that a binary exists, and force-reinstall on mismatch.
+          installed_version=""
+          if command -v whitaker-installer >/dev/null 2>&1; then
+            installed_version="$(whitaker-installer --version 2>/dev/null | awk '{print $2}')"
+          fi
+          if [ "${installed_version}" != "${WHITAKER_INSTALLER_VERSION}" ]; then
             if cargo binstall --version >/dev/null 2>&1; then
-              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+              cargo binstall --no-confirm --locked --force "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
             else
               echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
-              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+              cargo install --locked --force whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
             fi
           fi
           whitaker-installer

--- a/Makefile
+++ b/Makefile
@@ -87,17 +87,17 @@ typecheck-sqlite: ## Run cargo check with the sqlite backend
 typecheck-wireframe-only: ## Run cargo check with legacy networking disabled
 	$(CARGO) check $(WIREFRAME_ONLY_FEATURES)
 
-lint: lint-postgres lint-sqlite lint-wireframe-only ## Run Clippy for all feature sets
+lint: lint-postgres lint-sqlite lint-wireframe-only ## Run Clippy and Whitaker for all feature sets
 
-lint-postgres: ## Run Clippy with the postgres backend
+lint-postgres: ## Run Clippy and Whitaker with the postgres backend
 	$(CARGO) clippy $(TEST_POSTGRES_FEATURES) $(CLIPPY_FLAGS)
 	PATH="$(TOOL_PATH_PREFIX)$(if $(TOOL_PATH_PREFIX),:)$$PATH" RUSTFLAGS="-D warnings" $(WHITAKER) --all -- $(TEST_POSTGRES_FEATURES) --all-targets
 
-lint-sqlite: ## Run Clippy with the sqlite backend
+lint-sqlite: ## Run Clippy and Whitaker with the sqlite backend
 	$(CARGO) clippy $(TEST_SQLITE_FEATURES) $(CLIPPY_FLAGS)
 	PATH="$(TOOL_PATH_PREFIX)$(if $(TOOL_PATH_PREFIX),:)$$PATH" RUSTFLAGS="-D warnings" $(WHITAKER) --all -- $(TEST_SQLITE_FEATURES) --all-targets
 
-lint-wireframe-only: ## Run Clippy with legacy networking disabled
+lint-wireframe-only: ## Run Clippy and Whitaker with legacy networking disabled
 	$(CARGO) clippy $(WIREFRAME_ONLY_FEATURES) $(CLIPPY_FLAGS)
 	PATH="$(TOOL_PATH_PREFIX)$(if $(TOOL_PATH_PREFIX),:)$$PATH" RUSTFLAGS="-D warnings" $(WHITAKER) --all -- $(WIREFRAME_ONLY_FEATURES) --all-targets
 


### PR DESCRIPTION
## Summary

This change standardizes mxd's Whitaker continuous integration (CI) install on the estate-wide pattern introduced in leynos/netsuke#410, as part of the estate-wide Whitaker rollout. mxd already ran the Whitaker Dylint suite in CI, but installed `whitaker-installer` from a pinned git revision with a broad `~/.cargo` cache. The workflow now pins the installer to the 0.2.5 crates.io release via a job-level `WHITAKER_INSTALLER_VERSION` environment variable, prefers `cargo binstall --locked` with a build-from-source fallback for runners without binstall, and narrows the cache to the installer binary and the binstall download cache, keyed by runner operating system, architecture, and installer version.

The stale-lint clean-up step is dropped because the lint library directory is no longer cached, so stale suite libraries cannot accumulate between runs. The per-matrix-leg invocation is preserved: each feature leg still runs `whitaker --all` with its own mutually exclusive feature flags. The Makefile lint help text now mentions Whitaker alongside Clippy; the lint recipes themselves were already wired.

## Review walkthrough

- [.github/workflows/ci.yml](https://github.com/leynos/mxd/blob/adopt-whitaker/.github/workflows/ci.yml): replaces `WHITAKER_INSTALLER_REV` with `WHITAKER_INSTALLER_VERSION: '0.2.5'`, narrows the Whitaker cache, and splits installation into a hardened "Install Whitaker" step (shell-variable indirection, `--locked`, binstall-or-build fallback) followed by a plain "Lint with Whitaker" step that keeps the per-leg `${{ matrix.cargo_flags }}`.
- [Makefile](https://github.com/leynos/mxd/blob/adopt-whitaker/Makefile): the `lint`, `lint-postgres`, `lint-sqlite`, and `lint-wireframe-only` help text now mentions Whitaker.

## Validation

All gates were run locally with `env -u WHITAKER` so the Makefile's default tool resolution was exercised:

- `make check-fmt` — pass
- `make typecheck` — pass (all three feature sets)
- `make lint` — pass (Clippy and `whitaker --all` clean under `-D warnings` for the postgres, sqlite, and wireframe-only feature sets, suite v0.2.5)
- `make test` — pass (test-postgres 480, test-sqlite 484, test-wireframe-only 482, test-verification 69, doc tests 5; zero failures)
- `make markdownlint` — pass (61 files, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
