### PR TITLE
Fix lcov merge silently overwriting the postgres coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           format: lcov
           artefact-name-suffix: postgres
       - name: Merge coverage results
-        run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
+        run: bun x lcov-result-merger 'lcov-*.info' > lcov.info
       # CodeScene's "Code Coverage" PR check is driven by `cs-coverage
       # check` (uploads are only accepted for analysed branches, i.e.
       # main); without this step the check times out and blocks

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -92,7 +92,7 @@ jobs:
           format: lcov
           artefact-name-suffix: postgres-main
       - name: Merge coverage results
-        run: bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info
+        run: bun x lcov-result-merger 'lcov-*.info' > lcov.info
       - name: Upload coverage data to CodeScene
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- `lcov-result-merger` takes a single `<pattern> [outFile]` pair, not a list of input files. `bun x lcov-result-merger lcov-sqlite.info lcov-postgres.info > lcov.info` treated `lcov-postgres.info` as the output file, silently overwriting it, whilst the merged report piped to stdout (and redirected into `lcov.info`) stayed empty.
- Both `coverage-main.yml` (push to `main`) and `ci.yml` (pull request gate) upload/check this empty `lcov.info` against CodeScene, which has been rejecting every run so far with "coverage data does not contains any records related to the current repo".
- This was discovered while investigating ortho-config#377.

## Review walkthrough

- Replaced the two-filename invocation in both workflows with a single glob, `'lcov-*.info'`, matching the `output-path` values from each `generate-coverage` step (`lcov-sqlite.info`, `lcov-postgres.info`) and streaming the merge to stdout.
- The glob cannot match the `lcov.info` output file, so there is no risk of the merger reading its own output.
- No workflow contract tests reference the old invocation text, so none needed updating.

## Validation

- [x] Parsed both `.github/workflows/coverage-main.yml` and `.github/workflows/ci.yml` with `yaml.safe_load` to confirm they remain valid YAML.
- [x] Confirmed via `gh run view --log` on the two most recent `Coverage (main)` runs (29040137681, 29018139218) that the `Merge coverage results` step completed without error whilst the subsequent `Upload coverage data to CodeScene` step failed with "The coverage data does not contains any records related to the current repo" — direct evidence of the empty-upload defect.
- [ ] CI on this PR (coverage jobs) to confirm the fix produces a non-empty merged report.
