### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@v7.0.0
       - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332


### PR DESCRIPTION
Bumps the pinned `whitaker-installer` version used by CI from 0.2.5 to
0.2.6, because 0.2.5 provisions cargo-dylint 4.1.0, whose dylint driver
cannot build on the Whitaker Dylint suite's new `nightly-2026-05-28`
toolchain pin. This currently leaves the CI lint step red. Installer
0.2.6 provisions cargo-dylint 6.0.1, which does build on that
toolchain, and its prebuilt dependency binaries are now published.

Only the CI pin is touched; unrelated `0.2.5` strings elsewhere in the
repository (crate versions and `Cargo.lock` checksums for
`displaydoc`, `try-lock`, and `wasm-timer`) were left alone, as they
are unconnected to the Whitaker installer.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/mxd/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
