### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
-      - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Install cargo-audit
         run: cargo binstall --no-confirm cargo-audit
       - name: Audit dependencies

--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build release binary
         uses: >-
-          leynos/shared-actions/.github/actions/rust-build-release@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/rust-build-release@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           target: ${{ inputs.target }}
           bin-name: ${{ inputs.bin-name }}
@@ -80,7 +80,7 @@ jobs:
       - name: Package Linux artefacts
         if: inputs.platform == 'linux'
         uses: >-
-          leynos/shared-actions/.github/actions/linux-packages@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/linux-packages@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           project-dir: .
           package-name: ${{ inputs.bin-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@v7.0.0
-      - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           install-postgres-deps: ${{ matrix.install_postgres_deps }}
           install-sqlite-deps: ${{ matrix.install_sqlite_deps }}
@@ -168,7 +168,7 @@ jobs:
       MXD_TEST_BIND_HOST: "127.0.0.1"
     steps:
       - uses: actions/checkout@v7.0.0
-      - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           install-sqlite-deps: true
       - name: Cache Cargo directories
@@ -222,7 +222,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-      - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           install-sqlite-deps: true
           install-postgres-deps: true
@@ -255,7 +255,7 @@ jobs:
       # on main, which every PR run can restore; baselines saved here
       # stay scoped to the PR branch.
       - name: Generate coverage for SQLite
-        uses: leynos/shared-actions/.github/actions/generate-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         env:
           MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/debug/mxd-wireframe-server
         with:
@@ -265,7 +265,7 @@ jobs:
           artefact-name-suffix: sqlite
           with-ratchet: 'true'
       - name: Generate coverage for Postgres
-        uses: leynos/shared-actions/.github/actions/generate-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         env:
           MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/postgres/debug/mxd-wireframe-server
           POSTGRES_TEST_URL: postgres://postgres:password@127.0.0.1/test
@@ -286,7 +286,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: lcov
           mode: check

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -40,7 +40,7 @@ jobs:
       MXD_TEST_BIND_HOST: "127.0.0.1"
     steps:
       - uses: actions/checkout@v7.0.0
-      - uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+      - uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           install-sqlite-deps: true
           install-postgres-deps: true
@@ -71,7 +71,7 @@ jobs:
       # (the default feature set and broadest suite) carries it; the
       # postgres leg is generated unratcheted.
       - name: Generate coverage for SQLite
-        uses: leynos/shared-actions/.github/actions/generate-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         env:
           MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/debug/mxd-wireframe-server
         with:
@@ -81,7 +81,7 @@ jobs:
           artefact-name-suffix: sqlite-main
           with-ratchet: 'true'
       - name: Generate coverage for Postgres
-        uses: leynos/shared-actions/.github/actions/generate-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         env:
           MXD_VALIDATOR_SERVER_BINARY: ${{ github.workspace }}/target/postgres/debug/mxd-wireframe-server
           POSTGRES_TEST_URL: postgres://postgres:password@127.0.0.1/test
@@ -97,7 +97,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,12 @@ jobs:
       - id: release_modes
         name: Determine release modes
         uses: >-
-          leynos/shared-actions/.github/actions/determine-release-modes@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/determine-release-modes@18bed1ca49a6de3d8882bd72635a32ae3f023d57
 
       - id: ensure_version
         name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/ensure-cargo-version@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs.should-publish) }}
 
@@ -86,7 +86,7 @@ jobs:
       - id: bin_name
         name: Extract binary name from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/export-cargo-metadata@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/export-cargo-metadata@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           manifest-path: ${{ steps.manifest_path.outputs.value }}
           fields: bin-name
@@ -149,7 +149,7 @@ jobs:
       - id: upload_assets
         name: Upload artefacts to release
         uses: >-
-          leynos/shared-actions/.github/actions/upload-release-assets@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/upload-release-assets@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}


### PR DESCRIPTION
## Summary

- Bump every `leynos/shared-actions` reference in `.github/workflows/` to `18bed1ca49a6de3d8882bd72635a32ae3f023d57` (shared-actions main HEAD)
- This pin carries the coverage-ratchet baseline-freeze cache-key fix and symmetric ±1pp dead-band (shared-actions#353), plus routine follow-ups (#354, #356 whitaker-installer 0.2.6, #344)

## Review walkthrough

- `audit.yml` (1 ref), `ci.yml` (6), `coverage-main.yml` (4), `release.yml` (4), `build-and-package.yml` (2), `dependabot-automerge.yml` (1) — pins only, no other content changed

## Validation

- [x] `grep -rE "shared-actions/.+@"` in `.github/workflows/` shows only the new pin
- [ ] CI green on this PR
